### PR TITLE
Fix ROCm 6.2 compiler not fully supporting gfx12 when building CK with INSTANCES_ONLY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,21 +106,33 @@ list(APPEND CMAKE_PREFIX_PATH ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_PREFIX}/ll
 
 message("GPU_TARGETS= ${GPU_TARGETS}")
 
+find_package(hip)
+# No assumption that HIP kernels are launched with uniform block size for backward compatibility
+# SWDEV-413293 and https://reviews.llvm.org/D155213
+math(EXPR hip_VERSION_FLAT "(${hip_VERSION_MAJOR} * 1000 + ${hip_VERSION_MINOR}) * 100000 + ${hip_VERSION_PATCH}")
+message("hip_version_flat=${hip_VERSION_FLAT}")
+
 message("checking which targets are supported")
 #This is the list of targets to be used in case GPU_TARGETS is not set on command line
 #These targets will be filtered and only supported ones will be used
 #Setting GPU_TARGETS on command line will override this list
 if(NOT PROFILER_ONLY)
-  if(NOT ENABLE_ASAN_PACKAGING)
-    #build CK for all supported targets
-    rocm_check_target_ids(DEFAULT_GPU_TARGETS
-        TARGETS "gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201")
-  else()
-    #build CK only for xnack-supported targets
-    rocm_check_target_ids(DEFAULT_GPU_TARGETS
-        TARGETS "gfx908:xnack+;gfx90a:xnack+;gfx940:xnack+;gfx941:xnack+;gfx942:xnack+")
-    set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING " " FORCE)
-  endif()
+    if(NOT ENABLE_ASAN_PACKAGING)
+        #build CK for all supported targets
+        if(NOT WIN32 AND ${hip_VERSION_FLAT} LESS 600300000)
+            # WORKAROUND: compiler does not yet fully support gfx12 targets, need to fix version above
+            rocm_check_target_ids(DEFAULT_GPU_TARGETS
+                TARGETS "gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1102")
+        else()
+            rocm_check_target_ids(DEFAULT_GPU_TARGETS
+                TARGETS "gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201")
+        endif()
+    else()
+        #build CK only for xnack-supported targets
+        rocm_check_target_ids(DEFAULT_GPU_TARGETS
+            TARGETS "gfx908:xnack+;gfx90a:xnack+;gfx940:xnack+;gfx941:xnack+;gfx942:xnack+")
+        set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING " " FORCE)
+    endif()
 else()
     add_definitions(-DPROFILER_ONLY)
     set(GPU_TARGETS "" CACHE STRING "" FORCE)
@@ -169,11 +181,6 @@ endif()
 # CK config file to record supported datatypes, etc.
 configure_file(include/ck/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/ck/config.h)
 
-find_package(hip)
-# No assumption that HIP kernels are launched with uniform block size for backward compatibility
-# SWDEV-413293 and https://reviews.llvm.org/D155213
-math(EXPR hip_VERSION_FLAT "(${hip_VERSION_MAJOR} * 1000 + ${hip_VERSION_MINOR}) * 100000 + ${hip_VERSION_PATCH}")
-message("hip_version_flat=${hip_VERSION_FLAT}")
 if(NOT WIN32 AND ${hip_VERSION_FLAT} GREATER 500723302)
    message("Adding the fno-offload-uniform-block compiler flag")
    add_compile_options(-fno-offload-uniform-block)


### PR DESCRIPTION
- gfx12 target does not exist in ROCm 6.2 release branches, so everything should be okay there
- However, when we attempt to use ROCm 6.2 base docker as our CI docker, since we added gfx12 to the target list
- The only way to workaround is to add GPU_TARGETS to the cmake command line, to explicitly remove gfx12

We have to do this through all mainline staging tests till it is fixed in compiler

A global search in CK reveals that we have a few places like this:
```
    if(INSTANCES_ONLY)

        set(INST_TARGETS ${DEFAULT_GPU_TARGETS})

    else()

        set(INST_TARGETS ${GPU_TARGETS})

    endif()
```
