### PR TITLE
Update the grid distribution for fmha forward [Performance]

### DIFF
--- a/example/91_tile_program/fmha/fmha_fwd_tile_partitioner.hpp
+++ b/example/91_tile_program/fmha/fmha_fwd_tile_partitioner.hpp
@@ -24,10 +24,10 @@ struct FmhaFwdTilePartitioner
                                             ck::index_t hdim_v_)
     {
         // TODO: this may need tuning
-        return dim3(ck::math::integer_divide_ceil(seqlen_q_, kM0) *
-                        ck::math::integer_divide_ceil(hdim_v_, kN1),
-                    nhead_,
-                    batch_size_);
+        return dim3(nhead_,
+                    batch_size_,
+                    ck::math::integer_divide_ceil(seqlen_q_, kM0) *
+                        ck::math::integer_divide_ceil(hdim_v_, kN1));
     }
 
     __device__ auto operator()(ck::index_t /*seqlen_q*/, ck::index_t hdim_v)
@@ -37,9 +37,9 @@ struct FmhaFwdTilePartitioner
         // const index_t num_tile_m0 = seqlen_q / kM0;
         const index_t num_tile_n1 = ck::math::integer_divide_ceil(hdim_v, kN1);
 
-        const index_t i_block = blockIdx.x;
-        const index_t i_nhead = blockIdx.y;
-        const index_t i_batch = blockIdx.z;
+        const index_t i_block = blockIdx.z;
+        const index_t i_nhead = blockIdx.x;
+        const index_t i_batch = blockIdx.y;
 
         const auto f = [](index_t dividend, index_t divisor) {
             index_t quotient = dividend / divisor;


### PR DESCRIPTION
This PR is supposed to improve the fmha forward performance for memory competitive cases when looping over the seqlen_k dimension.  Specifically, it reduced the execution time of the following case greatly (from approximately `1580` us to less than `700` us on MI200

```bash
import time
import torch
from xformers.ops import fmha


def main():
    q_seqlen = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1500, 1500]
    kv_seqlen = [1530, 1530, 1506, 1529, 1528, 1528, 1527, 1527, 1526, 1526, 1525, 1525, 1524, 1501, 1523, 1523, 1522, 1522, 1521, 1521, 1520, 1520, 1519, 1519, 1518, 1518, 1517, 1517, 1516, 1516, 1515, 1515, 1514, 1514, 1513, 1513, 1512, 1512, 1511, 1511, 1510, 1510, 1509, 1509, 1508, 1508, 1507, 1507, 1506, 1505, 1505, 1504, 1504, 1503, 1503, 1502, 1502, 1501, 1500, 1500]
    options = {
        'device': 'cuda',
        'dtype': torch.bfloat16
    }
    q_shape = [1, 3058, 8, 128]
    kv_shape = [1, 491520, 8, 128]
    q = torch.randn(q_shape, **options)
    k = torch.randn(kv_shape, **options)
    v = torch.randn(kv_shape, **options)


    bias = fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(        q_seqlen=q_seqlen,  kv_padding=8192,  kv_seqlen=kv_seqlen,
    )

    y0 = fmha.memory_efficient_attention_forward(
              q,
              k,
              v,
              attn_bias=bias,
              op=None,
        )
    torch.cuda.synchronize()
    start = time.perf_counter()

    for itr in range(29):
        y0 = fmha.memory_efficient_attention_forward(
              q,
              k,
              v,
              attn_bias=bias,
              op=None,
        )
        torch.cuda.synchronize()

    end = time.perf_counter()

    ms = (end-start) * 10**6 // 29
    print(f"Elapsed {ms:.03f} micro secs.")

if __name__ == "__main__":
    main()
```