### PR TITLE
Fix the fp8 gemm for large tensors on MI300.

### DIFF
--- a/example/27_layernorm/run_layernorm_example.inc
+++ b/example/27_layernorm/run_layernorm_example.inc
@@ -8,8 +8,8 @@ int run_groupnorm_example()
 {
     bool time_kernel = false;
 
-    ck::index_t M      = 1024;
-    ck::index_t N      = 1024;
+    ck::index_t M = 1024;
+    ck::index_t N = 1024;
 
     Tensor<XDataType> x({M, N});
     Tensor<GammaDataType> gamma({N});
@@ -44,9 +44,9 @@ int run_groupnorm_example()
         {0, 1},
         std::vector<ck::index_t>{y.mDesc.GetStrides().begin(), y.mDesc.GetStrides().end()},
         std::vector<ck::index_t>{save_mean.mDesc.GetStrides().begin(),
-                                    save_mean.mDesc.GetStrides().end()},
+                                 save_mean.mDesc.GetStrides().end()},
         std::vector<ck::index_t>{save_mean.mDesc.GetStrides().begin(),
-                                    save_mean.mDesc.GetStrides().end()},
+                                 save_mean.mDesc.GetStrides().end()},
         {1},
         1e-4,
         x_dev.GetDeviceBuffer(),

--- a/example/42_groupnorm/run_groupnorm_example.inc
+++ b/example/42_groupnorm/run_groupnorm_example.inc
@@ -65,9 +65,9 @@ int run_groupnorm_example(int argc, char* argv[])
         {0, 0, 0, C, 1},
         std::vector<ck::index_t>{y.mDesc.GetStrides().begin(), y.mDesc.GetStrides().end()},
         std::vector<ck::index_t>{save_mean.mDesc.GetStrides().begin(),
-                                    save_mean.mDesc.GetStrides().end()},
+                                 save_mean.mDesc.GetStrides().end()},
         std::vector<ck::index_t>{save_mean.mDesc.GetStrides().begin(),
-                                    save_mean.mDesc.GetStrides().end()},
+                                 save_mean.mDesc.GetStrides().end()},
         {1, 2, 4}, // reduction dimension: [H, W, C]
         1e-6,
         x_dev.GetDeviceBuffer(),

--- a/include/ck/utility/type_convert.hpp
+++ b/include/ck/utility/type_convert.hpp
@@ -110,7 +110,15 @@ inline __host__ __device__ f8_t type_convert<f8_t, float>(float x)
     uint32_t ival = 0;
     ival       = __builtin_amdgcn_cvt_pk_fp8_f32(val.fval, val.fval, ival, false); // false -> WORD0
     val.i32val = ival;
-    return val.i8val[0];
+    const uint8_t nan_code = 0x80;
+    if(val.i8val[0] == nan_code)
+    {
+        return NumericLimits<f8_t>::Max();
+    }
+    else
+    {
+        return val.i8val[0];
+    }
 #else
     constexpr bool negative_zero_nan = true;
     constexpr bool clip              = true;

