### PR TITLE
add a CK_USE_CODEGEN build argument to enable codegen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,9 +97,9 @@ if(DL_KERNELS)
     add_definitions(-DDL_KERNELS)
     set(CK_ENABLE_DL_KERNELS "ON")
 endif()
+option(CK_USE_CODEGEN "Enable codegen library" OFF)
 if(CK_USE_CODEGEN)
     add_definitions(-DCK_USE_CODEGEN)
-    set(CK_USE_CODEGEN "ON")
 endif()
 
 include(getopt)
@@ -567,7 +567,7 @@ rocm_package_setup_component(profiler
 )
 add_subdirectory(profiler)
 
-if(DEFINED CK_USE_CODEGEN AND (GPU_TARGETS MATCHES "gfx9" OR GPU_ARCHS))
+if(CK_USE_CODEGEN AND (GPU_TARGETS MATCHES "gfx9" OR GPU_ARCHS))
   add_subdirectory(codegen)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,10 @@ if(DL_KERNELS)
     add_definitions(-DDL_KERNELS)
     set(CK_ENABLE_DL_KERNELS "ON")
 endif()
+if(CK_USE_CODEGEN)
+    add_definitions(-DCK_USE_CODEGEN)
+    set(CK_USE_CODEGEN "ON")
+endif()
 
 include(getopt)
 
@@ -563,7 +567,7 @@ rocm_package_setup_component(profiler
 )
 add_subdirectory(profiler)
 
-if(GPU_TARGETS MATCHES "gfx9" OR GPU_ARCHS)
+if(DEFINED CK_USE_CODEGEN AND (GPU_TARGETS MATCHES "gfx9" OR GPU_ARCHS))
   add_subdirectory(codegen)
 endif()
 


### PR DESCRIPTION
This change will require the "-DCK_USE_CODEGEN=ON" build argument in order to build the codegen folder.