### PR TITLE
Add a switch to build DL kernels and build them with staging compiler.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -459,6 +459,9 @@ def Build_CK(Map conf=[:]){
         if (params.COMPILER_VERSION == "amd-stg-open" || params.COMPILER_COMMIT != ""){
             dockerOpts = dockerOpts + " --env HIP_CLANG_PATH='/llvm-project/build/bin' "
         }
+        if (params.DL_KERNELS){
+            setup_args = setup_args + " -DDL_KERNELS=ON "
+        }
 
         def variant = env.STAGE_NAME
         def retimage
@@ -614,7 +617,7 @@ def process_results(Map conf=[:]){
 //launch develop branch daily at 23:00 UT in FULL_QA mode and at 19:00 UT with latest staging compiler version
 CRON_SETTINGS = BRANCH_NAME == "develop" ? '''0 23 * * * % RUN_FULL_QA=true;ROCMVERSION=5.7;COMPILER_VERSION=rc1
                                               0 21 * * * % ROCMVERSION=5.6;COMPILER_VERSION=;COMPILER_COMMIT=
-                                              0 19 * * * % BUILD_DOCKER=true;COMPILER_VERSION=amd-stg-open;COMPILER_COMMIT=''' : ""
+                                              0 19 * * * % BUILD_DOCKER=true;DL_KERNELS=true;COMPILER_VERSION=amd-stg-open;COMPILER_COMMIT=''' : ""
 
 pipeline {
     agent none
@@ -649,6 +652,10 @@ pipeline {
             name: "RUN_FULL_QA",
             defaultValue: false,
             description: "Select whether to run small set of performance tests (default) or full QA")
+        booleanParam(
+            name: "DL_KERNELS",
+            defaultValue: false,
+            description: "Select whether to build DL kernels (default: OFF)")
     }
     environment{
         dbuser = "${dbuser}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -210,6 +210,9 @@ def cmake_build(Map conf=[:]){
     } else{
         setup_args = ' -DBUILD_DEV=On' + setup_args
     }
+    if (params.DL_KERNELS){
+        setup_args = setup_args + " -DDL_KERNELS=ON "
+    }
 
     if(build_type_debug){
         setup_args = " -DCMAKE_BUILD_TYPE=debug -DCMAKE_CXX_FLAGS_DEBUG='${debug_flags}'" + setup_args
@@ -458,9 +461,6 @@ def Build_CK(Map conf=[:]){
         def dockerArgs = "--build-arg PREFIX=${prefixpath} --build-arg compiler_version='${params.COMPILER_VERSION}' --build-arg compiler_commit='${params.COMPILER_COMMIT}' --build-arg ROCMVERSION='${params.ROCMVERSION}' "
         if (params.COMPILER_VERSION == "amd-stg-open" || params.COMPILER_COMMIT != ""){
             dockerOpts = dockerOpts + " --env HIP_CLANG_PATH='/llvm-project/build/bin' "
-        }
-        if (params.DL_KERNELS){
-            setup_args = setup_args + " -DDL_KERNELS=ON "
         }
 
         def variant = env.STAGE_NAME


### PR DESCRIPTION
This change will add an new Jenkins parameter DL_KERNELS (off by default) and will make the daily cron job built with the staging compiler, which now includes the compiler patch, build DL kernels on all platforms.
I have confirmed that with the latest amd-stg-open compiler the build time on gfx1101 goes up from 6 minutes to 11 minutes when the dl kernels are built (down from 3 hours 15 minutes without the patch).