### PR TITLE
[Navi3x] Fix 3rd dword of buffer source descriptor

### DIFF
--- a/include/ck/ck.hpp
+++ b/include/ck/ck.hpp
@@ -36,7 +36,7 @@
 #elif defined(__gfx1030__) // for GPU code
 #define CK_BUFFER_RESOURCE_3RD_DWORD 0x31014000
 #elif defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) // for GPU code
-#define CK_BUFFER_RESOURCE_3RD_DWORD 0x10020000
+#define CK_BUFFER_RESOURCE_3RD_DWORD 0x31004000
 #endif
 
 // FMA instruction


### PR DESCRIPTION
As mentioned in #634 , incorrect 3rd dword blocked some kernels. This PR intend to fix it.