### PR TITLE
support dynamic buffer using memory coherence glc_slc bit from template

### DIFF
--- a/include/ck/utility/amd_buffer_addressing.hpp
+++ b/include/ck/utility/amd_buffer_addressing.hpp
@@ -287,17 +287,21 @@ llvm_amdgcn_raw_buffer_atomic_max_fp64(double vdata,
                                        int glc_slc) __asm("llvm.amdgcn.raw.buffer.atomic.fmax.f64");
 
 // memory coherency bit for buffer store/load instruction
-enum struct amd_buffer_coherence_bits
+// check ISA manual for each GFX target
+// e.g. for
+// https://www.amd.com/system/files/TechDocs/instinct-mi200-cdna2-instruction-set-architecture.pdf,
+// page 67~68
+enum struct AmdBufferCoherenceEnum
 {
-    default_coherence = 0, // default value
-    glc               = 1,
-    slc               = 2,
-    glc_slc           = 3,
+    DefaultCoherence = 0, // default value
+    GLC              = 1,
+    SLC              = 2,
+    GLC_SLC          = 3,
 };
 
 template <typename T,
           index_t N,
-          amd_buffer_coherence_bits coherence = amd_buffer_coherence_bits::default_coherence>
+          AmdBufferCoherenceEnum coherence = AmdBufferCoherenceEnum::DefaultCoherence>
 __device__ typename vector_type<T, N>::type amd_buffer_load_impl(int32x4_t src_wave_buffer_resource,
                                                                  index_t src_thread_addr_offset,
                                                                  index_t src_wave_addr_offset)
