### PR TITLE
Fixing most of the cppcheck errors.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -304,7 +304,7 @@ def buildHipClangJob(Map conf=[:]){
 
         gitStatusWrapper(credentialsId: "${status_wrapper_creds}", gitHubContext: "Jenkins - ${variant}", account: 'ROCm', repo: 'composable_kernel') {
             withDockerContainer(image: image, args: dockerOpts + ' -v=/var/jenkins/:/var/jenkins') {
-                timeout(time: 20, unit: 'HOURS')
+                timeout(time: 48, unit: 'HOURS')
                 {
                     cmake_build(conf)
                 }
@@ -757,6 +757,8 @@ pipeline {
                                 | xargs -n 1 -P 1 -I{} -t sh -c \'clang-format-12 -style=file {} | diff - {}\' && \
                                 /cppcheck/build/bin/cppcheck ../* -v -j \$(nproc) -I ../include -I ../profiler/include -I ../library/include \
                                 -D CK_ENABLE_FP64 -D CK_ENABLE_FP32 -D CK_ENABLE_FP16 -D CK_ENABLE_FP8 -D CK_ENABLE_BF16 -D CK_ENABLE_BF8 -D CK_ENABLE_INT8 -D DL_KERNELS \
+                                -D __gfx908__ -D __gfx90a__ -D __gfx940__ -D __gfx941__ -D __gfx942__ -D __gfx1030__ -D __gfx1100__ -D __gfx1101__ -D __gfx1102__ \
+                                -U __gfx803__ -U __gfx900__ -U __gfx906__ -U CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4 \
                                 --file-filter=*.cpp --force --enable=all --output-file=ck_cppcheck.log"
                     }
                     steps{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -755,7 +755,9 @@ pipeline {
                                 -o -iname \'*.cl\' \
                                 | grep -v 'build/' \
                                 | xargs -n 1 -P 1 -I{} -t sh -c \'clang-format-12 -style=file {} | diff - {}\' && \
-                                /cppcheck/build/bin/cppcheck ../* -v -j \$(nproc) -I ../include -I ../profiler/include -I ../library/include --file-filter=*.cpp --force --enable=all --output-file=ck_cppcheck.log"
+                                /cppcheck/build/bin/cppcheck ../* -v -j \$(nproc) -I ../include -I ../profiler/include -I ../library/include \
+                                -D CK_ENABLE_FP64 -D CK_ENABLE_FP32 -D CK_ENABLE_FP16 -D CK_ENABLE_FP8 -D CK_ENABLE_BF16 -D CK_ENABLE_BF8 -D CK_ENABLE_INT8 -D DL_KERNELS \
+                                --file-filter=*.cpp --force --enable=all --output-file=ck_cppcheck.log"
                     }
                     steps{
                         buildHipClangJobAndReboot(setup_cmd: "", build_cmd: "", execute_cmd: execute_cmd, no_reboot:true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -755,7 +755,7 @@ pipeline {
                                 -o -iname \'*.cl\' \
                                 | grep -v 'build/' \
                                 | xargs -n 1 -P 1 -I{} -t sh -c \'clang-format-12 -style=file {} | diff - {}\' && \
-                                /cppcheck/build/bin/cppcheck ../* -v -j \$(nproc) -I ../include -I ../profiler/include -I ../library/include --file-filter=*.cpp --enable=all --output-file=ck_cppcheck.log"
+                                /cppcheck/build/bin/cppcheck ../* -v -j \$(nproc) -I ../include -I ../profiler/include -I ../library/include --file-filter=*.cpp --force --enable=all --output-file=ck_cppcheck.log"
                     }
                     steps{
                         buildHipClangJobAndReboot(setup_cmd: "", build_cmd: "", execute_cmd: execute_cmd, no_reboot:true)

--- a/example/01_gemm/gemm_dl_int4.cpp
+++ b/example/01_gemm/gemm_dl_int4.cpp
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2023, Advanced Micro Devices, Inc. All rights reserved.
 
-#ifndef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
-#error Should compile this file with ck::int4_t support
-#endif
+#ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
 
 #include "common.hpp"
 
@@ -43,3 +41,4 @@ using ReferenceGemmInstance = ck::tensor_operation::host::
 #include "run_gemm_example.inc"
 
 int main(int argc, char* argv[]) { return !run_gemm_example(argc, argv); }
+#endif

--- a/example/01_gemm/gemm_xdl_int4.cpp
+++ b/example/01_gemm/gemm_xdl_int4.cpp
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2023, Advanced Micro Devices, Inc. All rights reserved.
 
-#ifndef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
-#error Should compile this file with ck::int4_t support
-#endif
+#ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
 
 #include "common.hpp"
 
@@ -44,3 +42,4 @@ using ReferenceGemmInstance = ck::tensor_operation::host::
 #include "run_gemm_example.inc"
 
 int main(int argc, char* argv[]) { return !run_gemm_example(argc, argv); }
+#endif

--- a/example/04_gemm_add_add_fastgelu/gemm_add_add_fastgelu_xdl_int4.cpp
+++ b/example/04_gemm_add_add_fastgelu/gemm_add_add_fastgelu_xdl_int4.cpp
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2023, Advanced Micro Devices, Inc. All rights reserved.
 
-#ifndef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
-#error Should compile this file with ck::int4_t support
-#endif
+#ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
 
 #include "common.hpp"
 
@@ -58,3 +56,4 @@ using ReferenceGemmInstance = ck::tensor_operation::host::ReferenceGemm<ADataTyp
 #include "run_gemm_add_add_fastgelu_example.inc"
 
 int main(int argc, char* argv[]) { return !run_gemm_add_add_fastgelu_example(argc, argv); }
+#endif

--- a/example/10_convnd_fwd_multiple_d_multiple_reduce/convnd_fwd_max_xdl_int4.cpp
+++ b/example/10_convnd_fwd_multiple_d_multiple_reduce/convnd_fwd_max_xdl_int4.cpp
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2023, Advanced Micro Devices, Inc. All rights reserved.
 
-#ifndef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
-#error Should compile this file with ck::int4_t support
-#endif
+#ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
 
 #define BUILD_INT4_EXAMPLE
 
@@ -24,3 +22,4 @@ using RsDataType        = ck::Tuple<R0DataType>;
 #include "run_convnd_fwd_max_example.inc"
 
 int main(int argc, char* argv[]) { return !run_convnd_fwd_max_example(argc, argv); }
+#endif

--- a/example/18_batched_gemm_reduce/batched_gemm_reduce_xdl_fp16.cpp
+++ b/example/18_batched_gemm_reduce/batched_gemm_reduce_xdl_fp16.cpp
@@ -272,15 +272,14 @@ int main(int argc, char* argv[])
         {
             for(int m = 0; m < M; ++m)
             {
-                auto reduce0_acc = reduce0_op.GetIdentityValue<ReduceAccDataType>();
-                auto reduce1_acc = reduce1_op.GetIdentityValue<ReduceAccDataType>();
-
+                auto reduce0_acc         = reduce0_op.GetIdentityValue<ReduceAccDataType>();
+                auto reduce1_acc         = reduce1_op.GetIdentityValue<ReduceAccDataType>();
+                ReduceAccDataType d0_val = 0;
+                ReduceAccDataType d1_val = 0;
                 for(int n = 0; n < N; ++n)
                 {
                     auto c_val =
                         ck::type_convert<ReduceAccDataType>(c_g_m_n_host_result(batch, m, n));
-                    ReduceAccDataType d0_val;
-                    ReduceAccDataType d1_val;
 
                     UnaryIdenticElementOp{}(d0_val, c_val);
                     UnarySquareElementOp{}(d1_val, c_val);

--- a/example/30_grouped_conv_fwd_multiple_d/grouped_conv_fwd_bias_relu_add_xdl_int4.cpp
+++ b/example/30_grouped_conv_fwd_multiple_d/grouped_conv_fwd_bias_relu_add_xdl_int4.cpp
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2023, Advanced Micro Devices, Inc. All rights reserved.
 
-#ifndef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
-#error Should compile this file with ck::int4_t support
-#endif
+#ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
 
 #include "common.hpp"
 
@@ -29,3 +27,4 @@ using OutElementOp = ck::tensor_operation::element_wise::AddReluAdd;
 #include "run_grouped_conv_fwd_bias_relu_add_example.inc"
 
 int main(int argc, char* argv[]) { return !run_grouped_conv_fwd_bias_relu_add_example(argc, argv); }
+#endif

--- a/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_int4.cpp
+++ b/example/31_batched_gemm_gemm/batched_gemm_gemm_xdl_int4.cpp
@@ -9,9 +9,7 @@ Gemm + Gemm fused operation. Computes C_m_o = A_m_k * B0_k_n * B1_n_o
                                                        Gemm1
 */
 
-#ifndef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
-#error Should compile this file with ck::int4_t support
-#endif
+#ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
 
 #include <iostream>
 #include <numeric>
@@ -144,3 +142,4 @@ static_assert(sizeof(ck::int4_t) == sizeof(int8_t));
 #endif
 
 int main(int argc, char* argv[]) { return run_batched_gemm_gemm_example(argc, argv) ? 0 : 1; }
+#endif

--- a/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_int4.cpp
+++ b/example/41_grouped_conv_conv_fwd/grouped_conv_conv_fwd_xdl_int4.cpp
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2023, Advanced Micro Devices, Inc. All rights reserved.
 
-#ifndef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
-#error Should compile this file with ck::int4_t support
-#endif
+#ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
 
 #include <cstdlib>
 #include <iostream>
@@ -120,3 +118,4 @@ static_assert(sizeof(ck::int4_t) == sizeof(int8_t));
 #endif
 
 int main(int argc, char* argv[]) { return run_grouped_conv_conv_fwd_example(argc, argv) ? 0 : 1; }
+#endif

--- a/example/48_pool3d_fwd/pool3d_fwd_common.hpp
+++ b/example/48_pool3d_fwd/pool3d_fwd_common.hpp
@@ -33,7 +33,7 @@ std::vector<ck::index_t> f_tensor_strides_ncdhw(ck::index_t N_,
     else if constexpr(ck::is_same<decltype(layout), ck::tensor_layout::convolution::NDHWC>::value)
         return {D * C_ * H * W, 1_uz, C_ * H * W, W * C_, C_};
     throw std::runtime_error("Pool3d_fwd: problem with layout. ");
-    return 0;
+    return {0, 0, 0, 0, 0};
 };
 
 template <typename TensorLayout>

--- a/example/48_pool3d_fwd/pool3d_fwd_common.hpp
+++ b/example/48_pool3d_fwd/pool3d_fwd_common.hpp
@@ -55,6 +55,8 @@ HostTensorDescriptor f_host_tensor_descriptor(std::size_t N_,
         return HostTensorDescriptor({N_, C_, D, H, W},
                                     {D * C_ * H * W, 1_uz, C_ * H * W, W * C_, C_});
     }
+    throw std::runtime_error("Pool3d_fwd: problem with layout. ");
+    return HostTensorDescriptor({0, 0, 0, 0, 0}, {0, 0, 0, 0, 0});
 };
 
 template <typename DevicePoolFwdInstance,

--- a/example/48_pool3d_fwd/pool3d_fwd_common.hpp
+++ b/example/48_pool3d_fwd/pool3d_fwd_common.hpp
@@ -32,6 +32,8 @@ std::vector<ck::index_t> f_tensor_strides_ncdhw(ck::index_t N_,
         return {C_ * D * H * W, D * H * W, H * W, W, 1_uz};
     else if constexpr(ck::is_same<decltype(layout), ck::tensor_layout::convolution::NDHWC>::value)
         return {D * C_ * H * W, 1_uz, C_ * H * W, W * C_, C_};
+    throw std::runtime_error("Pool3d_fwd: problem with layout. ");
+    return 0;
 };
 
 template <typename TensorLayout>

--- a/example/51_avgpool3d_bwd/avgpool3d_bwd_common.hpp
+++ b/example/51_avgpool3d_bwd/avgpool3d_bwd_common.hpp
@@ -27,7 +27,7 @@ std::vector<ck::index_t> f_tensor_strides_ncdhw(ck::index_t N_,
     else if constexpr(ck::is_same<decltype(layout), ck::tensor_layout::convolution::NDHWC>::value)
         return {D * C_ * H * W, 1_uz, C_ * H * W, W * C_, C_};
     throw std::runtime_error("Avgpool3d_bwd: problem with layout. ");
-    return 0;
+    return {0, 0, 0, 0, 0};
 };
 
 template <typename TensorLayout>

--- a/example/51_avgpool3d_bwd/avgpool3d_bwd_common.hpp
+++ b/example/51_avgpool3d_bwd/avgpool3d_bwd_common.hpp
@@ -49,6 +49,8 @@ HostTensorDescriptor f_host_tensor_descriptor(std::size_t N_,
         return HostTensorDescriptor({N_, C_, D, H, W},
                                     {D * C_ * H * W, 1_uz, C_ * H * W, W * C_, C_});
     }
+    throw std::runtime_error("Avgpool3d_bwd: problem with layout. ");
+    return HostTensorDescriptor({0, 0, 0, 0, 0}, {0, 0, 0, 0, 0});
 };
 
 template <typename DevicePoolBwdInstance,

--- a/example/51_avgpool3d_bwd/avgpool3d_bwd_common.hpp
+++ b/example/51_avgpool3d_bwd/avgpool3d_bwd_common.hpp
@@ -26,6 +26,8 @@ std::vector<ck::index_t> f_tensor_strides_ncdhw(ck::index_t N_,
         return {C_ * D * H * W, D * H * W, H * W, W, 1_uz};
     else if constexpr(ck::is_same<decltype(layout), ck::tensor_layout::convolution::NDHWC>::value)
         return {D * C_ * H * W, 1_uz, C_ * H * W, W * C_, C_};
+    throw std::runtime_error("Avgpool3d_bwd: problem with layout. ");
+    return 0;
 };
 
 template <typename TensorLayout>

--- a/include/ck/utility/amd_buffer_addressing.hpp
+++ b/include/ck/utility/amd_buffer_addressing.hpp
@@ -400,11 +400,6 @@ amd_buffer_load_impl_raw(int32x4_t src_wave_buffer_resource,
 
         return bit_cast<int8x64_t>(tmp);
     }
-    else
-    {
-        std::cout << "amd_buffer_load_impl_raw: wrong number of bits N. \n";
-        return 1;
-    }
 }
 
 template <typename T,
@@ -525,11 +520,6 @@ amd_buffer_store_impl_raw(const typename vector_type<int8_t, N>::type src_thread
                                            dst_thread_addr_offset,
                                            dst_wave_addr_offset + sizeof(int32_t) * 12,
                                            static_cast<index_t>(coherence));
-    }
-    else
-    {
-        std::cout << "amd_buffer_store_impl_raw: wrong number of bits N. \n";
-        return 1;
     }
 }
 

