### PR TITLE
fix CK path for hipTensor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -560,7 +560,7 @@ def Build_CK(Map conf=[:]){
                             sh """#!/bin/bash
                                 mkdir -p build
                                 ls -ltr
-                                CC=hipcc CXX=hipcc cmake -Bbuild . -D CMAKE_PREFIX_PATH="/opt/rocm;${env.WORKSPACE}/install"
+                                CC=hipcc CXX=hipcc cmake -Bbuild . -D CMAKE_PREFIX_PATH="${env.WORKSPACE}/install"
                                 cmake --build build -- -j
                             """
                         }


### PR DESCRIPTION
It turns our that the mainline branches of most rocm components have not been updated for several months.
Since hipTensor mainline branch got updated yesterday, it appeared that it was failing to build with the default installation of CK at /opt/rocm/. Pointing to the correct CK installation path helps resolve this issue.