### PR TITLE
Switch from hipTensor mainline to develop branch in CI tests.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -702,8 +702,8 @@ pipeline {
             description: "Use the CK build to verify hipTensor build and tests (default: ON)")
         string(
             name: 'hipTensor_branch',
-            defaultValue: 'mainline',
-            description: 'Specify which branch of hipTensor to use (default: mainline)')
+            defaultValue: 'develop',
+            description: 'Specify which branch of hipTensor to use (default: develop)')
         booleanParam(
             name: "USE_SCCACHE",
             defaultValue: true,


### PR DESCRIPTION
We have merged Bartek's changes with multiple data types support for conversion kernels and hipTensor have merged the necessary changes on their end. However, we cannot propagate the changes to the master branches yet while the release is still being rolled out. So we'll need to use the develop branch for testing in the meantime.