--- a/include/ck/utility/amd_buffer_addressing.hpp
+++ b/include/ck/utility/amd_buffer_addressing.hpp
@@ -400,6 +400,11 @@ amd_buffer_load_impl_raw(int32x4_t src_wave_buffer_resource,
 
         return bit_cast<int8x64_t>(tmp);
     }
+    else
+    {
+        throw std::runtime_error("amd_buffer_load_impl_raw: wrong number of bits N. ");
+        return 1;
+    }
 }
 
 template <typename T,

--- a/include/ck/utility/amd_buffer_addressing.hpp
+++ b/include/ck/utility/amd_buffer_addressing.hpp
@@ -402,7 +402,7 @@ amd_buffer_load_impl_raw(int32x4_t src_wave_buffer_resource,
     }
     else
     {
-        throw std::runtime_error("amd_buffer_load_impl_raw: wrong number of bits N. ");
+        std::cout << "amd_buffer_load_impl_raw: wrong number of bits N. \n";
         return 1;
     }
 }
@@ -525,6 +525,11 @@ amd_buffer_store_impl_raw(const typename vector_type<int8_t, N>::type src_thread
                                            dst_thread_addr_offset,
                                            dst_wave_addr_offset + sizeof(int32_t) * 12,
                                            static_cast<index_t>(coherence));
