### PR TITLE
Fix uninitialized data members if create tensor descriptor on device side

### DIFF
--- a/include/ck/tensor_description/multi_index_transform.hpp
+++ b/include/ck/tensor_description/multi_index_transform.hpp
@@ -393,9 +393,9 @@ struct Embed
 
     __host__ __device__ constexpr Embed() = default;
 
-    __host__ __device__ constexpr Embed(const UpLengths& up_lengths,
-                                        const Coefficients& coefficients)
-        : up_lengths_{up_lengths}, coefficients_{coefficients}
+    /// NOTE: force copying here to prevent uninitialized data members (on device side)
+    __host__ __device__ constexpr Embed(UpLengths up_lengths, Coefficients coefficients)
+        : up_lengths_{std::move(up_lengths)}, coefficients_{std::move(coefficients)}
     {
     }
 

--- a/include/ck/tensor_description/multi_index_transform.hpp
+++ b/include/ck/tensor_description/multi_index_transform.hpp
@@ -383,6 +383,8 @@ template <typename UpLengths,
           typename enable_if<UpLengths::Size() == Coefficients::Size(), bool>::type = false>
 struct Embed
 {
+    static_assert(!std::is_reference_v<UpLengths> && !std::is_reference_v<Coefficients>);
+
     static constexpr index_t NDimUp = UpLengths::Size();
 
     using LowerIndex = MultiIndex<1>;

--- a/include/ck/tensor_description/multi_index_transform.hpp
+++ b/include/ck/tensor_description/multi_index_transform.hpp
@@ -393,8 +393,13 @@ struct Embed
 
     __host__ __device__ constexpr Embed() = default;
 
+    __host__ constexpr Embed(const UpLengths& up_lengths, const Coefficients& coefficients)
+        : up_lengths_{up_lengths}, coefficients_{coefficients}
+    {
+    }
+
     /// NOTE: force copying here to prevent uninitialized data members (on device side)
-    __host__ __device__ constexpr Embed(UpLengths up_lengths, Coefficients coefficients)
+    __device__ constexpr Embed(UpLengths up_lengths, Coefficients coefficients)
         : up_lengths_{std::move(up_lengths)}, coefficients_{std::move(coefficients)}
     {
     }


### PR DESCRIPTION
After calling `make_naive_tensor_descriptor()` on device side, the data members of `Embed` object may not been properly initialized (with type `Tuple<>`).
Due to the complex usage of  `Tuple<>` (e.g. as `union` field), we cannot add non-trivial copy ctor for `TupleElementKeyData<>` (base type of `Tuple<>` ) without breaking rest of codes (the trivial copy ctor is not functional in this case). Thus I would like to force copying the parameters in `Embed` ctor.