### PR TITLE
change the googletest cmake syntax for older cmake versions.

### DIFF
--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -10,7 +10,6 @@ FetchContent_Declare(
     GTest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG f8d7d77c06936315286eb55f8de22cd23c188571
-    SYSTEM
 )
 
 # Suppress ROCMChecks WARNING on GoogleTests


### PR DESCRIPTION
This should fix the crashes observed in match-ci:

https://ontrack-internal.amd.com/browse/SWDEV-439272

The root cause is that math-ci is using Cmake version 3.21 and the SYSTEM flag is only supported in versions 3.25+.