+    }
+    else
+    {
+        std::cout << "amd_buffer_store_impl_raw: wrong number of bits N. \n";
+        return 1;
     }
 }
 

--- a/include/ck/utility/data_type.hpp
+++ b/include/ck/utility/data_type.hpp
@@ -278,6 +278,9 @@ struct vector_type<T, 4>
         {
             return data_.d4x1_;
         }
+        else{
+            return 0;
+        }
     }
 
     template <typename X>
@@ -297,6 +300,9 @@ struct vector_type<T, 4>
         else if constexpr(is_same<X, d4_t>::value)
         {
             return data_.d4x1_;
+        }
+        else{
+            return 0;
         }
     }
 };
@@ -347,6 +353,9 @@ struct vector_type<T, 8>
         {
             return data_.d8x1_;
         }
+        else{
+            return 0;
+        }
     }
 
     template <typename X>
@@ -371,6 +380,10 @@ struct vector_type<T, 8>
         else if constexpr(is_same<X, d8_t>::value)
         {
             return data_.d8x1_;
+        }
+        else
+        {
+            return 0;
         }
     }
 };
@@ -428,6 +441,10 @@ struct vector_type<T, 16>
         {
             return data_.d16x1_;
         }
+        else
+        {
+            return 0;
+        }
     }
 
     template <typename X>
