### PR TITLE
Fix config header installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,7 +449,7 @@ rocm_install(FILES
 )
 
 # Install CK version and configuration files
-install(FILES
+rocm_install(FILES
     ${PROJECT_BINARY_DIR}/include/ck/version.h
     ${PROJECT_BINARY_DIR}/include/ck/config.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ck/


### PR DESCRIPTION
Because this line used `install` instead of `rocm_install`, the config header was not flagged for inclusion in the package.