### PR TITLE
[Debug] Add bf16 as a custom data type

### DIFF
--- a/include/ck/tensor_operation/gpu/element/element_wise_operation.hpp
+++ b/include/ck/tensor_operation/gpu/element/element_wise_operation.hpp
@@ -71,9 +71,9 @@ struct AddReluAdd
     __host__ __device__ constexpr void operator()<bhalf_t, float, bhalf_t, bhalf_t>(
         bhalf_t& y, const float& x0, const bhalf_t& x1, const bhalf_t& x2) const
     {
-        float a = x0 + x1;
+        float a = x0 + x1.data;
         float b = a > 0 ? a : 0;
-        float c = b + x2;
+        float c = b + x2.data;
         y       = c;
     }
 

--- a/include/ck/utility/amd_buffer_addressing.hpp
+++ b/include/ck/utility/amd_buffer_addressing.hpp
@@ -69,7 +69,7 @@ llvm_amdgcn_raw_buffer_load_i8x4(int32x4_t srsrc,
                                  index_t glc_slc) __asm("llvm.amdgcn.raw.buffer.load.v4i8");
 
 // buffer load i16
-__device__ bhalf_t
+__device__ bhalf_t::data_type
 llvm_amdgcn_raw_buffer_load_i16(int32x4_t srsrc,
                                 index_t voffset,
                                 index_t soffset,
@@ -805,7 +805,7 @@ amd_buffer_load_invalid_element_return_zero(const T* p_src_wave,
 
     vector_t tmp = amd_buffer_load_impl<scalar_t, vector_size, coherence>(
         src_wave_buffer_resource, src_thread_addr_offset, 0);
-    return src_thread_element_valid ? tmp : vector_t(0);
+    return src_thread_element_valid ? tmp : vector_t{};
 #endif
 }
 

--- a/include/ck/utility/amd_xdlops.hpp
+++ b/include/ck/utility/amd_xdlops.hpp
@@ -209,8 +209,16 @@ struct intrin_mfma_f32_32x32x8bf16_1k<32, 32>
     template <class FloatC>
     __device__ static void Run(const bhalf4_t& reg_a, const bhalf4_t& reg_b, FloatC& reg_c)
     {
-        reg_c.template AsType<float16_t>()(Number<0>{}) = __builtin_amdgcn_mfma_f32_32x32x8bf16_1k(
-            reg_a, reg_b, reg_c.template AsType<float16_t>()[Number<0>{}], 0, 0, 0);
+        typedef ushort bhalf_vector4_t __attribute__((ext_vector_type(4)));
+        typedef float float_vector16_t __attribute__((ext_vector_type(16)));
+
+        bhalf_vector4_t a_vector4 = bit_cast<bhalf_vector4_t>(reg_a);
+        bhalf_vector4_t b_vector4 = bit_cast<bhalf_vector4_t>(reg_b);
+        float_vector16_t c_vector16 =
+            bit_cast<float_vector16_t>(reg_c.template AsType<float16_t>()[Number<0>{}]);
+
+        reg_c.template AsType<float16_t>()(Number<0>{}) = bit_cast<float16_t>(
+            __builtin_amdgcn_mfma_f32_32x32x8bf16_1k(a_vector4, b_vector4, c_vector16, 0, 0, 0));
     }
 };
 

