### PR TITLE
Upgrade the ccache version and update links.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ ENV PATH=$PATH:${SCCACHE_INSTALL_LOCATION}
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
     build-essential \
     cmake \
-    ccache \
     git \
     hip-rocclr \
     iputils-ping \
@@ -73,6 +72,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-
     kmod && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+#Install latest ccache
+RUN git clone https://github.com/ccache/ccache.git && \
+    cd ccache && mkdir build && cd build && cmake .. && make install
 
 #Install ninja build tracing tools
 RUN wget -qO /usr/local/bin/ninja.gz https://github.com/ninja-build/ninja/releases/latest/download/ninja-linux.zip
@@ -111,7 +114,7 @@ ENV LANG=C.UTF-8
 RUN groupadd -f render
 
 # Install the new rocm-cmake version
-RUN git clone -b master https://github.com/RadeonOpenCompute/rocm-cmake.git  && \
+RUN git clone -b master https://github.com/ROCm/rocm-cmake.git  && \
   cd rocm-cmake && mkdir build && cd build && \
   cmake  .. && cmake --build . && cmake --build . --target install
 
@@ -123,7 +126,7 @@ RUN sh -c "echo compiler version = '$compiler_version'"
 RUN sh -c "echo compiler commit = '$compiler_commit'"
 
 RUN if ( [ "$compiler_version" = "amd-staging" ] || [ "$compiler_version" = "amd-mainline-open" ] ) && [ "$compiler_commit" = "" ]; then \
-        git clone -b "$compiler_version" https://github.com/RadeonOpenCompute/llvm-project.git && \
+        git clone -b "$compiler_version" https://github.com/ROCm/llvm-project.git && \
         cd llvm-project && mkdir build && cd build && \
         cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld" -DLLVM_ENABLE_RUNTIMES="compiler-rt" ../llvm && \
         make -j 8 ; \
@@ -131,7 +134,7 @@ RUN if ( [ "$compiler_version" = "amd-staging" ] || [ "$compiler_version" = "amd
     fi
 
 RUN if ( [ "$compiler_version" = "amd-staging" ] || [ "$compiler_version" = "amd-mainline-open" ] ) && [ "$compiler_commit" != "" ]; then \
-        git clone -b "$compiler_version" https://github.com/RadeonOpenCompute/llvm-project.git && \
+        git clone -b "$compiler_version" https://github.com/ROCm/llvm-project.git && \
         cd llvm-project && git checkout "$compiler_commit" && echo "checking out commit $compiler_commit" && mkdir build && cd build && \
         cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld" -DLLVM_ENABLE_RUNTIMES="compiler-rt" ../llvm && \
         make -j 8 ; \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 ROCm/rocm-recipes
-RadeonOpenCompute/rocm-cmake@04f694df2a8dc9d7e35fa4dee4ba5fa407ec04f8 --build
+ROCm/rocm-cmake@04f694df2a8dc9d7e35fa4dee4ba5fa407ec04f8 --build
 danmar/cppcheck@2.9

--- a/docs/Contributors_Guide.rst
+++ b/docs/Contributors_Guide.rst
@@ -17,7 +17,7 @@ Getting started
    `Composable Kernel User Guide <https://rocm.docs.amd.com/projects/composable_kernel/en/latest/>`_.
    It provides insight into the core concepts, environment configuration, and steps to obtain or
    build the library. You can also find some of this information in the
-   `README file <https://github.com/ROCmSoftwarePlatform/composable_kernel/blob/develop/README.md>`_
+   `README file <https://github.com/ROCm/composable_kernel/blob/develop/README.md>`_
    on the project's GitHub page.
 #. **Additional reading:** The blog post `AMD Composable Kernel library: efficient fused kernels for AI apps with just a few lines of code <https://community.amd.com/t5/instinct-accelerators/amd-composable-kernel-library-efficient-fused-kernels-for-ai/ba-p/553224>`_ provides a deeper understanding of the CK library and showcases its performance capabilities.
    <https://community.amd.com/t5/instinct-accelerators/amd-composable-kernel-library-efficient-fused-kernels-for-ai/ba-p/553224>`_
