### PR TITLE
Add rocm5.6 RC4 and rocm5.7 to docker build options.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN useradd -rm -d /home/jenkins -s /bin/bash -u 1004 jenkins
 RUN chmod 1777 /tmp
 RUN apt-get update
 RUN apt-get install -y --allow-unauthenticated apt-utils wget gnupg2 curl
-RUN if [ "$ROCMVERSION" != "5.6" ]; then \
+RUN if [ "$ROCMVERSION" != "5.6" ] && [ "$ROCMVERSION" != "5.7" ]; then \
         wget -qO - http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
         sh -c "echo deb [arch=amd64] $DEB_ROCM_REPO ubuntu main > /etc/apt/sources.list.d/rocm.list"; \
     elif [ "$ROCMVERSION" = "5.6" ] && [ "$compiler_version" = "" ]; then \
@@ -25,6 +25,10 @@ RUN if [ "$ROCMVERSION" != "5.6" ]; then \
          apt update && apt-get install -y ./amdgpu-install-internal_5.6-20.04-1_all.deb && \
          sh -c 'echo deb [arch=amd64 trusted=yes] http://compute-artifactory.amd.com/artifactory/list/rocm-release-archive-20.04-deb/ 5.6 rel-62  > /etc/apt/sources.list.d/rocm-build.list' && \
          amdgpu-repo --amdgpu-build=1609671 && amdgpu-install -y --usecase=rocm --no-dkms; \
+    elif [ "$ROCMVERSION" = "5.7" ] && [ "$compiler_version" = "" ] || [ "$compiler_version" = "amd-stg-open" ]; then \
+         sh -c "wget http://artifactory-cdn.amd.com/artifactory/list/amdgpu-deb/amdgpu-install-internal_5.7-20.04-1_all.deb" && \
+         apt update && apt-get install -y ./amdgpu-install-internal_5.7-20.04-1_all.deb && \
+         amdgpu-repo --amdgpu-build=1609671 --rocm-build=compute-rocm-npi-mi300/1354 && amdgpu-install -y --usecase=rocm --no-dkms; \
     fi
 
 RUN wget --no-check-certificate -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,11 @@ RUN if [ "$ROCMVERSION" != "5.6" ]; then \
          apt update && apt-get install -y ./amd-nonfree-radeon_20.04-1_all.deb && \
          amdgpu-repo --amdgpu-build=1567752 --rocm-build=compute-rocm-dkms-no-npi-hipclang/11914 && \
          amdgpu-install -y --usecase=rocm --no-dkms; \
-    elif [ "$ROCMVERSION" = "5.6" ] && [ "$compiler_version" = "rc3" ] || [ "$compiler_version" = "amd-stg-open" ]; then \
+    elif [ "$ROCMVERSION" = "5.6" ] && [ "$compiler_version" = "rc4" ] || [ "$compiler_version" = "amd-stg-open" ]; then \
          sh -c "wget http://artifactory-cdn.amd.com/artifactory/list/amdgpu-deb/amdgpu-install-internal_5.6-20.04-1_all.deb" && \
          apt update && apt-get install -y ./amdgpu-install-internal_5.6-20.04-1_all.deb && \
-         sh -c 'echo deb [arch=amd64 trusted=yes] http://compute-artifactory.amd.com/artifactory/list/rocm-release-archive-20.04-deb/ 5.6 rel-45  > /etc/apt/sources.list.d/rocm-build.list' && \
-         amdgpu-repo --amdgpu-build=1602498 && amdgpu-install -y --usecase=rocm --no-dkms; \
+         sh -c 'echo deb [arch=amd64 trusted=yes] http://compute-artifactory.amd.com/artifactory/list/rocm-release-archive-20.04-deb/ 5.6 rel-62  > /etc/apt/sources.list.d/rocm-build.list' && \
+         amdgpu-repo --amdgpu-build=1609671 && amdgpu-install -y --usecase=rocm --no-dkms; \
     fi
 
 RUN wget --no-check-certificate -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ def runShell(String command){
 
 def getDockerImageName(){
     def img
-    if (params.ROCMVERSION != "5.6"){
+    if (params.ROCMVERSION != "5.6" && params.ROCMVERSION != "5.7"){
        if (params.COMPILER_VERSION == "") {
            img = "${env.CK_DOCKERHUB}:ck_ub20.04_rocm${params.ROCMVERSION}"
        }


### PR DESCRIPTION
These changes allow to build the CK docker and run CI with rocm5.6 RC4 and rocm5.7 compilers.