@@ -457,6 +474,10 @@ struct vector_type<T, 16>
         else if constexpr(is_same<X, d16_t>::value)
         {
             return data_.d16x1_;
+        }
+        else
+        {
+            return 0;
         }
     }
 };
@@ -520,6 +541,10 @@ struct vector_type<T, 32>
         {
             return data_.d32x1_;
         }
+        else
+        {
+            return 0;
+        }
     }
 
     template <typename X>
@@ -553,6 +578,10 @@ struct vector_type<T, 32>
         else if constexpr(is_same<X, d32_t>::value)
         {
             return data_.d32x1_;
+        }
+        else
+        {
+            return 0;
         }
     }
 };
@@ -623,6 +652,10 @@ struct vector_type<T, 64>
         {
             return data_.d64x1_;
         }
+        else
+        {
+            return 0;
+        }
     }
 
     template <typename X>
@@ -661,6 +694,10 @@ struct vector_type<T, 64>
         else if constexpr(is_same<X, d64_t>::value)
         {
             return data_.d64x1_;
+        }
+        else
+        {
+            return 0;
         }
     }
 };
@@ -737,6 +774,10 @@ struct vector_type<T, 128>
         {
             return data_.d128x1_;
         }
+        else
+        {
+            return 0;
+        }
     }
 
     template <typename X>
