### PR TITLE
Disable Werror to ignore xnack+ warnings

### DIFF
--- a/cmake/EnableCompilerWarnings.cmake
+++ b/cmake/EnableCompilerWarnings.cmake
@@ -66,7 +66,6 @@ else()
             -Wunreachable-code
             -Wunused
             -Wno-reserved-identifier
-            -Werror
             -Wsign-compare
             -Wno-extra-semi-stmt
         )

--- a/cmake/EnableCompilerWarnings.cmake
+++ b/cmake/EnableCompilerWarnings.cmake
@@ -66,6 +66,8 @@ else()
             -Wunreachable-code
             -Wunused
             -Wno-reserved-identifier
+            -Werror
+            -Wno-option-ignored
             -Wsign-compare
             -Wno-extra-semi-stmt
         )


### PR DESCRIPTION
Changes Proposed:
- When ASAN features are enabled, this change helps to ignore the xnack+ warning to consider as errors