### PR TITLE
Add basic setup for precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+-   repo: local
+    hooks:
+    -   id: clang-format
+        name: clang-format
+        entry: clang-format-10 -i --style=file
+        language: system
+        types_or: [c++, inc]
+    -   id: copyright-year-checker
+        name: copyright-year-checker
+        entry: script/check_copyright_year.sh
+        verbose: false
+        language: script
+        types: [c++]

--- a/script/check_copyright_year.sh
+++ b/script/check_copyright_year.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+current_year=$(date +%Y)
+exit_code=0
+
+for file in $@; do
+    if grep -q "Copyright (c)" $file
+    then
+        if ! grep -q "Copyright (c).*$current_year" $file
+        then
+            echo "ERROR: File $file has a copyright notice without the current year ($current_year)."
+            exit_code=1
+        fi
+    fi
+done
+
+exit $exit_code

--- a/script/install_precommit.sh
+++ b/script/install_precommit.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+run_and_check() {
+    "$@"
+    status=$?
+    if [ $status -ne 0 ]; then
+        echo "Error with \"$@\": Exited with status $status"
+        exit $status
+    fi
+    return $status
+}
+
+echo "I: Installing tools required for pre-commit checks..."
+run_and_check apt install clang-format-10
+
+echo "I: Installing pre-commit itself..."
+run_and_check pip3 install pre-commit
+run_and_check pre-commit install
+
+echo "I: Installation successful."

--- a/script/uninstall_precommit.sh
+++ b/script/uninstall_precommit.sh
@@ -1,0 +1,1 @@
+pre-commit uninstall


### PR DESCRIPTION
This change adds a basic precommit configuration that runs clang-format on the modified files and a very simple copyright year checker. It also adds scripts for installing and uninstalling pre-commit hook from the repository.