### PR TITLE
pass XDL and WMMA macros to libs that use CK

### DIFF
--- a/include/ck/config.h.in
+++ b/include/ck/config.h.in
@@ -104,6 +104,20 @@
 #cmakedefine CK_ENABLE_INSTANCES_ONLY @CK_ENABLE_INSTANCES_ONLY@
 #endif
 
+//
+// CK kernels which support XDL (MI series)
+//
+#ifndef CK_USE_XDL
+#cmakedefine CK_USE_XDL @CK_USE_XDL@
+#endif
+
+//
+// CK Kernels which support WMMA (recent Navi series)
+//
+#ifndef CK_USE_WMMA
+#cmakedefine CK_USE_WMMA @CK_USE_WMMA@
+#endif
+
 // clang-format on
 
 #endif // CK_CONFIG_H_IN


### PR DESCRIPTION
This should allow libraries like MIOpen to have the correct CK instances enabled for the desired GPU architectures.

Fix issue that these two variables are not passed to upper level libraries via #1223 