### PR TITLE
Add check for compiler GPU target support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,21 +24,15 @@ list(APPEND CMAKE_PREFIX_PATH ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_PREFIX}/ll
 message("GPU_TARGETS= ${GPU_TARGETS}")
 
 message("checking which targets are supported")
-rocm_check_target_ids(SUPPORTED_GPU_TARGETS
-    TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1102"
+#This is the list of targets to be used in case GPU_TARGETS is not set on command line
+#These targets will be filtered and only supported ones will be used
+#Setting GPU_TARGETS on command line will override this list
+rocm_check_target_ids(DEFAULT_GPU_TARGETS
+    TARGETS "gfx900;gfx906;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1102"
 )
-message("SUPPORTED_GPU_TARGETS= ${SUPPORTED_GPU_TARGETS}")
-
-foreach(target IN LISTS GPU_TARGETS)
- if(NOT target IN_LIST SUPPORTED_GPU_TARGETS)
-   list(REMOVE_ITEM GPU_TARGETS "${target}")
-   message("removing target ${target} from the list")
- else()
-   message("target ${target} is legit")
- endif()
-endforeach()
-
-message("New filtered GPU_TARGETS= ${GPU_TARGETS}")
+message("Supported GPU_TARGETS= ${DEFAULT_GPU_TARGETS}")
+set(AMDGPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING " ")
+find_package(hip)
 
 option(USE_BITINT_EXTENSION_INT4, "Whether to enable clang's BitInt extension to provide int4 data type." OFF)
 option(USE_OPT_NAVI3X, "Whether to enable LDS cumode and Wavefront32 mode for NAVI3X silicons." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,29 @@ include(ROCMSetupVersion)
 include(ROCMInstallSymlinks)
 include(ROCMCreatePackage)
 include(CheckCXXCompilerFlag)
-
+include(ROCMCheckTargetIds)
 rocm_setup_version(VERSION 0.2.0)
 include(TargetFlags)
 list(APPEND CMAKE_PREFIX_PATH ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_PREFIX}/llvm ${CMAKE_INSTALL_PREFIX}/hip /opt/rocm /opt/rocm/llvm /opt/rocm/hip)
+
+message("GPU_TARGETS= ${GPU_TARGETS}")
+
+message("checking which targets are supported")
+rocm_check_target_ids(SUPPORTED_GPU_TARGETS
+    TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1102"
+)
+message("SUPPORTED_GPU_TARGETS= ${SUPPORTED_GPU_TARGETS}")
+
+foreach(target IN LISTS GPU_TARGETS)
+ if(NOT target IN_LIST SUPPORTED_GPU_TARGETS)
+   list(REMOVE_ITEM GPU_TARGETS "${target}")
+   message("removing target ${target} from the list")
+ else()
+   message("target ${target} is legit")
+ endif()
+endforeach()
+
+message("New filtered GPU_TARGETS= ${GPU_TARGETS}")
 
 option(USE_BITINT_EXTENSION_INT4, "Whether to enable clang's BitInt extension to provide int4 data type." OFF)
 option(USE_OPT_NAVI3X, "Whether to enable LDS cumode and Wavefront32 mode for NAVI3X silicons." OFF)


### PR DESCRIPTION
With this change, we will be able to build CK for all possible GPU targets required by other ROCM libraries, e.g. MIOpen, while at the same time, filtering that list to exclude any targets not supported by the current compiler. For that scenario, the user should not set the GPU_TARGETS on the cmake command line.

At the same time, we will preserve the functionality of setting GPU_TARGETS on the command line, which will override the default target list, and can be used in cases when we want to build CK just for one or two specific architectures.