### PR TITLE
Update required CMake version to 3.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.25)
 cmake_policy(SET CMP0140 NEW)
 
 # This has to be initialized before the project() command appears


### PR DESCRIPTION
### Description
Configuration failure if we use older version of _CMake_. 

#### Error message
```bash
CMake Error at CMakeLists.txt:2 (cmake_policy):
  Policy "CMP0140" is not known to this version of CMake.
```

### Solution
Since we are using the [`return()`](https://cmake.org/cmake/help/latest/command/return.html#command:return) command with newly introduced parameter `PROPAGATE` (introduced in _CMake 3.25_). Thus we shall update the required version as well.