--- a/include/ck/utility/data_type.hpp
+++ b/include/ck/utility/data_type.hpp
@@ -7,11 +7,22 @@
 
 namespace ck {
 
-using bhalf_t = ushort;
-using half_t  = _Float16;
-using int4_t  = _BitInt(4);
-using f8_t    = _BitInt(8);
-using bf8_t   = unsigned _BitInt(8);
+using half_t = _Float16;
+using int4_t = _BitInt(4);
+using f8_t   = _BitInt(8);
+using bf8_t  = unsigned _BitInt(8);
+
+struct bhalf_t
+{
+    using type      = bhalf_t;
+    using data_type = ushort;
+
+    ushort data;
+
+    __host__ __device__ bhalf_t() = default;
+
+    __host__ __device__ constexpr bhalf_t(ushort init) : data(init) {}
+};
 
 // vector_type
 template <typename T, index_t N>
@@ -88,6 +99,20 @@ struct scalar_type<vector_type<T, N>>
 {
     using type                           = T;
     static constexpr index_t vector_size = N;
+};
+
+template <>
+struct scalar_type<ck::Tuple<ck::bhalf_t,
+                             ck::bhalf_t,
+                             ck::bhalf_t,
+                             ck::bhalf_t,
+                             ck::bhalf_t,
+                             ck::bhalf_t,
+                             ck::bhalf_t,
+                             ck::bhalf_t>>
+{
+    using type                           = ck::bhalf_t;
+    static constexpr index_t vector_size = 8;
 };
 
 //
@@ -193,7 +218,7 @@ template <typename T>
 struct vector_type<T, 2>
 {
     using d1_t = T;
-    typedef T d2_t __attribute__((ext_vector_type(2)));
+    using d2_t = StaticallyIndexedArray<T, 2>;
 
     using type = d2_t;
 
@@ -204,7 +229,7 @@ struct vector_type<T, 2>
         StaticallyIndexedArray<d2_t, 1> d2x1_;
     } data_;
 
-    __host__ __device__ constexpr vector_type() : data_{type{0}} {}
+    __host__ __device__ constexpr vector_type() : data_{type{0, 0}} {}
 
     __host__ __device__ constexpr vector_type(type v) : data_{v} {}
 
@@ -243,8 +268,8 @@ template <typename T>
 struct vector_type<T, 4>
 {
     using d1_t = T;
-    typedef T d2_t __attribute__((ext_vector_type(2)));
-    typedef T d4_t __attribute__((ext_vector_type(4)));
+    using d2_t = StaticallyIndexedArray<T, 2>;
+    using d4_t = StaticallyIndexedArray<T, 4>;
 
     using type = d4_t;
 
@@ -256,7 +281,7 @@ struct vector_type<T, 4>
         StaticallyIndexedArray<d4_t, 1> d4x1_;
     } data_;
 
-    __host__ __device__ constexpr vector_type() : data_{type{0}} {}
+    __host__ __device__ constexpr vector_type() : data_{0, 0, 0, 0} {}
 
     __host__ __device__ constexpr vector_type(type v) : data_{v} {}
 
@@ -305,9 +330,9 @@ template <typename T>
 struct vector_type<T, 8>
 {
     using d1_t = T;
-    typedef T d2_t __attribute__((ext_vector_type(2)));
-    typedef T d4_t __attribute__((ext_vector_type(4)));
-    typedef T d8_t __attribute__((ext_vector_type(8)));
+    using d2_t = StaticallyIndexedArray<T, 2>;
+    using d4_t = StaticallyIndexedArray<T, 4>;
+    using d8_t = StaticallyIndexedArray<T, 8>;
 
     using type = d8_t;
 
@@ -320,7 +345,7 @@ struct vector_type<T, 8>
         StaticallyIndexedArray<d8_t, 1> d8x1_;
     } data_;
 
-    __host__ __device__ constexpr vector_type() : data_{type{0}} {}
+    __host__ __device__ constexpr vector_type() : data_{type{0, 0, 0, 0, 0, 0, 0, 0}} {}
 
     __host__ __device__ constexpr vector_type(type v) : data_{v} {}
 
@@ -378,11 +403,11 @@ struct vector_type<T, 8>
 template <typename T>
 struct vector_type<T, 16>
 {
-    using d1_t = T;
-    typedef T d2_t __attribute__((ext_vector_type(2)));
-    typedef T d4_t __attribute__((ext_vector_type(4)));
-    typedef T d8_t __attribute__((ext_vector_type(8)));
-    typedef T d16_t __attribute__((ext_vector_type(16)));
+    using d1_t  = T;
+    using d2_t  = StaticallyIndexedArray<T, 2>;
+    using d4_t  = StaticallyIndexedArray<T, 4>;
+    using d8_t  = StaticallyIndexedArray<T, 8>;
+    using d16_t = StaticallyIndexedArray<T, 16>;
 
     using type = d16_t;
 
@@ -396,7 +421,10 @@ struct vector_type<T, 16>
         StaticallyIndexedArray<d16_t, 1> d16x1_;
     } data_;
 
-    __host__ __device__ constexpr vector_type() : data_{type{0}} {}
+    __host__ __device__ constexpr vector_type()
+        : data_{type{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}
+    {
+    }
 
     __host__ __device__ constexpr vector_type(type v) : data_{v} {}
 
@@ -464,12 +492,12 @@ struct vector_type<T, 16>
 template <typename T>
 struct vector_type<T, 32>
 {
-    using d1_t = T;
-    typedef T d2_t __attribute__((ext_vector_type(2)));
-    typedef T d4_t __attribute__((ext_vector_type(4)));
-    typedef T d8_t __attribute__((ext_vector_type(8)));
-    typedef T d16_t __attribute__((ext_vector_type(16)));
-    typedef T d32_t __attribute__((ext_vector_type(32)));
+    using d1_t  = T;
+    using d2_t  = StaticallyIndexedArray<T, 2>;
+    using d4_t  = StaticallyIndexedArray<T, 4>;
+    using d8_t  = StaticallyIndexedArray<T, 8>;
+    using d16_t = StaticallyIndexedArray<T, 16>;
+    using d32_t = StaticallyIndexedArray<T, 32>;
 
     using type = d32_t;
 
@@ -560,13 +588,13 @@ struct vector_type<T, 32>
 template <typename T>
 struct vector_type<T, 64>
 {
-    using d1_t = T;
-    typedef T d2_t __attribute__((ext_vector_type(2)));
-    typedef T d4_t __attribute__((ext_vector_type(4)));
-    typedef T d8_t __attribute__((ext_vector_type(8)));
-    typedef T d16_t __attribute__((ext_vector_type(16)));
-    typedef T d32_t __attribute__((ext_vector_type(32)));
-    typedef T d64_t __attribute__((ext_vector_type(64)));
+    using d1_t  = T;
+    using d2_t  = StaticallyIndexedArray<T, 2>;
+    using d4_t  = StaticallyIndexedArray<T, 4>;
+    using d8_t  = StaticallyIndexedArray<T, 8>;
+    using d16_t = StaticallyIndexedArray<T, 16>;
+    using d32_t = StaticallyIndexedArray<T, 32>;
+    using d64_t = StaticallyIndexedArray<T, 64>;
 
     using type = d64_t;
 
@@ -668,14 +696,14 @@ struct vector_type<T, 64>
 template <typename T>
 struct vector_type<T, 128>
 {
-    using d1_t = T;
-    typedef T d2_t __attribute__((ext_vector_type(2)));
-    typedef T d4_t __attribute__((ext_vector_type(4)));
-    typedef T d8_t __attribute__((ext_vector_type(8)));
-    typedef T d16_t __attribute__((ext_vector_type(16)));
-    typedef T d32_t __attribute__((ext_vector_type(32)));
-    typedef T d64_t __attribute__((ext_vector_type(64)));
-    typedef T d128_t __attribute__((ext_vector_type(128)));
+    using d1_t   = T;
+    using d2_t   = StaticallyIndexedArray<T, 2>;
+    using d4_t   = StaticallyIndexedArray<T, 4>;
+    using d8_t   = StaticallyIndexedArray<T, 8>;
+    using d16_t  = StaticallyIndexedArray<T, 16>;
+    using d32_t  = StaticallyIndexedArray<T, 32>;
+    using d64_t  = StaticallyIndexedArray<T, 64>;
+    using d128_t = StaticallyIndexedArray<T, 128>;
 
     using type = d128_t;
 
@@ -786,15 +814,15 @@ struct vector_type<T, 128>
 template <typename T>
 struct vector_type<T, 256>
 {
-    using d1_t = T;
-    typedef T d2_t __attribute__((ext_vector_type(2)));
-    typedef T d4_t __attribute__((ext_vector_type(4)));
-    typedef T d8_t __attribute__((ext_vector_type(8)));
-    typedef T d16_t __attribute__((ext_vector_type(16)));
-    typedef T d32_t __attribute__((ext_vector_type(32)));
-    typedef T d64_t __attribute__((ext_vector_type(64)));
-    typedef T d128_t __attribute__((ext_vector_type(128)));
-    typedef T d256_t __attribute__((ext_vector_type(256)));
+    using d1_t   = T;
+    using d2_t   = StaticallyIndexedArray<T, 2>;
+    using d4_t   = StaticallyIndexedArray<T, 4>;
+    using d8_t   = StaticallyIndexedArray<T, 8>;
+    using d16_t  = StaticallyIndexedArray<T, 16>;
+    using d32_t  = StaticallyIndexedArray<T, 32>;
+    using d64_t  = StaticallyIndexedArray<T, 64>;
+    using d128_t = StaticallyIndexedArray<T, 128>;
+    using d256_t = StaticallyIndexedArray<T, 256>;
 
     using type = d256_t;
 

--- a/include/ck/utility/dynamic_buffer.hpp
+++ b/include/ck/utility/dynamic_buffer.hpp
@@ -109,7 +109,7 @@ struct DynamicBuffer
             {
                 if constexpr(InvalidElementUseNumericalZeroValue)
                 {
-                    return X{0};
+                    return X{};
                 }
                 else
                 {

--- a/include/ck/utility/generic_memory_space_atomic.hpp
+++ b/include/ck/utility/generic_memory_space_atomic.hpp
@@ -44,7 +44,7 @@ __device__ float2_t atomic_add<float2_t>(float2_t* p_dst, const float2_t& x)
     constexpr auto I1 = Number<1>{};
 
     const vector_type<float, 2> vx{x};
-    vector_type<float, 2> vy{0};
+    vector_type<float, 2> vy{};
 
     vy.template AsType<float>()(I0) =
         atomicAdd(c_style_pointer_cast<float*>(p_dst), vx.template AsType<float>()[I0]);
@@ -61,7 +61,7 @@ __device__ double2_t atomic_add<double2_t>(double2_t* p_dst, const double2_t& x)
     constexpr auto I1 = Number<1>{};
 
     const vector_type<double, 2> vx{x};
-    vector_type<double, 2> vy{0};
+    vector_type<double, 2> vy{};
 
     vy.template AsType<double>()(I0) =
         atomicAdd(c_style_pointer_cast<double*>(p_dst), vx.template AsType<double>()[I0]);
@@ -110,7 +110,7 @@ __device__ float2_t atomic_max<float2_t>(float2_t* p_dst, const float2_t& x)
     constexpr auto I1 = Number<1>{};
 
     const vector_type<float, 2> vx{x};
-    vector_type<float, 2> vy{0};
+    vector_type<float, 2> vy{};
 
     vy.template AsType<float>()(I0) =
         atomicMax(c_style_pointer_cast<float*>(p_dst), vx.template AsType<float>()[I0]);

--- a/include/ck/utility/inner_product.hpp
+++ b/include/ck/utility/inner_product.hpp
@@ -99,7 +99,10 @@ __device__ void inner_product<half2_t, half2_t, float>(const half2_t& a, const h
                  : "=v"(c)
                  : "v"(a), "v"(b), "0"(c));
 #else
-    c = __builtin_amdgcn_fdot2(a, b, c, false);
+    typedef half_t half_vector2_t __attribute__((ext_vector_type(2)));
+    half_vector2_t a_vector2 = bit_cast<half_vector2_t>(a);
+    half_vector2_t b_vector2 = bit_cast<half_vector2_t>(b);
+    c                        = __builtin_amdgcn_fdot2(a_vector2, b_vector2, c, false);
 #endif
 #else
     const vector_type<half_t, 2> a_vector{a};

--- a/include/ck/utility/inner_product_dpp8.hpp
+++ b/include/ck/utility/inner_product_dpp8.hpp
@@ -100,9 +100,12 @@ template <int SrcLaneIdx>
 __device__ void intrinsic_fdot2_impl(const half2_t& a, const half2_t& b, float& c)
 {
     constexpr int sel_mask = get_dpp_sel_mask_broadcast<SrcLaneIdx>();
-    const half2_t val_from_other_lane =
-        bit_cast<half2_t>(__builtin_amdgcn_mov_dpp8(bit_cast<int>(a), sel_mask));
-    c = __builtin_amdgcn_fdot2(val_from_other_lane, b, c, false);
+    typedef half_t half_vector2_t __attribute__((ext_vector_type(2)));
+    half_vector2_t a_vector2 = bit_cast<half_vector2_t>(a);
+    half_vector2_t b_vector2 = bit_cast<half_vector2_t>(b);
+    const half_vector2_t val_from_other_lane =
+        bit_cast<half_vector2_t>(__builtin_amdgcn_mov_dpp8(bit_cast<int>(a_vector2), sel_mask));
+    c = __builtin_amdgcn_fdot2(val_from_other_lane, b_vector2, c, false);
 }
 
 /**

--- a/include/ck/utility/type_convert.hpp
+++ b/include/ck/utility/type_convert.hpp
@@ -41,7 +41,7 @@ inline __host__ __device__ constexpr float type_convert<float, bhalf_t>(bhalf_t 
     {
         uint32_t int32;
         float fp32;
-    } u = {uint32_t(x) << 16};
+    } u = {uint32_t(x.data) << 16};
 
     return u.fp32;
 }


### PR DESCRIPTION
Use bf16 as a struct containing ushort type of data instead of ushort type directly. Update all the build issues for compatibility. Investigate the compiler crash cause.