@@ -779,6 +820,10 @@ struct vector_type<T, 128>
         else if constexpr(is_same<X, d128_t>::value)
         {
             return data_.d128x1_;
+        }
+        else
+        {
+            return 0;
         }
     }
 };
@@ -861,6 +906,10 @@ struct vector_type<T, 256>
         {
             return data_.d256x1_;
         }
+        else
+        {
+            return 0;
+        }
     }
 
     template <typename X>
@@ -907,6 +956,10 @@ struct vector_type<T, 256>
         else if constexpr(is_same<X, d256_t>::value)
         {
             return data_.d256x1_;
+        }
+        else
+        {
+            return 0;
         }
     }
 };

--- a/include/ck/utility/data_type.hpp
+++ b/include/ck/utility/data_type.hpp
@@ -221,6 +221,10 @@ struct vector_type<T, 2>
         {
             return data_.d2x1_;
         }
+        else
+        {
+            return constexpr 0;
+        }
     }
 
     template <typename X>
@@ -235,6 +239,10 @@ struct vector_type<T, 2>
         else if constexpr(is_same<X, d2_t>::value)
         {
             return data_.d2x1_;
+        }
+        else
+        {
+            return constexpr 0;
         }
     }
 };
@@ -280,7 +288,7 @@ struct vector_type<T, 4>
         }
         else
         {
-            return 0;
+            return constexpr 0;
         }
     }
 
@@ -304,7 +312,7 @@ struct vector_type<T, 4>
         }
         else
         {
-            return 0;
+            return constexpr 0;
         }
     }
 };
@@ -357,7 +365,7 @@ struct vector_type<T, 8>
         }
         else
         {
-            return 0;
+            return constexpr 0;
         }
     }
 
@@ -386,7 +394,7 @@ struct vector_type<T, 8>
         }
         else
         {
-            return 0;
+            return constexpr 0;
         }
     }
 };
@@ -446,7 +454,7 @@ struct vector_type<T, 16>
         }
         else
         {
-            return 0;
+            return constexpr 0;
         }
     }
 
@@ -480,7 +488,7 @@ struct vector_type<T, 16>
         }
         else
         {
-            return 0;
+            return constexpr 0;
         }
     }
 };
@@ -546,7 +554,7 @@ struct vector_type<T, 32>
         }
         else
         {
-            return 0;
+            return constexpr 0;
         }
     }
 
@@ -584,7 +592,7 @@ struct vector_type<T, 32>
         }
         else
         {
-            return 0;
+            return constexpr 0;
         }
     }
 };
@@ -657,7 +665,7 @@ struct vector_type<T, 64>
         }
         else
         {
-            return 0;
+            return constexpr 0;
         }
     }
 
@@ -700,7 +708,7 @@ struct vector_type<T, 64>
         }
         else
         {
-            return 0;
+            return constexpr 0;
         }
     }
 };
@@ -779,7 +787,7 @@ struct vector_type<T, 128>
         }
         else
         {
-            return 0;
+            return constexpr 0;
         }
     }
 
@@ -826,7 +834,7 @@ struct vector_type<T, 128>
         }
         else
         {
-            return 0;
+            return constexpr 0;
         }
     }
 };
@@ -911,7 +919,7 @@ struct vector_type<T, 256>
         }
         else
         {
-            return 0;
+            return constexpr 0;
         }
     }
 
@@ -962,7 +970,7 @@ struct vector_type<T, 256>
         }
         else
         {
-            return 0;
+            return constexpr 0;
         }
     }
 };

