### PR TITLE
Fix incomplete object size (=4n + 3) support of amd_wave_read_first_lane()

### DIFF
--- a/include/ck/utility/amd_wave_read_first_lane.hpp
+++ b/include/ck/utility/amd_wave_read_first_lane.hpp
@@ -71,7 +71,7 @@ __device__ auto amd_wave_read_first_lane(const Object& obj)
     {
         using Carrier = detail::get_unsigned_int_t<RemainedSize>;
 
-        *reinterpret_cast<Carrier>(to_obj + CompleteSgprCopyBoundary) = amd_wave_read_first_lane(
+        *reinterpret_cast<Carrier*>(to_obj + CompleteSgprCopyBoundary) = amd_wave_read_first_lane(
             *reinterpret_cast<const Carrier*>(from_obj + CompleteSgprCopyBoundary));
     }
 

--- a/include/ck/utility/amd_wave_read_first_lane.hpp
+++ b/include/ck/utility/amd_wave_read_first_lane.hpp
@@ -51,16 +51,17 @@ struct get_carrier<3>
         __device__ inline carrier& operator=(const carrier& other) noexcept
         {
             std::copy_n(other.bytes.data(), bytes.size(), bytes.data());
+
             return *this;
         }
 
         __device__ inline operator value_type() const noexcept
         {
-            value_type value{};
+            std::array<std::byte, sizeof(value_type)> value;
 
-            std::copy_n(bytes.data(), bytes.size(), reinterpret_cast<std::byte*>(&value));
+            std::copy_n(bytes.data(), bytes.size(), value.data());
 
-            return value;
+            return *reinterpret_cast<const value_type*>(value.data());
         }
     };
 };

--- a/include/ck/utility/amd_wave_read_first_lane.hpp
+++ b/include/ck/utility/amd_wave_read_first_lane.hpp
@@ -41,7 +41,7 @@ struct get_carrier<3>
         static_assert(sizeof(bytes) <= sizeof(value_type));
 
         public:
-        __device__ inline carrier(value_type value) noexcept
+        __device__ carrier(value_type value) noexcept
         {
             auto from = reinterpret_cast<const std::byte*>(&value);
             for(auto to = bytes.begin(); to != bytes.end(); ++to, ++from)
@@ -51,7 +51,7 @@ struct get_carrier<3>
         }
 
         // method to trigger template substitution failure
-        __device__ inline carrier& operator=(const carrier& other) noexcept
+        __device__ carrier& operator=(const carrier& other) noexcept
         {
             auto from = other.bytes.begin();
             for(auto to = bytes.begin(); to != bytes.end(); ++to, ++from)
@@ -62,7 +62,7 @@ struct get_carrier<3>
             return *this;
         }
 
-        __device__ inline operator value_type() const noexcept
+        __device__ operator value_type() const noexcept
         {
             std::byte result[sizeof(value_type)];
 

--- a/include/ck/utility/amd_wave_read_first_lane.hpp
+++ b/include/ck/utility/amd_wave_read_first_lane.hpp
@@ -59,7 +59,7 @@ struct get_carrier<3>
         }
 
         // method to trigger template substitution failure
-        carrier(const carrier& other) noexcept
+        __device__ carrier(const carrier& other) noexcept
         {
             copy_n(other.bytes.begin(), bytes.size(), bytes.begin());
         }

--- a/include/ck/utility/amd_wave_read_first_lane.hpp
+++ b/include/ck/utility/amd_wave_read_first_lane.hpp
@@ -72,8 +72,8 @@ struct get_carrier<4>
     using type = uint32_t;
 };
 
-template <unsigned Size>
-using get_carrier_t = typename get_carrier<Size>::type;
+template <unsigned SizeInBytes>
+using get_carrier_t = typename get_carrier<SizeInBytes>::type;
 
 } // namespace detail
 

--- a/include/ck/utility/amd_wave_read_first_lane.hpp
+++ b/include/ck/utility/amd_wave_read_first_lane.hpp
@@ -7,7 +7,6 @@
 #include "ck/utility/functional2.hpp"
 #include "ck/utility/math.hpp"
 
-#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -44,24 +43,36 @@ struct get_carrier<3>
         public:
         __device__ inline carrier(value_type value) noexcept
         {
-            std::copy_n(reinterpret_cast<const std::byte*>(&value), bytes.size(), bytes.data());
+            auto from = reinterpret_cast<const std::byte*>(&value);
+            for(auto to = bytes.begin(); to != bytes.end(); ++to, ++from)
+            {
+                *to = *from;
+            }
         }
 
         // method to trigger template substitution failure
         __device__ inline carrier& operator=(const carrier& other) noexcept
         {
-            std::copy_n(other.bytes.data(), bytes.size(), bytes.data());
+            auto from = other.bytes.begin();
+            for(auto to = bytes.begin(); to != bytes.end(); ++to, ++from)
+            {
+                *to = *from;
+            }
 
             return *this;
         }
 
         __device__ inline operator value_type() const noexcept
         {
-            std::array<std::byte, sizeof(value_type)> value;
+            std::byte result[sizeof(value_type)];
 
-            std::copy_n(bytes.data(), bytes.size(), value.data());
+            auto to = result;
+            for(auto from = bytes.begin(); from != bytes.end(); ++to, ++from)
+            {
+                *to = *from;
+            }
 
-            return *reinterpret_cast<const value_type*>(value.data());
+            return *reinterpret_cast<const value_type*>(result);
         }
     };
 };