@@ -617,7 +621,7 @@ __device__ typename vector_type<T, N>::type amd_buffer_load_impl(int32x4_t src_w
 
 template <typename T,
           index_t N,
-          amd_buffer_coherence_bits coherence = amd_buffer_coherence_bits::default_coherence>
+          AmdBufferCoherenceEnum coherence = AmdBufferCoherenceEnum::DefaultCoherence>
 __device__ void amd_buffer_store_impl(const typename vector_type<T, N>::type src_thread_data,
                                       int32x4_t dst_wave_buffer_resource,
                                       index_t dst_thread_addr_offset,
@@ -1090,7 +1094,7 @@ __device__ void amd_buffer_atomic_max_impl(const typename vector_type<T, N>::typ
 // It is user's responsibility to make sure that is true.
 template <typename T,
           index_t N,
-          amd_buffer_coherence_bits coherence = amd_buffer_coherence_bits::default_coherence>
+          AmdBufferCoherenceEnum coherence = AmdBufferCoherenceEnum::DefaultCoherence>
 __device__ typename vector_type_maker<T, N>::type::type
 amd_buffer_load_invalid_element_return_zero(const T* p_src_wave,
                                             index_t src_thread_element_offset,
@@ -1126,7 +1130,7 @@ amd_buffer_load_invalid_element_return_zero(const T* p_src_wave,
 // It is user's responsibility to make sure that is true.
 template <typename T,
           index_t N,
-          amd_buffer_coherence_bits coherence = amd_buffer_coherence_bits::default_coherence>
+          AmdBufferCoherenceEnum coherence = AmdBufferCoherenceEnum::DefaultCoherence>
 __device__ typename vector_type_maker<T, N>::type::type
 amd_buffer_load_invalid_element_return_customized_value(const T* p_src_wave,
                                                         index_t src_thread_element_offset,
@@ -1156,7 +1160,7 @@ amd_buffer_load_invalid_element_return_customized_value(const T* p_src_wave,
 // It is user's responsibility to make sure that is true.
 template <typename T,
           index_t N,
-          amd_buffer_coherence_bits coherence = amd_buffer_coherence_bits::default_coherence>
+          AmdBufferCoherenceEnum coherence = AmdBufferCoherenceEnum::DefaultCoherence>
 __device__ void amd_buffer_store(const typename vector_type_maker<T, N>::type::type src_thread_data,
                                  T* p_dst_wave,
                                  const index_t dst_thread_element_offset,

--- a/include/ck/utility/dynamic_buffer.hpp
+++ b/include/ck/utility/dynamic_buffer.hpp
@@ -380,14 +380,19 @@ struct DynamicBuffer
     __host__ __device__ static constexpr bool IsDynamicBuffer() { return true; }
 };
 
-template <AddressSpaceEnum BufferAddressSpace, typename T, typename ElementSpaceSize>
+template <AddressSpaceEnum BufferAddressSpace,
+          amd_buffer_coherence_bits coherence = amd_buffer_coherence_bits::default_coherence,
+          typename T,
+          typename ElementSpaceSize>
 __host__ __device__ constexpr auto make_dynamic_buffer(T* p, ElementSpaceSize element_space_size)
 {
-    return DynamicBuffer<BufferAddressSpace, T, ElementSpaceSize, true>{p, element_space_size};
+    return DynamicBuffer<BufferAddressSpace, T, ElementSpaceSize, true, coherence>{
+        p, element_space_size};
 }
 
 template <
     AddressSpaceEnum BufferAddressSpace,
+    amd_buffer_coherence_bits coherence = amd_buffer_coherence_bits::default_coherence,
     typename T,
     typename ElementSpaceSize,
     typename X,
@@ -395,7 +400,7 @@ template <
 __host__ __device__ constexpr auto
 make_dynamic_buffer(T* p, ElementSpaceSize element_space_size, X invalid_element_value)
 {
-    return DynamicBuffer<BufferAddressSpace, T, ElementSpaceSize, false>{
+    return DynamicBuffer<BufferAddressSpace, T, ElementSpaceSize, false, coherence>{
         p, element_space_size, invalid_element_value};
 }
 

--- a/include/ck/utility/dynamic_buffer.hpp
+++ b/include/ck/utility/dynamic_buffer.hpp
@@ -19,7 +19,8 @@ namespace ck {
 template <AddressSpaceEnum BufferAddressSpace,
           typename T,
           typename ElementSpaceSize,
-          bool InvalidElementUseNumericalZeroValue>
+          bool InvalidElementUseNumericalZeroValue,
+          amd_buffer_coherence_bits coherence = amd_buffer_coherence_bits::default_coherence>
 struct DynamicBuffer
 {
     using type = T;
@@ -52,10 +53,9 @@ struct DynamicBuffer
     __host__ __device__ constexpr T& operator()(index_t i) { return p_data_[i]; }
 
     template <typename X,
-              amd_buffer_coherence_bits coherence = amd_buffer_coherence_bits::default_coherence,
               typename enable_if<is_same<typename scalar_type<remove_cvref_t<X>>::type,
                                          typename scalar_type<remove_cvref_t<T>>::type>::value,
-                                 bool>::type      = false>
+                                 bool>::type = false>
     __host__ __device__ constexpr auto Get(index_t i, bool is_valid_element) const
     {
         // X contains multiple T
@@ -148,10 +148,9 @@ struct DynamicBuffer
     }
 
     template <typename X,
-              amd_buffer_coherence_bits coherence = amd_buffer_coherence_bits::default_coherence,
               typename enable_if<is_same<typename scalar_type<remove_cvref_t<X>>::type,
                                          typename scalar_type<remove_cvref_t<T>>::type>::value,
-                                 bool>::type      = false>
+                                 bool>::type = false>
     __host__ __device__ void Set(index_t i, bool is_valid_element, const X& x)
     {
         // X contains multiple T

--- a/include/ck/utility/dynamic_buffer.hpp
+++ b/include/ck/utility/dynamic_buffer.hpp
@@ -20,7 +20,7 @@ template <AddressSpaceEnum BufferAddressSpace,
           typename T,
           typename ElementSpaceSize,
           bool InvalidElementUseNumericalZeroValue,
-          amd_buffer_coherence_bits coherence = amd_buffer_coherence_bits::default_coherence>
+          AmdBufferCoherenceEnum coherence = AmdBufferCoherenceEnum::DefaultCoherence>
 struct DynamicBuffer
 {
     using type = T;
@@ -381,7 +381,7 @@ struct DynamicBuffer
 };
 
 template <AddressSpaceEnum BufferAddressSpace,
-          amd_buffer_coherence_bits coherence = amd_buffer_coherence_bits::default_coherence,
+          AmdBufferCoherenceEnum coherence = AmdBufferCoherenceEnum::DefaultCoherence,
           typename T,
           typename ElementSpaceSize>
 __host__ __device__ constexpr auto make_dynamic_buffer(T* p, ElementSpaceSize element_space_size)
@@ -392,7 +392,7 @@ __host__ __device__ constexpr auto make_dynamic_buffer(T* p, ElementSpaceSize el
 
 template <
     AddressSpaceEnum BufferAddressSpace,
-    amd_buffer_coherence_bits coherence = amd_buffer_coherence_bits::default_coherence,
+    AmdBufferCoherenceEnum coherence = AmdBufferCoherenceEnum::DefaultCoherence,
     typename T,
     typename ElementSpaceSize,
     typename X,


### PR DESCRIPTION
- add `amd_buffer_coherence_bits` enum to switch between different coherence bits in buffer load/store.
- support changing coherence while creating a `DynamicBuffer` through template arg (so we no need to change every threadwise copy)
- support changing coherence with `make_dynamic_buffer()` function
- The default value is `amd_buffer_coherence_bits::default_coherence`

The change in this P.R has been used and verified by 

[gridwise_multiblock_batchnorm_forward_generic.hpp](https://github.com/ROCmSoftwarePlatform/composable_kernel/blob/batchnorm-fwd-new/include/ck/tensor_operation/gpu/grid/batchnorm_multiblock/gridwise_multiblock_batchnorm_forward_generic.hpp)
