### PR TITLE
Change to make seqlen_k == 0 be considered

### DIFF
--- a/example/91_tile_program/fmha/README.md
+++ b/example/91_tile_program/fmha/README.md
@@ -33,7 +33,7 @@ args:
         -h_k    num of head, for k/v, 0 means equal to h (default:0)
                  if not equal to h, then this is GQA/MQA case
           -s    seqlen_q (default:3328)
-        -s_k    seqlen_k, 0 means equal to s (default:0)
+        -s_k    seqlen_k, negative value means equal to s (default:-1)
           -d    head dim for q, k (default:128)
         -d_v    head dim for v, 0 means equal to d (default:0)
       -scale    scale factor. 0 means equal to 1/sqrt(seqlen) (default:0)

--- a/example/91_tile_program/fmha/fmha_fwd.cpp
+++ b/example/91_tile_program/fmha/fmha_fwd.cpp
@@ -45,8 +45,11 @@ auto create_args(int argc, char* argv[])
                 "0",
                 "num of head, for k/v, 0 means equal to h\n"
                 "if not equal to h, then this is GQA/MQA case")
-        .insert("s", "3328", "seqlen_q")
-        .insert("s_k", "0", "seqlen_k, 0 means equal to s")
+        .insert("s",
+                "3328",
+                "seqlen_q. if group-mode, means the average value of seqlen_q\n"
+                "total_seqlen_q = seqlen_q * batch, and seqlen_q per batch may vary")
+        .insert("s_k", "-1", "seqlen_k, negative value means equal to s")
         .insert("d", "128", "head dim for q, k")
         .insert("d_v", "0", "head dim for v, 0 means equal to d")
         .insert("scale", "0", "scale factor. 0 means equal to 1/sqrt(seqlen)")
@@ -124,7 +127,7 @@ bool run(const ArgParser& arg_parser)
 
     ck::index_t seqlen_q = arg_parser.get_int("s");
     ck::index_t seqlen_k = arg_parser.get_int("s_k");
-    if(seqlen_k == 0)
+    if(seqlen_k < 0)
         seqlen_k = seqlen_q;
     ck::index_t hdim_q = arg_parser.get_int("d");
     ck::index_t hdim_v = arg_parser.get_int("d_v");

--- a/include/ck/tile_program/block_tile_pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/include/ck/tile_program/block_tile_pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -165,8 +165,9 @@ struct BlockFmhaPipelineQRKSVS
 
         const auto num_total_loop = math::integer_divide_ceil(seqlen_k_end - seqlen_k_start, kN0);
 
-        // check early exit if masked and no work to do.
-        if constexpr(FmhaMask::IsMasking)
+        // check early exit if there is no work to do. also avoid fullfilling unwanted sentinel
+        // values (-INF).
+        if constexpr(kPadSeqLenK || FmhaMask::IsMasking)
         {
             if(num_total_loop <= 0)
             {

--- a/include/ck/tile_program/block_tile_pipeline/block_fmha_pipeline_qs_ks_vs.hpp
+++ b/include/ck/tile_program/block_tile_pipeline/block_fmha_pipeline_qs_ks_vs.hpp
@@ -169,8 +169,9 @@ struct BlockFmhaPipelineQSKSVS
 
         const auto num_total_loop = math::integer_divide_ceil(seqlen_k_end - seqlen_k_start, kN0);
 
-        // check early exit if masked and no work to do.
-        if constexpr(FmhaMask::IsMasking)
+        // check early exit if there is no work to do. also avoid fullfilling unwanted sentinel
+        // values (-INF).
+        if constexpr(kPadSeqLenK || FmhaMask::IsMasking)
         {
             if(num_total_loop <= 0)
             {


### PR DESCRIPTION
Small changes in the three fmha forward kernel pipelines to include `seqlen_k == 0` into consideration.  This PR is for satisfying the request form Meta to solve the issue in upstream xformers