### PR TITLE
Only call iglp_opt(1) on certain architectures (For ROCm 6.1)

### DIFF
--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_pipeline_v2.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_pipeline_v2.hpp
@@ -80,7 +80,9 @@ struct GridwiseGemmPipeline_v2
             do
             {
 #if CK_EXPERIMENTAL_PIPELINE_V2_IGLP_OPT
+#if defined(__gfx90a__) || defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
                 __builtin_amdgcn_iglp_opt(CK_EXPERIMENTAL_PIPELINE_V2_IGLP_OPT);
+#endif
 #endif
 
                 block_sync_lds();


### PR DESCRIPTION
This PR addresses the complier out-of-memory issue while using `__builtin_amdgcn_iglp_opt(1)` intrinsic.
Since `__builtin_amdgcn_iglp_opt(1)` was designed for MI200 & MI300, compiling it for other architectures may cause runtime error or unexpected performance drop. 

If `PROFILER_ONLY`=**ON** and `GPU_ARCH`=**gfx90**, **gfx908** will be added into `GPU_TARGETS`, that will cause out-of-memory in the corresponding `MFMASmallGemmSingleWaveOpt` implementation. The compiler [fix](https://github.com/llvm/llvm-project/commit/6d8b44a506787cd79d0cb82a05d296d6b49d057d) for this issue is only available from ROCm 6.1.1. So we need this PR to restrict the use of `__builtin_amdgcn_iglp_opt(1)` on certain architectures.