### PR TITLE
Reduce initial range for half_t splitk

### DIFF
--- a/profiler/include/profiler/profile_gemm_splitk_impl.hpp
+++ b/profiler/include/profiler/profile_gemm_splitk_impl.hpp
@@ -72,8 +72,8 @@ bool profile_gemm_splitk_impl(int do_verification,
     {
     case 0: break;
     case 1:
-        a_m_k.GenerateTensorValue(GeneratorTensor_2<ADataType>{-5, 5});
-        b_k_n.GenerateTensorValue(GeneratorTensor_2<BDataType>{-5, 5});
+        a_m_k.GenerateTensorValue(GeneratorTensor_2<ADataType>{0, 1});
+        b_k_n.GenerateTensorValue(GeneratorTensor_2<BDataType>{-1, 1});
         break;
     default:
         a_m_k.GenerateTensorValue(GeneratorTensor_3<ADataType>{0.0, 1.0});


### PR DESCRIPTION
- Failed validation with splitK_gemm with atomic_fp16 due to precision loss for large integer number
- Reduced initial number range