### PR TITLE
add -Wno-pass-failed compiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ endif()
 
 #for f8/bf8_t type
 add_compile_options(-Wno-bit-int-extension)
+add_compile_options(-Wno-pass-failed)
 
 if(DL_KERNELS)
     add_definitions(-DDL_KERNELS)


### PR DESCRIPTION
Adding the compiler flag to fix the build error with staging compiler.