### PR TITLE
Fix datatype in inner_product when V_DOT2 is disabled

### DIFF
--- a/include/ck/utility/inner_product.hpp
+++ b/include/ck/utility/inner_product.hpp
@@ -94,8 +94,8 @@ __device__ void inner_product<half2_t, half2_t, float>(const half2_t& a, const h
     const vector_type<half_t, 2> b_vector{b};
 
     static_for<0, 2, 1>{}([&](auto i) {
-        c += type_convert<int32_t>(a_vector.AsType<half_t>()[i]) *
-             type_convert<int32_t>(b_vector.AsType<half_t>()[i]);
+        c += type_convert<float>(a_vector.AsType<half_t>()[i]) *
+             type_convert<float>(b_vector.AsType<half_t>()[i]);
     });
 #endif
 }


### PR DESCRIPTION
This PR fixes the datatype used in `inner_product` for `half2_t` when `CK_USE_AMD_V_DOT2_F32_F16` is not set. It works when we initialize tensors with integer values, but when we use decimal ones, the "C++" path does not work.
Running `bin/example_gemm_dl_fp16 1 2 0` after removing the definition of `CK_USE_AMD_V_DOT2_F32_F16` fails right now and passes after this change.