### PR TITLE
Replace CMake `return` from later CMake

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -30,7 +30,7 @@ function(add_example_executable EXAMPLE_NAME FILE_NAME)
                 set(test 0)
                 break()
             elseif((source MATCHES "fp8" OR source MATCHES "fp32" OR source MATCHES "fp64" OR source MATCHES "bf16" OR source MATCHES "int8" OR source MATCHES "fp16" OR
-                source MATCHES "_f8" OR source MATCHES "_f32" OR source MATCHES "_f64" OR source MATCHES "_i8" OR source MATCHES "_f16" OR source MATCHES "_b16") AND 
+                source MATCHES "_f8" OR source MATCHES "_f32" OR source MATCHES "_f64" OR source MATCHES "_i8" OR source MATCHES "_f16" OR source MATCHES "_b16") AND
                 NOT(source MATCHES type OR source MATCHES type1))
                     #if filename contains a type which doesn't match any selected type, mark it for removal
                     set(test 1)
@@ -59,7 +59,7 @@ function(add_example_executable EXAMPLE_NAME FILE_NAME)
         set(result 0)
     endif()
     #message("add_example returns ${result}")
-    return(PROPAGATE result)
+    set(result ${result} PARENT_SCOPE)
 endfunction(add_example_executable EXAMPLE_NAME)
 
 function(add_example_executable_no_testing EXAMPLE_NAME FILE_NAME)
@@ -87,7 +87,7 @@ function(add_example_executable_no_testing EXAMPLE_NAME FILE_NAME)
                     set(test 0)
                     break()
                 elseif((source MATCHES "fp8" OR source MATCHES "fp32" OR source MATCHES "fp64" OR source MATCHES "bf16" OR source MATCHES "int8" OR source MATCHES "fp16" OR
-                  source MATCHES "_f8" OR source MATCHES "_f32" OR source MATCHES "_f64" OR source MATCHES "_i8" OR source MATCHES "_f16" OR source MATCHES "_b16") AND 
+                  source MATCHES "_f8" OR source MATCHES "_f32" OR source MATCHES "_f64" OR source MATCHES "_i8" OR source MATCHES "_f16" OR source MATCHES "_b16") AND
                   NOT(source MATCHES type OR source MATCHES type1))
                     #if filename contains a type which doesn't match any selected type, mark it for removal
                     set(test 1)
@@ -96,7 +96,7 @@ function(add_example_executable_no_testing EXAMPLE_NAME FILE_NAME)
         if(test EQUAL 1)
             message("removing example ${source} ")
             list(REMOVE_ITEM FILE_NAME "${source}")
-        endif()    
+        endif()
     endforeach()
     endif()
     foreach(source IN LISTS FILE_NAME)
@@ -114,7 +114,7 @@ function(add_example_executable_no_testing EXAMPLE_NAME FILE_NAME)
         set(result 0)
     endif()
     #message("add_example returns ${result}")
-    return(PROPAGATE result)
+    set(result ${result} PARENT_SCOPE)
 endfunction(add_example_executable_no_testing EXAMPLE_NAME)
 
 # add all example subdir

--- a/library/src/tensor_operation_instance/gpu/CMakeLists.txt
+++ b/library/src/tensor_operation_instance/gpu/CMakeLists.txt
@@ -24,7 +24,7 @@ function(add_instance_library INSTANCE_NAME)
                         set(test 0)
                         break()
                 elseif((source MATCHES "fp8" OR source MATCHES "fp32" OR source MATCHES "fp64" OR source MATCHES "bf16" OR source MATCHES "int8" OR source MATCHES "fp16" OR
-                  source MATCHES "_f8" OR source MATCHES "_f32" OR source MATCHES "_f64" OR source MATCHES "_i8" OR source MATCHES "_f16" OR source MATCHES "_b16") AND 
+                  source MATCHES "_f8" OR source MATCHES "_f32" OR source MATCHES "_f64" OR source MATCHES "_i8" OR source MATCHES "_f16" OR source MATCHES "_b16") AND
                   NOT(source MATCHES type OR source MATCHES type1))
                         #if filename contains a type which doesn't match any selected type, mark it for removal
                         set(test 1)
@@ -51,7 +51,7 @@ function(add_instance_library INSTANCE_NAME)
         set(result 0)
     endif()
     #message("add_instance_library returns ${result}")
-    return(PROPAGATE result)
+    set(result ${result} PARENT_SCOPE)
 endfunction(add_instance_library INSTANCE_NAME)
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,7 +32,7 @@ function(add_test_executable TEST_NAME)
                 set(test 0)
                 break()
             elseif((source MATCHES "fp8" OR source MATCHES "fp32" OR source MATCHES "fp64" OR source MATCHES "bf16" OR source MATCHES "int8" OR source MATCHES "fp16" OR
-                source MATCHES "_f8" OR source MATCHES "_f32" OR source MATCHES "_f64" OR source MATCHES "_i8" OR source MATCHES "_f16" OR source MATCHES "_b16") AND 
+                source MATCHES "_f8" OR source MATCHES "_f32" OR source MATCHES "_f64" OR source MATCHES "_i8" OR source MATCHES "_f16" OR source MATCHES "_b16") AND
                 NOT(source MATCHES type OR source MATCHES type1))
                     #if filename contains a type which doesn't match any selected type, mark it for removal
                     set(test 1)
@@ -61,7 +61,7 @@ function(add_test_executable TEST_NAME)
         set(result 0)
     endif()
     #message("add_test returns ${result}")
-    return(PROPAGATE result)
+    set(result ${result} PARENT_SCOPE)
 endfunction(add_test_executable TEST_NAME)
 
 include(GoogleTest)
@@ -91,7 +91,7 @@ function(add_gtest_executable TEST_NAME)
                 set(test 0)
                 break()
             elseif((source MATCHES "fp8" OR source MATCHES "fp32" OR source MATCHES "fp64" OR source MATCHES "bf16" OR source MATCHES "int8" OR source MATCHES "fp16" OR
-                source MATCHES "_f8" OR source MATCHES "_f32" OR source MATCHES "_f64" OR source MATCHES "_i8" OR source MATCHES "_f16" OR source MATCHES "_b16") AND 
+                source MATCHES "_f8" OR source MATCHES "_f32" OR source MATCHES "_f64" OR source MATCHES "_i8" OR source MATCHES "_f16" OR source MATCHES "_b16") AND
                 NOT(source MATCHES type OR source MATCHES type1))
                     #if filename contains a type which doesn't match any selected type, mark it for removal
                     set(test 1)
@@ -123,7 +123,7 @@ function(add_gtest_executable TEST_NAME)
         set(result 0)
     endif()
     #message("add_gtest returns ${result}")
-    return(PROPAGATE result)
+    set(result ${result} PARENT_SCOPE)
 endfunction(add_gtest_executable TEST_NAME)
 
 add_subdirectory(magic_number_division)


### PR DESCRIPTION
Previously these functions used [`return(PROPAGATE ...)`](https://cmake.org/cmake/help/latest/command/return.html), which was introduced in CMake 3.25. This has been changed to use the pattern for returning values from CMake functions in older versions of CMake, to maintain compatibility.