### PR TITLE
[gtest] suppress unsafe buffer warn

### DIFF
--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -21,6 +21,7 @@ list(APPEND GTEST_CMAKE_CXX_FLAGS
      -Wno-comma
      -Wno-old-style-cast
      -Wno-deprecated
+     -Wno-unsafe-buffer-usage
 )
 message(STATUS "Suppressing googltest warnings with flags: ${GTEST_CMAKE_CXX_FLAGS}")
 


### PR DESCRIPTION
ref: https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1912

Currenly ths is blocking a compiler patch:
"I am trying to land this patch 785694: [SafeBufferUsage] restore safe buffer usage warnings for MIOpen GTest | http://gerrit-git.amd.com/c/lightning/ec/llvm-project/+/785694"