### PR TITLE
fix the latest errors with staging compiler

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -140,6 +140,7 @@ function(add_gtest_executable TEST_NAME)
     set(result ${result} PARENT_SCOPE)
 endfunction()
 
+add_compile_options(-Wno-c++20-extensions)
 add_subdirectory(magic_number_division)
 add_subdirectory(space_filling_curve)
 add_subdirectory(conv_util)


### PR DESCRIPTION
This should fix the errors triggered by the recent compiler changes and our usage of the TYPED_TEST_SUITE function for google tests.