### PR TITLE
docs: fix broken contributing link (#1244)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,6 @@ The CK documentation is structured as follows:
 
     * :ref:`hello-world`
 
-To contribute to the documentation refer to `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/index.html>`_.
+To contribute to the documentation refer to `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
 
 You can find licensing information on the `Licensing <https://rocm.docs.amd.com/en/latest/about/license.html>`_ page.


### PR DESCRIPTION
Summary of proposed changes:

Cherry-pick fixed broken link from `develop`