### PR TITLE
Fix the CI builds using clang++ directly.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -773,8 +773,8 @@ pipeline {
                                          -DCMAKE_EXE_LINKER_FLAGS=" -L ${env.WORKSPACE}/script -T hip_fatbin_insert "
                                          -DCMAKE_CXX_FLAGS=" -O3 " 
                                      """
-                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake 
-                                           -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
+                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && 
+                                           cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
                                            -DGPU_TARGETS="gfx908;gfx90a;gfx940;gfx941;gfx942" 
                                            -DCMAKE_CXX_COMPILER="${build_compiler()}" 
                                            -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j 
@@ -794,8 +794,8 @@ pipeline {
                     agent{ label rocmnode("gfx908 || gfx90a") }
                     environment{
                         setup_args = """ -DCMAKE_INSTALL_PREFIX=../install -DGPU_TARGETS="gfx908;gfx90a" -DCMAKE_CXX_FLAGS=" -O3 " """
-                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake 
-                                           -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
+                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && 
+                                           cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
                                            -DGPU_TARGETS="gfx908;gfx90a" 
                                            -DCMAKE_CXX_COMPILER="${build_compiler()}" 
                                            -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j 
@@ -815,8 +815,8 @@ pipeline {
                     agent{ label rocmnode("navi21") }
                     environment{
                         setup_args = """ -DCMAKE_INSTALL_PREFIX=../install -DGPU_TARGETS="gfx1030" -DDL_KERNELS=ON -DCMAKE_CXX_FLAGS=" -O3 " """ 
-                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake 
-                                           -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
+                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && 
+                                           cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
                                            -DGPU_TARGETS="gfx1030" 
                                            -DCMAKE_CXX_COMPILER="${build_compiler()}" 
                                            -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j 
@@ -836,8 +836,8 @@ pipeline {
                     agent{ label rocmnode("navi32") }
                     environment{
                         setup_args = """ -DCMAKE_INSTALL_PREFIX=../install -DGPU_TARGETS="gfx1101" -DDL_KERNELS=ON -DCMAKE_CXX_FLAGS=" -O3 " """
-                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake 
-                                           -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
+                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && 
+                                           cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
                                            -DGPU_TARGETS="gfx1101" 
                                            -DCMAKE_CXX_COMPILER="${build_compiler()}" 
                                            -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -768,17 +768,15 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx908 || gfx90a") }
                     environment{
-                        setup_args = """ -DCMAKE_INSTALL_PREFIX=../install 
-                                         -DGPU_TARGETS="gfx908;gfx90a;gfx940;gfx941;gfx942" 
-                                         -DCMAKE_EXE_LINKER_FLAGS=" -L ${env.WORKSPACE}/script -T hip_fatbin_insert "
-                                         -DCMAKE_CXX_FLAGS=" -O3 " 
-                                     """
-                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && 
-                                           cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
-                                           -DGPU_TARGETS="gfx908;gfx90a;gfx940;gfx941;gfx942" 
-                                           -DCMAKE_CXX_COMPILER="${build_compiler()}" 
-                                           -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j 
-                                       """ 
+                        setup_args = """ -DCMAKE_INSTALL_PREFIX=../install \
+                                         -DGPU_TARGETS="gfx908;gfx90a;gfx940;gfx941;gfx942" \
+                                         -DCMAKE_EXE_LINKER_FLAGS=" -L ${env.WORKSPACE}/script -T hip_fatbin_insert " \
+                                         -DCMAKE_CXX_FLAGS=" -O3 " """
+                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && \
+                                           cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" \
+                                           -DGPU_TARGETS="gfx908;gfx90a;gfx940;gfx941;gfx942" \
+                                           -DCMAKE_CXX_COMPILER="${build_compiler()}" \
+                                           -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j """ 
                     }
                     steps{
                         Build_CK_and_Reboot(setup_args: setup_args, config_targets: "install", no_reboot:true, build_type: 'Release', execute_cmd: execute_args, prefixpath: '/usr/local')
@@ -794,12 +792,11 @@ pipeline {
                     agent{ label rocmnode("gfx908 || gfx90a") }
                     environment{
                         setup_args = """ -DCMAKE_INSTALL_PREFIX=../install -DGPU_TARGETS="gfx908;gfx90a" -DCMAKE_CXX_FLAGS=" -O3 " """
-                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && 
-                                           cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
-                                           -DGPU_TARGETS="gfx908;gfx90a" 
-                                           -DCMAKE_CXX_COMPILER="${build_compiler()}" 
-                                           -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j 
-                                        """ 
+                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && \
+                                           cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" \
+                                           -DGPU_TARGETS="gfx908;gfx90a" \
+                                           -DCMAKE_CXX_COMPILER="${build_compiler()}" \
+                                           -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j """ 
                     }
                     steps{
                         Build_CK_and_Reboot(setup_args: setup_args, config_targets: "install", no_reboot:true, build_type: 'Release', execute_cmd: execute_args, prefixpath: '/usr/local')
@@ -815,12 +812,11 @@ pipeline {
                     agent{ label rocmnode("navi21") }
                     environment{
                         setup_args = """ -DCMAKE_INSTALL_PREFIX=../install -DGPU_TARGETS="gfx1030" -DDL_KERNELS=ON -DCMAKE_CXX_FLAGS=" -O3 " """ 
-                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && 
-                                           cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
-                                           -DGPU_TARGETS="gfx1030" 
-                                           -DCMAKE_CXX_COMPILER="${build_compiler()}" 
-                                           -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j 
-                                       """
+                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && \
+                                           cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" \
+                                           -DGPU_TARGETS="gfx1030" \
+                                           -DCMAKE_CXX_COMPILER="${build_compiler()}" \
+                                           -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j """
                     }
                     steps{
                         Build_CK_and_Reboot(setup_args: setup_args, config_targets: "install", no_reboot:true, build_type: 'Release', execute_cmd: execute_args, prefixpath: '/usr/local')
@@ -836,12 +832,11 @@ pipeline {
                     agent{ label rocmnode("navi32") }
                     environment{
                         setup_args = """ -DCMAKE_INSTALL_PREFIX=../install -DGPU_TARGETS="gfx1101" -DDL_KERNELS=ON -DCMAKE_CXX_FLAGS=" -O3 " """
-                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && 
-                                           cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
-                                           -DGPU_TARGETS="gfx1101" 
-                                           -DCMAKE_CXX_COMPILER="${build_compiler()}" 
-                                           -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j 
-                                       """
+                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && \
+                                           cmake -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" \
+                                           -DGPU_TARGETS="gfx1101" \
+                                           -DCMAKE_CXX_COMPILER="${build_compiler()}" \
+                                           -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j """
                     }
                     steps{
                         Build_CK_and_Reboot(setup_args: setup_args, config_targets: "install", no_reboot:true, build_type: 'Release', execute_cmd: execute_args, prefixpath: '/usr/local')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -768,8 +768,17 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx908 || gfx90a") }
                     environment{
-                        setup_args = """ -DCMAKE_INSTALL_PREFIX=../install -DGPU_TARGETS="gfx908;gfx90a;gfx940;gfx941;gfx942" -DCMAKE_EXE_LINKER_FLAGS=" -L ${env.WORKSPACE}/script -T hip_fatbin_insert " """
-                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake -D CMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" -DGPU_TARGETS="gfx908;gfx90a;gfx940;gfx941;gfx942" -D CMAKE_CXX_COMPILER="${build_compiler()}" .. && make -j """ 
+                        setup_args = """ -DCMAKE_INSTALL_PREFIX=../install 
+                                         -DGPU_TARGETS="gfx908;gfx90a;gfx940;gfx941;gfx942" 
+                                         -DCMAKE_EXE_LINKER_FLAGS=" -L ${env.WORKSPACE}/script -T hip_fatbin_insert "
+                                         -DCMAKE_CXX_FLAGS=" -O3 " 
+                                     """
+                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake 
+                                           -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
+                                           -DGPU_TARGETS="gfx908;gfx90a;gfx940;gfx941;gfx942" 
+                                           -DCMAKE_CXX_COMPILER="${build_compiler()}" 
+                                           -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j 
+                                       """ 
                     }
                     steps{
                         Build_CK_and_Reboot(setup_args: setup_args, config_targets: "install", no_reboot:true, build_type: 'Release', execute_cmd: execute_args, prefixpath: '/usr/local')
@@ -784,8 +793,13 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx908 || gfx90a") }
                     environment{
-                        setup_args = """ -DCMAKE_INSTALL_PREFIX=../install -DGPU_TARGETS="gfx908;gfx90a" """
-                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake -D CMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" -DGPU_TARGETS="gfx908;gfx90a" -D CMAKE_CXX_COMPILER="${build_compiler()}" .. && make -j """ 
+                        setup_args = """ -DCMAKE_INSTALL_PREFIX=../install -DGPU_TARGETS="gfx908;gfx90a" -DCMAKE_CXX_FLAGS=" -O3 " """
+                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake 
+                                           -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
+                                           -DGPU_TARGETS="gfx908;gfx90a" 
+                                           -DCMAKE_CXX_COMPILER="${build_compiler()}" 
+                                           -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j 
+                                        """ 
                     }
                     steps{
                         Build_CK_and_Reboot(setup_args: setup_args, config_targets: "install", no_reboot:true, build_type: 'Release', execute_cmd: execute_args, prefixpath: '/usr/local')
@@ -800,8 +814,13 @@ pipeline {
                     }
                     agent{ label rocmnode("navi21") }
                     environment{
-                        setup_args = """ -DCMAKE_INSTALL_PREFIX=../install -DGPU_TARGETS="gfx1030" -DDL_KERNELS=ON """ 
-                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake -D CMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" -DGPU_TARGETS="gfx1030" -D CMAKE_CXX_COMPILER="${build_compiler()}" .. && make -j """
+                        setup_args = """ -DCMAKE_INSTALL_PREFIX=../install -DGPU_TARGETS="gfx1030" -DDL_KERNELS=ON -DCMAKE_CXX_FLAGS=" -O3 " """ 
+                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake 
+                                           -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
+                                           -DGPU_TARGETS="gfx1030" 
+                                           -DCMAKE_CXX_COMPILER="${build_compiler()}" 
+                                           -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j 
+                                       """
                     }
                     steps{
                         Build_CK_and_Reboot(setup_args: setup_args, config_targets: "install", no_reboot:true, build_type: 'Release', execute_cmd: execute_args, prefixpath: '/usr/local')
@@ -816,8 +835,13 @@ pipeline {
                     }
                     agent{ label rocmnode("navi32") }
                     environment{
-                        setup_args = """ -DCMAKE_INSTALL_PREFIX=../install -DGPU_TARGETS="gfx1101" -DDL_KERNELS=ON """
-                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake -D CMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" -DGPU_TARGETS="gfx1101" -DDL_KERNELS=ON -D CMAKE_CXX_COMPILER="${build_compiler()}" .. && make -j """
+                        setup_args = """ -DCMAKE_INSTALL_PREFIX=../install -DGPU_TARGETS="gfx1101" -DDL_KERNELS=ON -DCMAKE_CXX_FLAGS=" -O3 " """
+                        execute_args = """ cd ../client_example && rm -rf build && mkdir build && cd build && cmake 
+                                           -DCMAKE_PREFIX_PATH="${env.WORKSPACE}/install;/opt/rocm" 
+                                           -DGPU_TARGETS="gfx1101" 
+                                           -DCMAKE_CXX_COMPILER="${build_compiler()}" 
+                                           -DCMAKE_CXX_FLAGS=" -O3 " .. && make -j 
+                                       """
                     }
                     steps{
                         Build_CK_and_Reboot(setup_args: setup_args, config_targets: "install", no_reboot:true, build_type: 'Release', execute_cmd: execute_args, prefixpath: '/usr/local')


### PR DESCRIPTION
It appears that to build the client examples for gfx11 targets using clang requires adding the -O3 compiler flag.