--- a/include/ck/utility/type_convert.hpp
+++ b/include/ck/utility/type_convert.hpp
@@ -100,13 +100,14 @@ template <>
 inline __host__ __device__ f8_t type_convert<f8_t, float>(float x)
 {
 #if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
-    if(x > type_convert<float>(NumericLimits<f8_t>::Max()))
+    float max_fp8 = 240.0f;
+    if(x > max_fp8)
     {
-        x = type_convert<float>(NumericLimits<f8_t>::Max());
+        x = max_fp8;
     }
-    else if(x < type_convert<float>(-NumericLimits<f8_t>::Max()))
+    else if(x < -max_fp8)
     {
-        x = type_convert<float>(-NumericLimits<f8_t>::Max());
+        x = -max_fp8;
     }
     union
     {

--- a/include/ck/utility/type_convert.hpp
+++ b/include/ck/utility/type_convert.hpp
@@ -101,14 +101,7 @@ inline __host__ __device__ f8_t type_convert<f8_t, float>(float x)
 {
 #if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
     float max_fp8 = 240.0f;
-    if(x > max_fp8)
-    {
-        x = max_fp8;
-    }
-    else if(x < -max_fp8)
-    {
-        x = -max_fp8;
-    }
+    x = x > max_fp8 ? max_fp8 : (x < -max_fp8 ? -max_fp8 : x);
     union
     {
         float fval;

--- a/include/ck/utility/type_convert.hpp
+++ b/include/ck/utility/type_convert.hpp
@@ -118,6 +118,7 @@ inline __host__ __device__ f8_t type_convert<f8_t, float>(float x)
     uint32_t ival = 0;
     ival       = __builtin_amdgcn_cvt_pk_fp8_f32(val.fval, val.fval, ival, false); // false -> WORD0
     val.i32val = ival;
+    return val.i8val[0];
 #else
     constexpr bool negative_zero_nan = true;
     constexpr bool clip              = true;

--- a/include/ck/utility/type_convert.hpp
+++ b/include/ck/utility/type_convert.hpp
@@ -100,6 +100,14 @@ template <>
 inline __host__ __device__ f8_t type_convert<f8_t, float>(float x)
 {
 #if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+    if(x > type_convert<float>(NumericLimits<f8_t>::Max()))
+    {
+        x = type_convert<float>(NumericLimits<f8_t>::Max());
+    }
+    else if(x < type_convert<float>(-NumericLimits<f8_t>::Max()))
+    {
+        x = type_convert<float>(-NumericLimits<f8_t>::Max());
+    }
     union
     {
         float fval;
@@ -110,15 +118,6 @@ inline __host__ __device__ f8_t type_convert<f8_t, float>(float x)
     uint32_t ival = 0;
     ival       = __builtin_amdgcn_cvt_pk_fp8_f32(val.fval, val.fval, ival, false); // false -> WORD0
     val.i32val = ival;
-    const uint8_t nan_code = 0x80;
-    if(val.i8val[0] == nan_code)
-    {
-        return NumericLimits<f8_t>::Max();
-    }
-    else
-    {
-        return val.i8val[0];
-    }
 #else
     constexpr bool negative_zero_nan = true;
     constexpr bool clip              = true;

--- a/include/ck/utility/type_convert.hpp
+++ b/include/ck/utility/type_convert.hpp
@@ -101,7 +101,7 @@ inline __host__ __device__ f8_t type_convert<f8_t, float>(float x)
 {
 #if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
     float max_fp8 = 240.0f;
-    x = x > max_fp8 ? max_fp8 : (x < -max_fp8 ? -max_fp8 : x);
+    x             = x > max_fp8 ? max_fp8 : (x < -max_fp8 ? -max_fp8 : x);
     union
     {
         float fval;

--- a/profiler/include/profiler/profile_gemm_impl.hpp
+++ b/profiler/include/profiler/profile_gemm_impl.hpp
@@ -75,8 +75,8 @@ int profile_gemm_impl(int do_verification,
         b_k_n.GenerateTensorValue(GeneratorTensor_2<BDataType>{-5, 5});
         break;
     default:
-        a_m_k.GenerateTensorValue(GeneratorTensor_3<ADataType>{0.0, 1.0});
-        b_k_n.GenerateTensorValue(GeneratorTensor_3<BDataType>{-0.5, 0.5});
+        a_m_k.GenerateTensorValue(GeneratorTensor_3<ADataType>{0.0, 0.1});
+        b_k_n.GenerateTensorValue(GeneratorTensor_3<BDataType>{-0.05, 0.05});
     }
 
     using AElementOp = ck::tensor_operation::element_wise::PassThrough;


### PR DESCRIPTION
Two fixes: 
when using init=1: make sure the values are within [-240;+240] range before converting from fp16 to fp8;
when using init=2: use smaller input values in the A and B tensors to reduce the round-off error.