### PR TITLE
adding -Wno-switch-default compiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ endif()
 #for f8/bf8_t type
 add_compile_options(-Wno-bit-int-extension)
 add_compile_options(-Wno-pass-failed)
+add_compile_options(-Wno-switch-default)
 
 if(DL_KERNELS)
     add_definitions(-DDL_KERNELS)


### PR DESCRIPTION
This should fix the compiler errors observed with latest compiler versions when building the google test code and CK:
https://ontrack-internal.amd.com/browse/SWDEV-436625