### PR TITLE
Delete any dangling images after building a new one.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,7 +135,7 @@ def buildDocker(install_prefix){
             echo "Building image: ${image_name}"
             retimage = docker.build("${image_name}", dockerArgs + ' .')
             retimage.push()
-            sh """docker rmi $(docker images -a | grep "^<none>" | awk '{print $3}')"""
+            sh """docker rmi $(docker images -a | grep "^<none>" | awk '{print \$3}')"""
         }
         else{
             echo "Checking for image: ${image_name}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,7 +135,7 @@ def buildDocker(install_prefix){
             echo "Building image: ${image_name}"
             retimage = docker.build("${image_name}", dockerArgs + ' .')
             retimage.push()
-            sh """docker rmi $(docker images -a | grep "^<none>" | awk '{print ${3}}')"""
+            sh 'docker images -q -f dangling=true | xargs --no-run-if-empty docker rmi'
         }
         else{
             echo "Checking for image: ${image_name}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,6 +135,7 @@ def buildDocker(install_prefix){
             echo "Building image: ${image_name}"
             retimage = docker.build("${image_name}", dockerArgs + ' .')
             retimage.push()
+            sh """docker rmi $(docker images -a | grep "^<none>" | awk '{print $3}')"""
         }
         else{
             echo "Checking for image: ${image_name}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,7 +135,7 @@ def buildDocker(install_prefix){
             echo "Building image: ${image_name}"
             retimage = docker.build("${image_name}", dockerArgs + ' .')
             retimage.push()
-            sh """docker rmi $(docker images -a | grep "^<none>" | awk '{print \$3}')"""
+            sh """docker rmi $(docker images -a | grep "^<none>" | awk '{print ${3}}')"""
         }
         else{
             echo "Checking for image: ${image_name}"


### PR DESCRIPTION
Every time we build a new image in CI, since we are using the same recurring tags, the older existing images do not get deleted, they just get un-tagged and will linger until they overfill the disc space and cause the CI to crash.

This change will delete any "dangling" images after a new one is built.