### PR TITLE
[Cmake] Set cmake default build type Release and path to /opt/rocm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,18 @@
 cmake_minimum_required(VERSION 3.14)
 
+# This has to be initialized before the project() command appears
+# Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
+if( NOT MSVC_IDE AND NOT CMAKE_BUILD_TYPE )
+    set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." )
+endif()
+
+# Default installation path
+if(WIN32)
+    set(CMAKE_INSTALL_PREFIX "/opt/rocm/x86_64-w64-mingw32" CACHE PATH "")
+else()
+    set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "")
+endif()
+
 set(version 1.1.0)
 # Check support for CUDA/HIP in Cmake
 project(composable_kernel VERSION ${version})


### PR DESCRIPTION
So here is the special user case:

If user has an existing ROCm docker, CK will be at 
> /opt/rocm

However, when user tried to build CK again from code without specifying the install prefix, it will be installed at:
> /usr/local

Then any third party who build on top of CK will have a problem depending on which of the two paths have priority, and it will be difficult for debugging and triage.

Like any other ROCm component, let's set `/opt/rocm` as the default installation path.