### PR TITLE
Remove reinterpret_cast uses that result in undefined behaviour.

### DIFF
--- a/include/ck/utility/f8_utils.hpp
+++ b/include/ck/utility/f8_utils.hpp
@@ -196,7 +196,7 @@ __host__ __device__ Y run_cast_from_f8(X x)
 
     // prepare the codes
     constexpr X nan_code = 0x80;
-    using T_bitwise = typename NumericUtils<Y>::bitwise_type;
+    using T_bitwise      = typename NumericUtils<Y>::bitwise_type;
 
     constexpr T_bitwise Inf_bitwise    = NumericUtils<Y>::Inf;
     constexpr T_bitwise NegInf_bitwise = NumericUtils<Y>::NegInf;

--- a/include/ck/utility/f8_utils.hpp
+++ b/include/ck/utility/f8_utils.hpp
@@ -44,7 +44,7 @@ __host__ __device__ Y run_cast_to_f8(X x, uint32_t rng)
 
     // convert to bitwise
     using T_bitwise     = typename NumericUtils<X>::bitwise_type;
-    T_bitwise x_bitwise = *(reinterpret_cast<T_bitwise*>(&x));
+    T_bitwise x_bitwise = bit_cast<T_bitwise>(x);
 
     // unpack the input, depends on datatype
     head     = x_bitwise & NumericUtils<X>::head_mask;
@@ -196,7 +196,6 @@ __host__ __device__ Y run_cast_from_f8(X x)
 
     // prepare the codes
     constexpr X nan_code = 0x80;
-    Y Inf, NegInf, NaN, Neg0;
     using T_bitwise = typename NumericUtils<Y>::bitwise_type;
 
     constexpr T_bitwise Inf_bitwise    = NumericUtils<Y>::Inf;
@@ -204,10 +203,10 @@ __host__ __device__ Y run_cast_from_f8(X x)
     constexpr T_bitwise NaN_bitwise    = NumericUtils<Y>::NaN;
     constexpr T_bitwise Neg0_bitwise   = NumericUtils<Y>::Neg0;
 
-    Inf    = *(reinterpret_cast<const Y*>(&Inf_bitwise));
-    NegInf = *(reinterpret_cast<const Y*>(&NegInf_bitwise));
-    NaN    = *(reinterpret_cast<const Y*>(&NaN_bitwise));
-    Neg0   = *(reinterpret_cast<const Y*>(&Neg0_bitwise));
+    constexpr Y Inf    = bit_cast<Y>(Inf_bitwise);
+    constexpr Y NegInf = bit_cast<Y>(NegInf_bitwise);
+    constexpr Y NaN    = bit_cast<Y>(NaN_bitwise);
+    constexpr Y Neg0   = bit_cast<Y>(Neg0_bitwise);
 
     // check if x is 0.0
     if(x == 0)
@@ -239,7 +238,7 @@ __host__ __device__ Y run_cast_from_f8(X x)
     {
         retval = x;
         retval <<= 8;
-        return *(reinterpret_cast<const Y*>(&retval));
+        return bit_cast<Y>(retval);
     }
 
     // subnormal input
@@ -263,7 +262,7 @@ __host__ __device__ Y run_cast_from_f8(X x)
     }
 
     retval = (sign << (out_exp + out_mant)) | (exponent << out_mant) | mantissa;
-    return *(reinterpret_cast<const Y*>(&retval));
+    return bit_cast<Y>(retval);
 }
 
 } // namespace


### PR DESCRIPTION
See [cppreference/reinterpret_cast#Type_accessibility](https://en.cppreference.com/w/cpp/language/reinterpret_cast#Type_accessibility).

Use a bitcast instead implemented through memcpy.

Closes #1439