### PR TITLE
SWDEV-439954 - Use the macro __FILE_NAME_ to print the name of file

### DIFF
--- a/include/ck/host_utility/hip_check_error.hpp
+++ b/include/ck/host_utility/hip_check_error.hpp
@@ -12,7 +12,7 @@ inline void hip_check_error(hipError_t x)
     if(x != hipSuccess)
     {
         std::ostringstream ss;
-        ss << "HIP runtime error: " << hipGetErrorString(x) << ". " << __FILE__ << ": " << __LINE__
+        ss << "HIP runtime error: " << hipGetErrorString(x) << ". " << __FILE_NAME__ << ": " << __LINE__
            << "in function: " << __func__;
         throw std::runtime_error(ss.str());
     }
@@ -25,7 +25,7 @@ inline void hip_check_error(hipError_t x)
         if(_tmpVal != hipSuccess)                                                  \
         {                                                                          \
             std::ostringstream ostr;                                               \
-            ostr << "HIP Function Failed (" << __FILE__ << "," << __LINE__ << ") " \
+            ostr << "HIP Function Failed (" << __FILE_NAME__ << "," << __LINE__ << ") " \
                  << hipGetErrorString(_tmpVal);                                    \
             throw std::runtime_error(ostr.str());                                  \
         }                                                                          \

--- a/include/ck/tensor_operation/gpu/device/impl/device_contraction_utils.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_contraction_utils.hpp
@@ -35,14 +35,14 @@ auto CalculateMaxRead(const std::vector<index_t>& lengths, const std::vector<ind
     if(lengths.size() != NumDim1 + NumDim2)
     {
         std::ostringstream err;
-        err << "Incorrect number of lengths in " << __FILE__ << ":" << __LINE__
+        err << "Incorrect number of lengths in " << __FILE_NAME__ << ":" << __LINE__
             << ", in function: " << __func__;
         throw std::runtime_error(err.str());
     }
     if(strides.size() != NumDim1 + NumDim2)
     {
         std::ostringstream err;
-        err << "Incorrect number of strides in " << __FILE__ << ":" << __LINE__
+        err << "Incorrect number of strides in " << __FILE_NAME__ << ":" << __LINE__
             << ", in function: " << __func__;
         throw std::runtime_error(err.str());
     }


### PR DESCRIPTION
The header files were using the macro __FILE__ in debug prints. As a result, absolute paths are getting embeddeded in libraries(libhiptensor) using those header files. Use the macro __FILE_NAME__