### PR TITLE
Fix in dropout lambda to avoid the compiling issue on some docker/compiler

### DIFF
--- a/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp
+++ b/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp
@@ -744,11 +744,11 @@ struct FmhaFwdKernel
             }
         }();
 
-        auto dropout = [&]() {
+        auto dropout = [&, i_nhead_ = i_nhead, i_batch_ = i_batch]() {
             if constexpr(kHasDropout)
             {
-                return BlockDropout{i_batch,
-                                    i_nhead,
+                return BlockDropout{i_batch_,
+                                    i_nhead_,
                                     kargs.num_head_q,
                                     kargs.drop_seed,
                                     kargs.drop_offset,


### PR DESCRIPTION
Compiling issue is reported on both ck_tile and xformers c++ extension building after upgrading the docker to latest `rocm/pytorch-nightly:latest`

This PR is to regularize the using of C++ codes to strictly follow the C++17 specification