### PR TITLE
Duplicate Cmake tidy-target issue

### DIFF
--- a/library/src/tensor_operation_instance/gpu/mha/CMakeLists.txt
+++ b/library/src/tensor_operation_instance/gpu/mha/CMakeLists.txt
@@ -27,7 +27,7 @@ rocm_install(FILES ${MHA_HEADERS} DESTINATION include/ck_tile/ops)
 # headers for building lib
 file(COPY ${MHA_HEADERS} DESTINATION ${FMHA_CPP_FOLDER})
 
-# actually generate the cpp files but before that delete the blob file, if it exists to avoid append of old content.
+# Delete the blob file, if it exists to avoid append of old content.
 if(EXISTS ${FMHA_CPP_FOLDER}/blob_list.txt)
     file(REMOVE ${FMHA_CPP_FOLDER}/blob_list.txt)
 endif()
@@ -44,7 +44,7 @@ else()
   file(STRINGS ${FMHA_CPP_FOLDER}/blob_list.txt FMHA_FWD_GEN_BLOBS)
 endif()
 
-
+# actually generate the kernel content now
 add_custom_command(
   OUTPUT ${FMHA_FWD_GEN_BLOBS}
   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/example/ck_tile/01_fmha/generate.py

--- a/library/src/tensor_operation_instance/gpu/mha/CMakeLists.txt
+++ b/library/src/tensor_operation_instance/gpu/mha/CMakeLists.txt
@@ -27,7 +27,7 @@ rocm_install(FILES ${MHA_HEADERS} DESTINATION include/ck_tile/ops)
 # headers for building lib
 file(COPY ${MHA_HEADERS} DESTINATION ${FMHA_CPP_FOLDER})
 
-# Delete the blob file, if it exists to avoid append of old content.
+# Delete the blob file if it exists to avoid append of old content.
 if(EXISTS ${FMHA_CPP_FOLDER}/blob_list.txt)
     file(REMOVE ${FMHA_CPP_FOLDER}/blob_list.txt)
 endif()

--- a/library/src/tensor_operation_instance/gpu/mha/CMakeLists.txt
+++ b/library/src/tensor_operation_instance/gpu/mha/CMakeLists.txt
@@ -39,7 +39,12 @@ else()
   file(STRINGS ${FMHA_CPP_FOLDER}/blob_list.txt FMHA_FWD_GEN_BLOBS)
 endif()
 
-# actually generate the cpp files
+
+# actually generate the cpp files but before that delete the blob file, if it exists to avoid append of old content.
+if(EXISTS ${FMHA_CPP_FOLDER}/blob_list.txt)
+    file(REMOVE ${FMHA_CPP_FOLDER}/blob_list.txt)
+endif()
+
 add_custom_command(
   OUTPUT ${FMHA_FWD_GEN_BLOBS}
   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/example/ck_tile/01_fmha/generate.py

--- a/library/src/tensor_operation_instance/gpu/mha/CMakeLists.txt
+++ b/library/src/tensor_operation_instance/gpu/mha/CMakeLists.txt
@@ -27,6 +27,11 @@ rocm_install(FILES ${MHA_HEADERS} DESTINATION include/ck_tile/ops)
 # headers for building lib
 file(COPY ${MHA_HEADERS} DESTINATION ${FMHA_CPP_FOLDER})
 
+# actually generate the cpp files but before that delete the blob file, if it exists to avoid append of old content.
+if(EXISTS ${FMHA_CPP_FOLDER}/blob_list.txt)
+    file(REMOVE ${FMHA_CPP_FOLDER}/blob_list.txt)
+endif()
+
 # generate a list of kernels, but not actually emit files at config stage
 execute_process(
   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/example/ck_tile/01_fmha/generate.py
@@ -39,11 +44,6 @@ else()
   file(STRINGS ${FMHA_CPP_FOLDER}/blob_list.txt FMHA_FWD_GEN_BLOBS)
 endif()
 
-
-# actually generate the cpp files but before that delete the blob file, if it exists to avoid append of old content.
-if(EXISTS ${FMHA_CPP_FOLDER}/blob_list.txt)
-    file(REMOVE ${FMHA_CPP_FOLDER}/blob_list.txt)
-endif()
 
 add_custom_command(
   OUTPUT ${FMHA_FWD_GEN_BLOBS}


### PR DESCRIPTION
From CMake we run python script to generate `blob_list.txt` file (See below what `blob_list.txt` looks like). When user run the cmake second time, the python script would re-append the same kernel name to `blob_list.txt`. This tidy-target did not like because now there are multiple kernel with same name. This PR fixes that by deleting the `blob_list.txt` before generating that file.
Address https://github.com/ROCm/composable_kernel/issues/1510

Eg: of blob_list.txt 

```
/data/ck/composable_kernel/build/library/src/tensor_operation_instance/gpu/mha/fmha_fwd_d256_fp8_batch_shb_b128x128x32x256x32x256_r4x1x1_w32x32x32_qr_vc_mask_squant.cpp
/data/ck/composable_kernel/build/library/src/tensor_operation_instance/gpu/mha/fmha_fwd_d256_fp8_batch_shb_b128x128x32x256x32x256_r4x1x1_w32x32x32_qr_vc_bias_mask_squant.cpp
/data/ck/composable_kernel/build/library/src/tensor_operation_instance/gpu/mha/fmha_fwd_d256_fp8_batch_shb_b128x128x32x256x32x256_r4x1x1_w32x32x32_qr_vc_alibi_mask_squant.cpp
/data/ck/composable_kernel/build/library/src/tensor_operation_instance/gpu/mha/fmha_fwd_api.cpp
```