--- a/include/ck/utility/amd_wave_read_first_lane.hpp
+++ b/include/ck/utility/amd_wave_read_first_lane.hpp
@@ -42,25 +42,23 @@ struct get_carrier<3>
         static_assert(sizeof(bytes) <= sizeof(value_type));
 
         public:
-        inline carrier(value_type value) noexcept
+        __device__ inline carrier(value_type value) noexcept
         {
-            auto const from = reinterpret_cast<const std::byte*>(&value);
-            std::copy_n(from, bytes.size(), bytes.data());
+            std::copy_n(reinterpret_cast<const std::byte*>(&value), bytes.size(), bytes.data());
         }
 
         // method to trigger template substitution failure
-        inline carrier& operator=(const carrier& other) noexcept
+        __device__ inline carrier& operator=(const carrier& other) noexcept
         {
             std::copy_n(other.bytes.data(), bytes.size(), bytes.data());
             return *this;
         }
 
-        inline operator value_type() const noexcept
+        __device__ inline operator value_type() const noexcept
         {
             value_type value{};
 
-            auto const to = reinterpret_cast<std::byte*>(&value);
-            std::copy_n(bytes.data(), bytes.size(), to);
+            std::copy_n(bytes.data(), bytes.size(), reinterpret_cast<std::byte*>(&value));
 
             return value;
         }

--- a/include/ck/utility/amd_wave_read_first_lane.hpp
+++ b/include/ck/utility/amd_wave_read_first_lane.hpp
@@ -15,28 +15,28 @@ namespace ck {
 namespace detail {
 
 template <unsigned Size>
-struct get_unsigned_int;
+struct get_carrier;
 
 template <>
-struct get_unsigned_int<1>
+struct get_carrier<1>
 {
     using type = uint8_t;
 };
 
 template <>
-struct get_unsigned_int<2>
+struct get_carrier<2>
 {
     using type = uint16_t;
 };
 
 template <>
-struct get_unsigned_int<4>
+struct get_carrier<4>
 {
     using type = uint32_t;
 };
 
 template <unsigned Size>
-using get_unsigned_int_t = typename get_unsigned_int<Size>::type;
+using get_carrier_t = typename get_carrier<Size>::type;
 
 } // namespace detail
 
@@ -61,7 +61,7 @@ __device__ auto amd_wave_read_first_lane(const Object& obj)
     constexpr Size CompleteSgprCopyBoundary = ObjectSize - RemainedSize;
     for(Size offset = 0; offset < CompleteSgprCopyBoundary; offset += SgprSize)
     {
-        using Sgpr = detail::get_unsigned_int_t<SgprSize>;
+        using Sgpr = detail::get_carrier_t<SgprSize>;
 
         *reinterpret_cast<Sgpr*>(to_obj + offset) =
             amd_wave_read_first_lane(*reinterpret_cast<const Sgpr*>(from_obj + offset));
@@ -69,7 +69,7 @@ __device__ auto amd_wave_read_first_lane(const Object& obj)
 
     if constexpr(0 < RemainedSize)
     {
-        using Carrier = detail::get_unsigned_int_t<RemainedSize>;
+        using Carrier = detail::get_carrier_t<RemainedSize>;
 
         *reinterpret_cast<Carrier*>(to_obj + CompleteSgprCopyBoundary) = amd_wave_read_first_lane(
             *reinterpret_cast<const Carrier*>(from_obj + CompleteSgprCopyBoundary));

--- a/include/ck/utility/amd_wave_read_first_lane.hpp
+++ b/include/ck/utility/amd_wave_read_first_lane.hpp
@@ -58,16 +58,16 @@ struct get_carrier<3>
             return to;
         }
 
-        public:
-        __device__ carrier(value_type value) noexcept
-        {
-            copy_n(reinterpret_cast<const std::byte*>(&value), bytes.size(), bytes.begin());
-        }
-
         // method to trigger template substitution failure
-        __device__ carrier& operator=(const carrier& other) noexcept
+        carrier(const carrier& other) noexcept
         {
             copy_n(other.bytes.begin(), bytes.size(), bytes.begin());
+        }
+
+        public:
+        __device__ carrier& operator=(value_type value) noexcept
+        {
+            copy_n(reinterpret_cast<const std::byte*>(&value), bytes.size(), bytes.begin());
 
             return *this;
         }


### PR DESCRIPTION
This is a complement to [PR 711](https://github.com/ROCmSoftwarePlatform/composable_kernel/pull/711)

Though it's unlikely to use **(4n + 3)** byte class types in real-world scenarios. I think it's still necessary to fix missing size support of `ck::amd_wave_read_first_lane()`. 

We can create such type by declaring a struct `S` which has only single byte-array data member:

```c++
struct S {
   unsigned char uca[3];
};
static_assert(sizeof(S) == 3);

const auto s = ck::amd_wave_read_first_lane(S{1, 2, 3}); // compilation error before this PR
assert(s.uca[0] == 1);
assert(s.uca[1] == 2);
assert(s.uca[2] == 3);
```