### PR TITLE
Separate bibtex requirement from rocm-docs-core

### DIFF
--- a/docs/.sphinx/requirements.in
+++ b/docs/.sphinx/requirements.in
@@ -1,1 +1,2 @@
-git+https://github.com/RadeonOpenCompute/rocm-docs-core.git
+git+https://github.com/samjwu/rocm-docs-core.git@bibtex
+sphinxcontrib-bibtex==2.5.0

--- a/docs/.sphinx/requirements.in
+++ b/docs/.sphinx/requirements.in
@@ -1,2 +1,2 @@
-git+https://github.com/samjwu/rocm-docs-core.git@bibtex
+git+https://github.com/RadeonOpenCompute/rocm-docs-core.git
 sphinxcontrib-bibtex==2.5.0

--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -46,9 +46,11 @@ docutils==0.16
     # via
     #   breathe
     #   myst-parser
+    #   pybtex-docutils
     #   pydata-sphinx-theme
     #   rocm-docs-core
     #   sphinx
+    #   sphinxcontrib-bibtex
 executing==1.2.0
     # via stack-data
 fastjsonschema==2.16.3
@@ -94,6 +96,8 @@ jupyter-core==5.3.0
     #   ipykernel
     #   jupyter-client
     #   nbformat
+latexcodec==2.0.1
+    # via pybtex
 linkify-it-py==1.0.3
     # via myst-parser
 markdown-it-py==2.2.0
@@ -150,6 +154,12 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
+pybtex==0.24.0
+    # via
+    #   pybtex-docutils
+    #   sphinxcontrib-bibtex
+pybtex-docutils==1.0.2
+    # via sphinxcontrib-bibtex
 pycparser==2.21
     # via cffi
 pydata-sphinx-theme==0.13.1
@@ -175,6 +185,7 @@ pyyaml==6.0
     #   jupyter-cache
     #   myst-nb
     #   myst-parser
+    #   pybtex
     #   sphinx-external-toc
 pyzmq==25.0.2
     # via
@@ -184,11 +195,13 @@ requests==2.28.2
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core @ git+https://github.com/RadeonOpenCompute/rocm-docs-core.git
+rocm-docs-core @ git+https://github.com/samjwu/rocm-docs-core.git@bibtex
     # via -r requirements.in
 six==1.16.0
     # via
     #   asttokens
+    #   latexcodec
+    #   pybtex
     #   python-dateutil
 smmap==5.0.0
     # via gitdb
@@ -208,6 +221,7 @@ sphinx==4.3.1
     #   sphinx-design
     #   sphinx-external-toc
     #   sphinx-notfound-page
+    #   sphinxcontrib-bibtex
 sphinx-book-theme==1.0.0rc2
     # via rocm-docs-core
 sphinx-copybutton==0.5.1
@@ -220,6 +234,8 @@ sphinx-notfound-page==0.8.3
     # via rocm-docs-core
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
+sphinxcontrib-bibtex==2.5.0
+    # via -r requirements.in
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.1

--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -195,7 +195,7 @@ requests==2.28.2
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core @ git+https://github.com/samjwu/rocm-docs-core.git@bibtex
+rocm-docs-core @ git+https://github.com/RadeonOpenCompute/rocm-docs-core.git
     # via -r requirements.in
 six==1.16.0
     # via
@@ -235,7 +235,9 @@ sphinx-notfound-page==0.8.3
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-bibtex==2.5.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   rocm-docs-core
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,8 @@ mathjax3_config = {
     }
 }
 
-bibtex_bibfiles = ['refs.bib']
-
 for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)
+
+extensions += ['sphinxcontrib.bibtex']
+bibtex_bibfiles = ['refs.bib']


### PR DESCRIPTION
Since CK is the only repo that uses this extension and it requires a custom config, it doesn't seem worthwhile to add it as a dependency to rocm-docs-core. This PR makes it a separate line in the requirements.in file.

Successful test build: https://readthedocs.com/projects/advanced-micro-devices-composable-kernel/builds/1373701/