@@ -33,7 +33,7 @@ You can make an impact by reporting issues or proposing code enhancements throug
 Reporting issues
 ----------------
 
-Use `Github issues <https://github.com/ROCmSoftwarePlatform/composable_kernel/issues>`_
+Use `Github issues <https://github.com/ROCm/composable_kernel/issues>`_
 to track public bugs and enhancement requests.
 
 If you encounter an issue with the library, please check if the problem has already been
@@ -68,7 +68,7 @@ Creating Pull Requests
 ----------------------
 
 You can submit `Pull Requests (PR) on GitHub
-<https://github.com/ROCmSoftwarePlatform/composable_kernel/pulls>`_.
+<https://github.com/ROCm/composable_kernel/pulls>`_.
 
 All contributors are required to develop their changes on a separate branch and then create a
 pull request to merge their changes into the `develop` branch, which is the default
@@ -89,7 +89,7 @@ When submitting a Pull Request you should:
   the project's root directory. We leverage `pre-commit` to run `clang-format` automatically. We
   highly recommend contributors utilize this method to maintain consistent code formatting.
   Instructions on setting up `pre-commit` can be found in the project's
-  `README file <https://github.com/ROCmSoftwarePlatform/composable_kernel/blob/develop/README.md>`_
+  `README file <https://github.com/ROCm/composable_kernel/blob/develop/README.md>`_
 
 * Link your PR to any related issues:
 

--- a/docs/dockerhub.rst
+++ b/docs/dockerhub.rst
@@ -38,7 +38,7 @@ The docker images have everything you need for running CK including:
 
 * `ROCm <https://www.amd.com/en/graphics/servers-solutions-rocm>`_
 * `CMake <https://cmake.org/getting-started/>`_
-* `Compiler <https://github.com/RadeonOpenCompute/llvm-project>`_
+* `Compiler <https://github.com/ROCm/llvm-project>`_
 * `Composable Kernel library <https://github.com/ROCm/composable_kernel>`_
 
 Running the docker container
@@ -97,5 +97,5 @@ Editing the docker image
 =======================
 
 If you want to customize the docker image, edit the
-`Dockerfile <https://github.com/ROCmSoftwarePlatform/composable_kernel/blob/develop/Dockerfile>`_
+`Dockerfile <https://github.com/ROCm/composable_kernel/blob/develop/Dockerfile>`_
 from the GitHub repository to suit your needs.

--- a/docs/tutorial_hello_world.rst
+++ b/docs/tutorial_hello_world.rst
@@ -32,7 +32,7 @@ CK library acceleration features are based on:
 If you need more technical details and benchmarking results read the following 
 `blog post <https://community.amd.com/t5/instinct-accelerators/amd-composable-kernel-library-efficient-fused-kernels-for-ai/ba-p/553224>`_.
 
-To download the library visit the `composable_kernel repository <https://github.com/ROCmSoftwarePlatform/composable_kernel>`_.
+To download the library visit the `composable_kernel repository <https://github.com/ROCm/composable_kernel>`_.
 
 Hardware targets
 ================
@@ -58,7 +58,7 @@ This tutorial is based on the use of docker images as explained in :ref:`docker-
 
 .. note::
 
-   You can also `install ROCm <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/>`_ on your system, clone the `Composable Kernel repository <https://github.com/ROCmSoftwarePlatform/composable_kernel.git>`_ on GitHub, and use that to build and run the examples using the commands described below.
+   You can also `install ROCm <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/>`_ on your system, clone the `Composable Kernel repository <https://github.com/ROCm/composable_kernel.git>`_ on GitHub, and use that to build and run the examples using the commands described below.
 
 Both the docker container and GitHub repository include the Composable Kernel library. Navigate to the library::
 


### PR DESCRIPTION
This PR will upgrade the ccache in our dockers to the latest version, which can handle the clang use with "-x hip" flags to build the GPU code.

Also, updated the links everywhere to use the new ROCm org.