### PR TITLE
Fix the optional ckProfiler grouped_gemm arguments.

### DIFF
--- a/profiler/src/profile_grouped_gemm.cpp
+++ b/profiler/src/profile_grouped_gemm.cpp
@@ -98,8 +98,8 @@ int profile_grouped_gemm(int argc, char* argv[])
     int n_iter   = 10;
     if(argc == 17)
     {
-        n_warmup = std::stoi(argv[16]);
-        n_iter   = std::stoi(argv[17]);
+        n_warmup = std::stoi(argv[15]);
+        n_iter   = std::stoi(argv[16]);
     }
 
 #ifdef CK_ENABLE_FP16


### PR DESCRIPTION
The optional arguments for ckProfiler grouped_gemm were offset by 1 which caused a runtime error.
With the updated indices, the ckProfiler works correctly.