--- a/include/ck/utility/data_type.hpp
+++ b/include/ck/utility/data_type.hpp
@@ -920,7 +920,7 @@ struct vector_type<T, 256>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 
@@ -971,7 +971,7 @@ struct vector_type<T, 256>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 };

--- a/include/ck/utility/data_type.hpp
+++ b/include/ck/utility/data_type.hpp
@@ -189,6 +189,7 @@ struct vector_type<T, 1>
     }
 };
 
+int static err = 0;
 template <typename T>
 struct vector_type<T, 2>
 {
@@ -223,7 +224,7 @@ struct vector_type<T, 2>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 
@@ -242,7 +243,7 @@ struct vector_type<T, 2>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 };
@@ -288,7 +289,7 @@ struct vector_type<T, 4>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 
@@ -312,7 +313,7 @@ struct vector_type<T, 4>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 };
@@ -365,7 +366,7 @@ struct vector_type<T, 8>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 
@@ -394,7 +395,7 @@ struct vector_type<T, 8>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 };
@@ -454,7 +455,7 @@ struct vector_type<T, 16>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 
@@ -488,7 +489,7 @@ struct vector_type<T, 16>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 };
@@ -554,7 +555,7 @@ struct vector_type<T, 32>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 
@@ -592,7 +593,7 @@ struct vector_type<T, 32>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 };
@@ -665,7 +666,7 @@ struct vector_type<T, 64>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 
@@ -708,7 +709,7 @@ struct vector_type<T, 64>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 };
@@ -787,7 +788,7 @@ struct vector_type<T, 128>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 
@@ -834,7 +835,7 @@ struct vector_type<T, 128>
         }
         else
         {
-            return constexpr 0;
+            return err;
         }
     }
 };

--- a/include/ck/utility/data_type.hpp
+++ b/include/ck/utility/data_type.hpp
@@ -278,7 +278,8 @@ struct vector_type<T, 4>
         {
             return data_.d4x1_;
         }
-        else{
+        else
+        {
             return 0;
         }
     }
@@ -301,7 +302,8 @@ struct vector_type<T, 4>
         {
             return data_.d4x1_;
         }
-        else{
+        else
+        {
             return 0;
         }
     }
@@ -353,7 +355,8 @@ struct vector_type<T, 8>
         {
             return data_.d8x1_;
         }
-        else{
+        else
+        {
             return 0;
         }
     }

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_column_to_image.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_column_to_image.hpp
@@ -265,6 +265,8 @@ struct ReferenceColumnToImage : public device::BaseOperator
 
                 return 0;
             }
+            throw std::runtime_error("Col2Img: number of dimensions should be between 1 and 3.");
+            return 1;
         }
 
         float Run(const device::BaseArgument* p_arg,

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_bwd_data.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_bwd_data.hpp
@@ -313,8 +313,9 @@ struct ReferenceConvBwdData : public device::BaseOperator
 
                 return 0;
             }
-            throw std::runtime_error("Conv_bwd_data: number of dimensions must be between 1 and 3.");
-            return 1;            
+            throw std::runtime_error(
+                "Conv_bwd_data: number of dimensions must be between 1 and 3.");
+            return 1;
         }
 
         float Run(const device::BaseArgument* p_arg,

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_bwd_data.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_bwd_data.hpp
@@ -313,6 +313,8 @@ struct ReferenceConvBwdData : public device::BaseOperator
 
                 return 0;
             }
+            throw std::runtime_error("Conv_bwd_data: number of dimensions must be between 1 and 3.");
+            return 1;            
         }
 
         float Run(const device::BaseArgument* p_arg,

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_bwd_weight.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_bwd_weight.hpp
@@ -265,6 +265,8 @@ struct ReferenceConvBwdWeight : public device::BaseOperator
 
                 return 0;
             }
+            throw std::runtime_error("Conv_bwd: number of dimensions must be between 1 and 3.");
+            return 1;
         }
 
         float Run(const device::BaseArgument* p_arg,

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp
@@ -360,6 +360,8 @@ struct ReferenceConvFwd : public device::BaseOperator
 
                 return 0;
             }
+            throw std::runtime_error("Conv_fwd: number of dimensions must be between 1 and 3.");
+            return 1;  
         }
 
         float Run(const device::BaseArgument* p_arg,

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp
@@ -361,7 +361,7 @@ struct ReferenceConvFwd : public device::BaseOperator
                 return 0;
             }
             throw std::runtime_error("Conv_fwd: number of dimensions must be between 1 and 3.");
