### PR TITLE
downgrade minimum required python version to 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(version 1.1.0)
 project(composable_kernel VERSION ${version} LANGUAGES CXX)
 include(CTest)
 
-find_package(Python3 3.8 COMPONENTS Interpreter REQUIRED)
+find_package(Python3 3.6 COMPONENTS Interpreter REQUIRED)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 


### PR DESCRIPTION
Downgrading the minimum required python version from 3.8 to 3.6.
This should allow the release and CQE teams to build CK successfully without upgrading their python versions.


centOS and SLES may have outdated python versions