### PR TITLE
fix clang format

### DIFF
--- a/library/src/tensor_operation_instance/gpu/gemm/device_gemm_xdl_c_shuffle_f16_f8_f16_mk_kn_mn_instance.cpp
+++ b/library/src/tensor_operation_instance/gpu/gemm/device_gemm_xdl_c_shuffle_f16_f8_f16_mk_kn_mn_instance.cpp
@@ -16,7 +16,7 @@ namespace tensor_operation {
 namespace device {
 namespace instance {
 
-using F8 = ck::f8_t;
+using F8  = ck::f8_t;
 using F16 = ck::half_t;
 using F32 = float;
 

--- a/library/src/tensor_operation_instance/gpu/gemm/device_gemm_xdl_c_shuffle_f16_f8_f16_mk_nk_mn_instance.cpp
+++ b/library/src/tensor_operation_instance/gpu/gemm/device_gemm_xdl_c_shuffle_f16_f8_f16_mk_nk_mn_instance.cpp
@@ -16,7 +16,7 @@ namespace tensor_operation {
 namespace device {
 namespace instance {
 
-using F8 = ck::f8_t;
+using F8  = ck::f8_t;
 using F16 = ck::half_t;
 using F32 = float;
 


### PR DESCRIPTION
Fix for the previous commit:

http://micimaster.amd.com/blue/organizations/jenkins/MLLIBS%2Fcomposable_kernel/detail/develop/4/pipeline/

[2023-12-08T21:01:11.229Z] sh -c 'clang-format-12 -style=file ../library/src/tensor_operation_instance/gpu/gemm/device_gemm_xdl_c_shuffle_f16_f8_f16_mk_kn_mn_instance.cpp | diff - ../library/src/tensor_operation_instance/gpu/gemm/device_gemm_xdl_c_shuffle_f16_f8_f16_mk_kn_mn_instance.cpp' 
[2023-12-08T21:01:11.229Z] 19c19
[2023-12-08T21:01:11.229Z] < using F8  = ck::f8_t;
[2023-12-08T21:01:11.229Z] ---
[2023-12-08T21:01:11.229Z] > using F8 = ck::f8_t;