-            return 1;  
+            return 1;
         }
 
         float Run(const device::BaseArgument* p_arg,

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm.hpp
@@ -63,12 +63,11 @@ struct ReferenceGemm : public device::BaseOperator
                 const int K = arg.a_m_k_.mDesc.GetLengths()[1];
 
                 AccDataType v_acc = 0;
+                ComputeTypeA v_a = 0;
+                ComputeTypeB v_b = 0;
 
                 for(int k = 0; k < K; ++k)
                 {
-                    ComputeTypeA v_a;
-                    ComputeTypeB v_b;
-
                     // use PassThrough instead of ConvertBF16RTN for reference calculation
                     if constexpr(is_same_v<AElementwiseOperation,
                                            ck::tensor_operation::element_wise::ConvertBF16RTN>)
@@ -94,7 +93,7 @@ struct ReferenceGemm : public device::BaseOperator
                         ck::type_convert<AccDataType>(v_a) * ck::type_convert<AccDataType>(v_b);
                 }
 
-                CDataType v_c;
+                CDataType v_c = 0;
 
                 arg.c_element_op_(v_c, v_acc);
 

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_gemm.hpp
@@ -63,8 +63,8 @@ struct ReferenceGemm : public device::BaseOperator
                 const int K = arg.a_m_k_.mDesc.GetLengths()[1];
 
                 AccDataType v_acc = 0;
-                ComputeTypeA v_a = 0;
-                ComputeTypeB v_b = 0;
+                ComputeTypeA v_a  = 0;
+                ComputeTypeB v_b  = 0;
 
                 for(int k = 0; k < K; ++k)
                 {

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_image_to_column.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_image_to_column.hpp
@@ -229,6 +229,8 @@ struct ReferenceImageToColumn : public device::BaseOperator
 
                 return 0;
             }
+            throw std::runtime_error("Img2Col: number of dimensions should be between 1 and 3.");
+            return 1;
         }
 
         float Run(const device::BaseArgument* p_arg,

--- a/library/include/ck/library/tensor_operation_instance/gpu/batched_gemm_gemm.hpp
+++ b/library/include/ck/library/tensor_operation_instance/gpu/batched_gemm_gemm.hpp
@@ -106,9 +106,8 @@ struct DeviceOperationInstanceFactory<
         return op_ptrs;
     }
 };
-
+#endif
 } // namespace instance
 } // namespace device
 } // namespace tensor_operation
 } // namespace ck
-#endif

--- a/library/include/ck/library/tensor_operation_instance/gpu/gemm_streamk.hpp
+++ b/library/include/ck/library/tensor_operation_instance/gpu/gemm_streamk.hpp
@@ -114,9 +114,8 @@ struct DeviceOperationInstanceFactory<ck::tensor_operation::device::DeviceGemmSt
         return op_ptrs;
     }
 };
-
+#endif
 } // namespace instance
 } // namespace device
 } // namespace tensor_operation
 } // namespace ck
-#endif

--- a/library/include/ck/library/utility/algorithm.hpp
+++ b/library/include/ck/library/utility/algorithm.hpp
@@ -30,6 +30,7 @@ auto fill(OutputRange&& range, const T& init)
     std::fill(std::begin(std::forward<OutputRange>(range)),
               std::end(std::forward<OutputRange>(range)),
               init);
+    return 0;
 }
 
 template <typename InputRange, typename OutputIterator, typename UnaryOperation>

--- a/library/include/ck/library/utility/algorithm.hpp
+++ b/library/include/ck/library/utility/algorithm.hpp
@@ -30,7 +30,6 @@ auto fill(OutputRange&& range, const T& init)
     std::fill(std::begin(std::forward<OutputRange>(range)),
               std::end(std::forward<OutputRange>(range)),
               init);
-    return 0;
 }
 
 template <typename InputRange, typename OutputIterator, typename UnaryOperation>

--- a/profiler/src/profile_gemm.cpp
+++ b/profiler/src/profile_gemm.cpp
@@ -137,9 +137,14 @@ int profile_gemm(int argc, char* argv[])
         return pass ? 0 : 1;
     };
 
-    if(false)
+    if(data_type != GemmDataType::F32_F32_F32 && data_type != GemmDataType::F16_F16_F16 &&
+       data_type != GemmDataType::BF16_BF16_BF16 && data_type != GemmDataType::INT8_INT8_INT8 &&
+       data_type != GemmDataType::F8_F8_F8)
+    {
         // dummy clause before the else clauses for different data types
+        std::cout << "Gemm: this data_type is not implemented" << std::endl;
         return 1;
+    }
 #ifdef CK_ENABLE_FP32
     else if(data_type == GemmDataType::F32_F32_F32 && layout == GemmMatrixLayout::MK_KN_MN)
     {
@@ -232,7 +237,7 @@ int profile_gemm(int argc, char* argv[])
 #endif
     else
     {
-        std::cout << "this data_type & layout is not implemented" << std::endl;
+        std::cout << "Gemm: this data_type & layout is not implemented" << std::endl;
 
         return 1;
     }

--- a/profiler/src/profile_gemm.cpp
+++ b/profiler/src/profile_gemm.cpp
@@ -137,6 +137,9 @@ int profile_gemm(int argc, char* argv[])
         return pass ? 0 : 1;
     };
 
+    if(false)
+        // dummy clause before the else clauses for different data types
+        return 1;
 #ifdef CK_ENABLE_FP32
     else if(data_type == GemmDataType::F32_F32_F32 && layout == GemmMatrixLayout::MK_KN_MN)
     {

--- a/profiler/src/profile_gemm.cpp
+++ b/profiler/src/profile_gemm.cpp
@@ -137,8 +137,6 @@ int profile_gemm(int argc, char* argv[])
         return pass ? 0 : 1;
     };
 
-    if(false)
-        ;
 #ifdef CK_ENABLE_FP32
     else if(data_type == GemmDataType::F32_F32_F32 && layout == GemmMatrixLayout::MK_KN_MN)
     {

--- a/script/clang-format-overwrite.sh
+++ b/script/clang-format-overwrite.sh
@@ -1,2 +1,2 @@
-#find . -name deps -prune -o -name build -prune -o -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' -o -iname '*.h.in' -o -iname '*.hpp.in' -o -iname '*.cpp.in' -o -iname '*.cl' -o -iname '*.cuh' -o -iname '*.cu' -o -iname '*.inc' | xargs -n 1 -P 16 -I{} -t sh -c 'clang-format-12 -i -style=file {}'
+find . -name deps -prune -o -name build -prune -o -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' -o -iname '*.h.in' -o -iname '*.hpp.in' -o -iname '*.cpp.in' -o -iname '*.cl' -o -iname '*.cuh' -o -iname '*.cu' -o -iname '*.inc' | xargs -n 1 -P 16 -I{} -t sh -c 'clang-format-12 -i -style=file {}'
 git status --porcelain | awk '$1 != "D" && (match($2, "\\.cpp|hpp|inc")) {print $2}' | xargs -n 1 -P 16 -I{} -t sh -c 'clang-format-12 -i -style=file {}'

--- a/test/conv_tensor_rearrange/test_conv_tensor_rearrange_interface.cpp
+++ b/test/conv_tensor_rearrange/test_conv_tensor_rearrange_interface.cpp
@@ -135,6 +135,8 @@ class TestConvTensorRearrangeInterface : public ::testing::Test
 
             return col2img.IsSupportedArgument(argument);
         }
+        throw std::runtime_error("Conv_tensor_rearrange: problem with tensor rearrange operator. ");
+        return 1;
     }
 };
 


### PR DESCRIPTION
This PR decreases the number of errors reported by cppcheck from 100 to 33, mostly dealing with exits from non-void functions that didn't return anything and protecting the int4 source code with the macros instead of issuing an error.

The few remaining errors are mostly false flags where the cppcheck is confused by the gpu kernel syntax, e.g.:

../test/data_type/test_int4.cpp:101:17: error: Shifting 32-bit value by 64 bits is undefined behaviour [shiftTooManyBits]
    copy<<<1, 64>>>(reinterpret_cast<const int4_t*>(d_src_i4.GetDeviceBuffer()),
    
  or is confused by the lambda function syntax:

  ../profiler/include/profiler/profile_batched_gemm_softmax_gemm_impl.hpp:101:36: error: Syntax Error: AST broken, binary operator '=' doesn't have two operands. [internalAstError]
    const int DefaultBatchStrideA  = (ck::is_same_v<ALayout, Col> ? K : M) * StrideA;
    
 or doesn't like the way the buffers are allocated in the client examples:
    
    ../client_example/21_grouped_gemm_bias/grouped_gemm_fixed_nk_bias_fp16.cpp:124:33: error: inconclusive: Out of bounds access in 'e_dev_bufs[i]', if 'e_dev_bufs' size is 1 and 'i' is 15 [containerOutOfBounds]
        p_e.push_back(e_dev_bufs[i].GetDeviceBuffer());