### PR TITLE
[CK_TILE] Allow using default gemm pipeline policy

### DIFF
--- a/example/ck_tile/03_gemm/gemm_basic.cpp
+++ b/example/ck_tile/03_gemm/gemm_basic.cpp
@@ -28,8 +28,8 @@ float gemm_calc(const gemm_basic_args& args, const ck_tile::stream_config& s)
     constexpr int kBlockPerCu = 1;
 
     // This part comes from the Codegen
-    constexpr ck_tile::index_t M_Tile = 128;
-    constexpr ck_tile::index_t N_Tile = 128;
+    constexpr ck_tile::index_t M_Tile = 128; // make sure this is no less than warp size
+    constexpr ck_tile::index_t N_Tile = 128; // make sure this is no less than warp size
     constexpr ck_tile::index_t K_Tile = 32;
 
     constexpr ck_tile::index_t M_Warp = 2;

--- a/example/ck_tile/03_gemm/gemm_basic.cpp
+++ b/example/ck_tile/03_gemm/gemm_basic.cpp
@@ -16,7 +16,7 @@
 #include "gemm_basic.hpp"
 
 #if !defined(EXAMPLE_USE_UNIVERSAL_GEMM_PIPELINE_POLICY)
-#define EXAMPLE_USE_UNIVERSAL_GEMM_PIPELINE_POLICY 0
+#define EXAMPLE_USE_UNIVERSAL_GEMM_PIPELINE_POLICY 1
 #endif
 
 template <typename ALayout, typename BLayout, typename CLayout>

--- a/example/ck_tile/03_gemm/gemm_basic.cpp
+++ b/example/ck_tile/03_gemm/gemm_basic.cpp
@@ -8,6 +8,7 @@
 #include <ostream>
 #include <string>
 #include <tuple>
+#include <utility>
 
 #include "ck_tile/ops/epilogue.hpp"
 #include "ck_tile/ops/gemm.hpp"
@@ -15,11 +16,12 @@
 #include "gemm_basic.hpp"
 
 #if !defined(EXAMPLE_USE_UNIVERSAL_GEMM_PIPELINE_POLICY)
-#define EXAMPLE_USE_UNIVERSAL_GEMM_PIPELINE_POLICY 1
+#define EXAMPLE_USE_UNIVERSAL_GEMM_PIPELINE_POLICY 0
 #endif
 
 template <typename ALayout, typename BLayout, typename CLayout>
-float gemm_calc(const gemm_basic_args& args, const ck_tile::stream_config& s)
+std::pair<float, std::string> gemm_calc(const gemm_basic_args& args,
+                                        const ck_tile::stream_config& s)
 {
     // The kPadA, kPadB, kPadC & kBlockPerCu should also come from the Codegen part.
     constexpr bool kPadA        = true;
@@ -116,7 +118,7 @@ float gemm_calc(const gemm_basic_args& args, const ck_tile::stream_config& s)
     float ave_time = ck_tile::launch_kernel(
         s, ck_tile::make_kernel<blocks.x, kBlockPerCu>(Kernel{}, grids, blocks, 0, kargs));
 
-    return ave_time;
+    return std::make_pair(ave_time, "GemmPipelineAGmemBGmemCRegV1");
 }
 
 #include "run_gemm_example.inc"

--- a/example/ck_tile/03_gemm/gemm_basic.cpp
+++ b/example/ck_tile/03_gemm/gemm_basic.cpp
@@ -14,6 +14,10 @@
 #include "ck_tile/host.hpp"
 #include "gemm_basic.hpp"
 
+#if !defined(EXAMPLE_USE_UNIVERSAL_GEMM_PIPELINE_POLICY)
+#define EXAMPLE_USE_UNIVERSAL_GEMM_PIPELINE_POLICY 1
+#endif
+
 template <typename ALayout, typename BLayout, typename CLayout>
 float gemm_calc(const gemm_basic_args& args, const ck_tile::stream_config& s)
 {
@@ -28,8 +32,8 @@ float gemm_calc(const gemm_basic_args& args, const ck_tile::stream_config& s)
     constexpr int kBlockPerCu = 1;
 
     // This part comes from the Codegen
-    constexpr ck_tile::index_t M_Tile = 128; // make sure this is no less than warp size
-    constexpr ck_tile::index_t N_Tile = 128; // make sure this is no less than warp size
+    constexpr ck_tile::index_t M_Tile = 128;
+    constexpr ck_tile::index_t N_Tile = 128;
     constexpr ck_tile::index_t K_Tile = 32;
 
     constexpr ck_tile::index_t M_Warp = 2;
@@ -71,9 +75,19 @@ float gemm_calc(const gemm_basic_args& args, const ck_tile::stream_config& s)
         ck_tile::TileGemmTraits<kPadA, kPadB, kPadC, ALayout, BLayout, CLayout>;
     using CodegenPipelineProblem = ck_tile::
         GemmPipelineProblem<ADataType, BDataType, AccDataType, CodegenGemmShape, CodegenGemmTraits>;
+    /// NOTICE: There are 3 limitations for using UniversalGemmPipelineAgBgCrPolicy<>
+    ///     1. Both of M_Tile and N_Tile should be no less than get_warp_size()
+    ///     2. K_Warp should be 1
+    ///     3. (K_Tile * N_Warp_Tile / K_Warp_Tile) should be no less than 64
+#if EXAMPLE_USE_UNIVERSAL_GEMM_PIPELINE_POLICY
     using CodegenGemmPolicy = ck_tile::UniversalGemmPipelineAgBgCrPolicy<ALayout, BLayout, CLayout>;
-    using CodegenGemmPipeline =
-        ck_tile::GemmPipelineAGmemBGmemCRegV1<CodegenPipelineProblem, CodegenGemmPolicy>;
+#endif
+    using CodegenGemmPipeline = ck_tile::GemmPipelineAGmemBGmemCRegV1<CodegenPipelineProblem
+#if EXAMPLE_USE_UNIVERSAL_GEMM_PIPELINE_POLICY
+                                                                      ,
+                                                                      CodegenGemmPolicy
+#endif
+                                                                      >;
     // ToDo: Will add the codegen part to test different pipeline policies in GEMM.
     // Now we only use the BlockGemmASmemBSmemCRegV1DefaultPolicy.
     using Kernel = ck_tile::GemmKernel<TilePartitioner, CodegenGemmPipeline, GemmEpilogue>;

--- a/example/ck_tile/03_gemm/gemm_basic.hpp
+++ b/example/ck_tile/03_gemm/gemm_basic.hpp
@@ -87,6 +87,3 @@ auto create_args(int argc, char* argv[])
     bool result = arg_parser.parse(argc, argv);
     return std::make_tuple(result, arg_parser);
 }
-
-// host API
-float gemm_calc(gemm_basic_args args, const ck_tile::stream_config& s);

--- a/example/ck_tile/03_gemm/gemm_basic.hpp
+++ b/example/ck_tile/03_gemm/gemm_basic.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <iomanip>
 #include <string>
 
 #include "ck_tile/core.hpp"

--- a/example/ck_tile/03_gemm/gemm_mem_pipeline.cpp
+++ b/example/ck_tile/03_gemm/gemm_mem_pipeline.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <string>
 #include <tuple>
+#include <utility>
 
 #include "ck_tile/ops/epilogue.hpp"
 #include "ck_tile/ops/gemm.hpp"
@@ -15,7 +16,8 @@
 #include "gemm_basic.hpp"
 
 template <typename ALayout, typename BLayout, typename CLayout>
-float gemm_calc(const gemm_basic_args& args, const ck_tile::stream_config& s)
+std::pair<float, std::string> gemm_calc(const gemm_basic_args& args,
+                                        const ck_tile::stream_config& s)
 {
     // ToDo: This will be modified by the codegen code later.
     constexpr ck_tile::index_t M_Tile = 128;
@@ -180,7 +182,7 @@ float gemm_calc(const gemm_basic_args& args, const ck_tile::stream_config& s)
         }
     }
 
-    return ave_time;
+    return std::make_pair(ave_time, "BaseGemmPipelineAgBgCrMem");
 }
 
 #include "run_gemm_example.inc"

--- a/example/ck_tile/03_gemm/run_gemm_example.inc
+++ b/example/ck_tile/03_gemm/run_gemm_example.inc
@@ -28,10 +28,10 @@ float invoke_gemm(ck_tile::DeviceMem& a_m_k_dev_buf,
     args.stride_B = stride_B;
     args.stride_C = stride_C;
 
-    float ave_time = gemm_calc<ALayout, BLayout, CLayout>(
+    auto [ave_time, pipeline_name] = gemm_calc<ALayout, BLayout, CLayout>(
         args, ck_tile::stream_config{nullptr, true, 1, n_warmup, n_repeat});
 
-    std::string op_name{"Gemm{MemBoundPipeline}"};
+    const std::string op_name = "Gemm{" + pipeline_name + "}";
 
     std::size_t flop = std::size_t(2) * M * N * K;
     std::size_t num_byte =
@@ -39,7 +39,7 @@ float invoke_gemm(ck_tile::DeviceMem& a_m_k_dev_buf,
     float tflops     = static_cast<float>(flop) / 1.E9 / ave_time;
     float gb_per_sec = num_byte / 1.E6 / ave_time;
 
-    std::cout << "Run " << op_name << "kernel with M =" << M << " N =" << N << " K =" << K
+    std::cout << "Run " << op_name << " kernel with M =" << M << " N =" << N << " K =" << K
               << " StrideA =" << stride_A << " StrideB =" << stride_B << " StrideC =" << stride_C
               << " : " << ave_time << " ms, " << tflops << " TFlops, " << gb_per_sec << " GB/s, "
               << std::endl;

--- a/example/ck_tile/03_gemm/run_gemm_example.inc
+++ b/example/ck_tile/03_gemm/run_gemm_example.inc
@@ -41,7 +41,8 @@ float invoke_gemm(ck_tile::DeviceMem& a_m_k_dev_buf,
 
     std::cout << "Run " << op_name << " kernel with M =" << M << " N =" << N << " K =" << K
               << " StrideA =" << stride_A << " StrideB =" << stride_B << " StrideC =" << stride_C
-              << " : " << ave_time << " ms, " << tflops << " TFlops, " << gb_per_sec << " GB/s, "
+              << " : " << std::fixed << std::setprecision(3) << ave_time << " ms, " << tflops << " TFlops, " 
+              << gb_per_sec << " GB/s, "
               << std::endl;
 
     return ave_time;

--- a/example/ck_tile/03_gemm/run_gemm_example.inc
+++ b/example/ck_tile/03_gemm/run_gemm_example.inc
@@ -154,7 +154,7 @@ int run_gemm_example_with_layouts(int argc,
 
         pass = ck_tile::check_err(c_m_n_dev_result, c_m_n_host_ref);
 
-        std::cout << "The CPU veification result is:" << (pass ? "correct" : "fail") << std::endl;
+        std::cout << "The CPU veification result is: " << (pass ? "correct" : "FAIL") << std::endl;
     }
     else if(arg_parser.get_int("v") == 2)
     {
@@ -176,7 +176,7 @@ int run_gemm_example_with_layouts(int argc,
         c_m_n_gpu_buf_ref.FromDevice(c_m_n_gpu_ref.data());
         pass = ck_tile::check_err(c_m_n_dev_result, c_m_n_gpu_ref);
 
-        std::cout << "The GPU veification result is: " << (pass ? "correct" : "fail") << std::endl;
+        std::cout << "The GPU veification result is: " << (pass ? "correct" : "FAIL") << std::endl;
     }
 
     return pass;

--- a/example/ck_tile/03_gemm/script/run_full_test.sh
+++ b/example/ck_tile/03_gemm/script/run_full_test.sh
@@ -20,6 +20,7 @@ export GPU_arch=$4
 echo 'GPU_arch: ' $GPU_arch
 
 # run verification tests
-example/ck_tile/03_gemm/script/smoke_test.sh
+SCRIPT_DIR="$(dirname "$0")"
+$SCRIPT_DIR/smoke_test.sh
 
 # We do not have a performance benchmark for gemm yet. Will add it in the future.

--- a/example/ck_tile/03_gemm/script/smoke_test.sh
+++ b/example/ck_tile/03_gemm/script/smoke_test.sh
@@ -13,7 +13,7 @@ run_fp16_tests() {
             for n in 128 2048; do
                 for k in 32 64; do
 
-                    $EXE -b=$batch -m=$m -n=$n -k=$k -stride_a=0 -stride_b=0 -stride_c=0 -e=1e-5 -prec=fp16 $COMMON_ARGS
+                    $EXE -b=$batch -m=$m -n=$n -k=$k -stride_a=0 -stride_b=0 -stride_c=0 -prec=fp16 $COMMON_ARGS
                     if [ $? -eq 0 ]; then
                         echo "Success: Test with batch=$batch, m=$m, n=$n, k=$k executed successfully."
                     else

--- a/include/ck_tile/ops/gemm/kernel/gemm_kernel.hpp
+++ b/include/ck_tile/ops/gemm/kernel/gemm_kernel.hpp
@@ -63,7 +63,7 @@ struct GemmKernel
 
     CK_TILE_HOST_DEVICE static constexpr index_t GetSmemSize()
     {
-        return max(GemmPipeline::GetSmemSize(), EpiloguePipeline::GetSmemSize());
+        return max(1, GemmPipeline::GetSmemSize(), EpiloguePipeline::GetSmemSize());
     }
 
     CK_TILE_DEVICE void operator()(GemmCommonKargs kargs) const

--- a/include/ck_tile/ops/gemm/kernel/gemm_tile_partitioner.hpp
+++ b/include/ck_tile/ops/gemm/kernel/gemm_tile_partitioner.hpp
@@ -17,8 +17,8 @@ struct GemmTilePartitioner
 
     CK_TILE_HOST static constexpr auto GridSize(index_t M, index_t N, index_t batch_size)
     {
-        index_t GridDimX = (M + kM - 1) / kM;
-        index_t GridDimY = (N + kN - 1) / kN;
+        index_t GridDimX = integer_divide_ceil(M, kM);
+        index_t GridDimY = integer_divide_ceil(N, kN);
         index_t GridDimZ = batch_size;
         return dim3(GridDimX, GridDimY, GridDimZ);
     }

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "ck_tile/core.hpp"
+#include "ck_tile/ops/gemm/warp/warp_gemm_dispatcher.hpp"
 
 namespace ck_tile {
 
@@ -271,8 +272,21 @@ struct GemmPipelineAGmemBGmemCRegV1DefaultPolicy
     template <typename Problem>
     CK_TILE_HOST_DEVICE static constexpr auto GetBlockGemm()
     {
-        using BlockGemmPolicy = BlockGemmASmemBSmemCRegV1DefaultPolicy;
-
+        using AccDataType     = float;
+        using BlockWarps      = typename Problem::BlockGemmShape::BlockWarps;
+        using WarpTile        = typename Problem::BlockGemmShape::WarpTile;
+        using WarpGemm        = WarpGemmMfmaDispatcher<typename Problem::ADataType,
+                                                typename Problem::BDataType,
+                                                AccDataType,
+                                                WarpTile::at(number<0>{}),
+                                                WarpTile::at(number<1>{}),
+                                                WarpTile::at(number<2>{}),
+                                                /*TransposeC=*/true>;
+        using BlockGemmPolicy = BlockGemmASmemBSmemCRegV1CustomPolicy<typename Problem::ADataType,
+                                                                      typename Problem::BDataType,
+                                                                      typename Problem::CDataType,
+                                                                      BlockWarps,
+                                                                      WarpGemm>;
         return BlockGemmASmemBSmemCRegV1<Problem, BlockGemmPolicy>{};
     }
 };

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp
@@ -129,11 +129,15 @@ struct GemmPipelineAGmemBGmemCRegV1DefaultPolicy
         constexpr index_t kMPerBlock = Problem::BlockGemmShape::kM;
         constexpr index_t kKPerBlock = Problem::BlockGemmShape::kK;
 
+        constexpr index_t PixelPerThread = (kMPerBlock * kKPerBlock) / kBlockSize;
+        constexpr index_t MaxVectorSize  = 16 / sizeof(ADataType);
+        static_assert(0 < PixelPerThread);
+
         constexpr auto a_lds_block_desc_d1_d2_d3 = make_naive_tensor_descriptor_packed(
             make_tuple(number<kMPerBlock / 2>{}, number<2>{}, number<kKPerBlock>{}),
             number<kKPerBlock>{});
 
-        constexpr index_t kK1 = 16 / sizeof(ADataType);
+        constexpr index_t kK1 = min(MaxVectorSize, PixelPerThread);
 
         constexpr auto a_lds_block_desc_d4_d5_d6 = transform_tensor_descriptor(
             a_lds_block_desc_d1_d2_d3,
@@ -164,11 +168,15 @@ struct GemmPipelineAGmemBGmemCRegV1DefaultPolicy
         constexpr index_t kNPerBlock = Problem::BlockGemmShape::kN;
         constexpr index_t kKPerBlock = Problem::BlockGemmShape::kK;
 
+        constexpr index_t PixelPerThread = (kNPerBlock * kKPerBlock) / kBlockSize;
+        constexpr index_t MaxVectorSize  = 16 / sizeof(BDataType);
+        static_assert(0 < PixelPerThread);
+
         constexpr auto b_lds_block_desc_d1_d2_d3 = make_naive_tensor_descriptor_packed(
             make_tuple(number<kNPerBlock / 2>{}, number<2>{}, number<kKPerBlock>{}),
             number<kKPerBlock>{});
 
-        constexpr index_t kK1 = 16 / sizeof(BDataType);
+        constexpr index_t kK1 = min(MaxVectorSize, PixelPerThread);
 
         constexpr auto b_lds_block_desc_d4_d5_d6 = transform_tensor_descriptor(
             b_lds_block_desc_d1_d2_d3,

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp
@@ -199,7 +199,11 @@ struct GemmPipelineAGmemBGmemCRegV1DefaultPolicy
         constexpr index_t kMPerBlock = Problem::BlockGemmShape::kM;
         constexpr index_t kKPerBlock = Problem::BlockGemmShape::kK;
 
-        constexpr index_t K1 = 16 / sizeof(ADataType);
+        constexpr index_t PixelPerThread = (kMPerBlock * kKPerBlock) / kBlockSize;
+        constexpr index_t MaxVectorSize  = 16 / sizeof(ADataType);
+        static_assert(0 < PixelPerThread);
+
+        constexpr index_t K1 = min(MaxVectorSize, PixelPerThread);
         constexpr index_t K0 = kKPerBlock / K1;
         constexpr index_t M2 = get_warp_size() / K0;
 #if 1 // coalesce reading for each blocks
@@ -239,7 +243,11 @@ struct GemmPipelineAGmemBGmemCRegV1DefaultPolicy
         constexpr index_t kNPerBlock = Problem::BlockGemmShape::kN;
         constexpr index_t kKPerBlock = Problem::BlockGemmShape::kK;
 
-        constexpr index_t K1 = 16 / sizeof(BDataType);
+        constexpr index_t PixelPerThread = (kNPerBlock * kKPerBlock) / kBlockSize;
+        constexpr index_t MaxVectorSize  = 16 / sizeof(BDataType);
+        static_assert(0 < PixelPerThread);
+
+        constexpr index_t K1 = min(MaxVectorSize, PixelPerThread);
         constexpr index_t K0 = kKPerBlock / K1;
         constexpr index_t N2 = get_warp_size() / K0;
 #if 1 // coalesce reading for each blocks

--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -33,6 +33,9 @@ struct UniversalGemmPipelineAgBgCrPolicy
                                                 Problem::BlockGemmShape::WarpTile::at(I2),
                                                 TransposeC>;
 
+        static_assert(Problem::BlockGemmShape::BlockWarps::at(I2) == 1,
+                      "Assume there is only 1 warp among K dimension");
+
         using ADataType = remove_cvref_t<typename Problem::ADataType>;
 
         constexpr index_t MPerBlock = Problem::BlockGemmShape::kM;
@@ -180,6 +183,9 @@ struct UniversalGemmPipelineAgBgCrPolicy
                                                 Problem::BlockGemmShape::WarpTile::at(I1),
                                                 Problem::BlockGemmShape::WarpTile::at(I2),
                                                 TransposeC>;
+
+        static_assert(Problem::BlockGemmShape::BlockWarps::at(I2) == 1,
+                      "Assume there is only 1 warp among K dimension");
 
         using BDataType = remove_cvref_t<typename Problem::BDataType>;
 
@@ -355,6 +361,9 @@ struct UniversalGemmPipelineAgBgCrPolicy
                                                 Problem::BlockGemmShape::WarpTile::at(I2),
                                                 TransposeC>;
 
+        static_assert(Problem::BlockGemmShape::BlockWarps::at(I2) == 1,
+                      "Assume there is only 1 warp among K dimension");
+
         constexpr index_t BlockSize = Problem::kBlockSize;
 
         constexpr index_t MPerBlock = Problem::BlockGemmShape::kM;
@@ -389,6 +398,9 @@ struct UniversalGemmPipelineAgBgCrPolicy
                                                 Problem::BlockGemmShape::WarpTile::at(I1),
                                                 Problem::BlockGemmShape::WarpTile::at(I2),
                                                 TransposeC>;
+
+        static_assert(Problem::BlockGemmShape::BlockWarps::at(I2) == 1,
+                      "Assume there is only 1 warp among K dimension");
 
         constexpr index_t BlockSize = Problem::kBlockSize;
 

--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -87,6 +87,10 @@ struct UniversalGemmPipelineAgBgCrPolicy
             // more dimension in merge_transform increase the difficulty of generating immarg offset
             // for compiler.
             constexpr auto MThreads = get_warp_size() * Problem::BlockGemmShape::BlockWarps::at(I0);
+            static_assert(MThreads <= MPerBlock,
+                          "Make sure GEMM M tile (BlockTile[0]) is greater than or equal to "
+                          "(get_warp_size() * BlockWarps[0])");
+
             constexpr auto MPerThread = MPerBlock / MThreads;
             static_assert(MPerBlock == MThreads * MPerThread);
 
@@ -237,21 +241,31 @@ struct UniversalGemmPipelineAgBgCrPolicy
         else // RowMajor B
         {
             constexpr auto NThreads = get_warp_size() * Problem::BlockGemmShape::BlockWarps::at(I1);
+            static_assert(NThreads <= NPerBlock,
+                          "Make sure GEMM N tile (BlockTile[1]) is greater than or equal to "
+                          "(get_warp_size() * BlockWarps[1])");
+
             constexpr auto NPerThread = NPerBlock / NThreads;
             static_assert(NPerBlock == NThreads * NPerThread);
 
-            constexpr auto KThreadWrite     = Problem::kBlockSize / NThreads;
-            constexpr auto K0PerThreadWrite = KIterPerWarp / KThreadWrite;
-            constexpr auto KThreadRead      = 64 / WarpGemm::kN;
-            constexpr auto K0PerThreadRead  = KIterPerWarp / KThreadRead;
+            constexpr auto KPerThreadForWrite  = Problem::kBlockSize / NThreads;
+            constexpr auto K0PerThreadForWrite = KIterPerWarp / KPerThreadForWrite;
+            constexpr auto KPerThreadForRead   = 64 / WarpGemm::kN;
+            constexpr auto K0PerThreadForRead  = KIterPerWarp / KPerThreadForRead;
+
+            static_assert(KPerThreadForRead <= KIterPerWarp,
+                          "GEMM N warp tile size (WarpTile[1]) is too small");
+
+            static_assert(KIterPerWarp == K0PerThreadForWrite * KPerThreadForWrite);
+            static_assert(KIterPerWarp == K0PerThreadForRead * KPerThreadForRead);
 
             constexpr auto kfold = (KPerWarp * NThreads * sizeof(BDataType) > 128)
                                        ? 1
                                        : 128 / (KPerWarp * NThreads * sizeof(BDataType));
-            constexpr auto KThreadReadPerm =
-                (kfold * K0PerThreadWrite / K0PerThreadRead) > 1
-                    ? KThreadRead / (kfold * K0PerThreadWrite / K0PerThreadRead)
-                    : KThreadRead;
+            constexpr auto KPerThreadForReadPerm =
+                (kfold * K0PerThreadForWrite / K0PerThreadForRead) > 1
+                    ? KPerThreadForRead / (kfold * K0PerThreadForWrite / K0PerThreadForRead)
+                    : KPerThreadForRead;
 
             // 1<=npair<=kN0
             constexpr auto npair =
@@ -262,9 +276,9 @@ struct UniversalGemmPipelineAgBgCrPolicy
                            : 128 / (KPerWarp * WarpGemm::kN * sizeof(BDataType)));
 
             constexpr auto b_lds_block_desc = make_naive_tensor_descriptor_packed(
-                make_tuple(number<KThreadWrite / kfold / KThreadReadPerm>{},
-                           number<K0PerThreadWrite>{},
-                           number<KThreadReadPerm * NPerThread>{},
+                make_tuple(number<KPerThreadForWrite / kfold / KPerThreadForReadPerm>{},
+                           number<K0PerThreadForWrite>{},
+                           number<KPerThreadForReadPerm * NPerThread>{},
                            number<kfold * NThreads / npair>{},
                            number<npair>{},
                            KPerWarp));
@@ -272,9 +286,10 @@ struct UniversalGemmPipelineAgBgCrPolicy
             constexpr auto b_lds_block_desc_permuted = transform_tensor_descriptor(
                 b_lds_block_desc,
                 make_tuple(
-                    make_pass_through_transform(number<KThreadWrite / kfold / KThreadReadPerm>{}),
-                    make_pass_through_transform(number<K0PerThreadWrite>{}),
-                    make_xor_transform(make_tuple(number<KThreadReadPerm * NPerThread>{},
+                    make_pass_through_transform(
+                        number<KPerThreadForWrite / kfold / KPerThreadForReadPerm>{}),
+                    make_pass_through_transform(number<K0PerThreadForWrite>{}),
+                    make_xor_transform(make_tuple(number<KPerThreadForReadPerm * NPerThread>{},
                                                   number<kfold * NThreads / npair>{})),
                     make_pass_through_transform(number<npair>{}),
                     make_pass_through_transform(KPerWarp)),
@@ -286,10 +301,11 @@ struct UniversalGemmPipelineAgBgCrPolicy
             constexpr auto b_lds_block_desc_unmerged = transform_tensor_descriptor(
                 b_lds_block_desc_permuted,
                 make_tuple(
-                    make_pass_through_transform(number<KThreadWrite / kfold / KThreadReadPerm>{}),
-                    make_pass_through_transform(number<K0PerThreadWrite>{}),
+                    make_pass_through_transform(
+                        number<KPerThreadForWrite / kfold / KPerThreadForReadPerm>{}),
+                    make_pass_through_transform(number<K0PerThreadForWrite>{}),
                     make_unmerge_transform(
-                        make_tuple(number<KThreadReadPerm>{}, number<NPerThread>{})),
+                        make_tuple(number<KPerThreadForReadPerm>{}, number<NPerThread>{})),
                     make_unmerge_transform(make_tuple(number<kfold>{}, number<NThreads / npair>{})),
                     make_pass_through_transform(number<npair>{}),
                     make_pass_through_transform(KPerWarp)),
@@ -308,12 +324,12 @@ struct UniversalGemmPipelineAgBgCrPolicy
 
             constexpr auto b_lds_block_desc_n_k = transform_tensor_descriptor(
                 b_lds_block_desc_unmerged,
-                make_tuple(make_merge_transform_v3_division_mod(
-                               make_tuple(number<KThreadReadPerm>{},
-                                          number<KThreadWrite / kfold / KThreadReadPerm>{},
-                                          number<kfold>{},
-                                          number<K0PerThreadWrite>{},
-                                          KPerWarp)),
+                make_tuple(make_merge_transform_v3_division_mod(make_tuple(
+                               number<KPerThreadForReadPerm>{},
+                               number<KPerThreadForWrite / kfold / KPerThreadForReadPerm>{},
+                               number<kfold>{},
+                               number<K0PerThreadForWrite>{},
+                               KPerWarp)),
                            make_merge_transform_v3_division_mod(make_tuple(
                                number<NThreads / npair>{}, number<npair>{}, number<NPerThread>{}))),
                 make_tuple(sequence<0, 1, 4, 2, 7>{}, sequence<5, 6, 3>{}),

--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -37,9 +37,10 @@ struct UniversalGemmPipelineAgBgCrPolicy
 
         constexpr index_t MPerBlock = Problem::BlockGemmShape::kM;
         constexpr index_t KPerBlock = Problem::BlockGemmShape::kK;
-        constexpr index_t K1        = WarpGemm::kK;
-        constexpr index_t K0        = KPerBlock / K1;
-        static_assert(KPerBlock == K0 * K1);
+
+        constexpr index_t KPerWarp     = WarpGemm::kK;
+        constexpr index_t KIterPerWarp = KPerBlock / KPerWarp;
+        static_assert(KPerBlock == KIterPerWarp * KPerWarp);
 
         if constexpr(std::is_same<tensor_layout::gemm::RowMajor, LayoutA>::value)
         {
@@ -47,28 +48,29 @@ struct UniversalGemmPipelineAgBgCrPolicy
                                                   ? 1
                                                   : 32 * 4 / KPerBlock / sizeof(ADataType);
             constexpr auto a_lds_block_desc = make_naive_tensor_descriptor(
-                make_tuple(K0 * number<MLdsLayer>{}, number<MPerBlock / MLdsLayer>{}, K1),
-                make_tuple(K1, number<KPerBlock * MLdsLayer>{}, I1));
+                make_tuple(
+                    KIterPerWarp * number<MLdsLayer>{}, number<MPerBlock / MLdsLayer>{}, KPerWarp),
+                make_tuple(KPerWarp, number<KPerBlock * MLdsLayer>{}, I1));
 
             constexpr auto a_lds_block_desc_permuted = transform_tensor_descriptor(
                 a_lds_block_desc,
                 make_tuple(make_xor_transform(make_tuple(number<MPerBlock / MLdsLayer>{},
-                                                         number<K0 * MLdsLayer>{})),
-                           make_pass_through_transform(K1)),
+                                                         number<KIterPerWarp * MLdsLayer>{})),
+                           make_pass_through_transform(KPerWarp)),
                 make_tuple(sequence<1, 0>{}, sequence<2>{}),
                 make_tuple(sequence<1, 0>{}, sequence<2>{}));
 
             constexpr auto a_lds_block_desc_ak0_kMLdsLayer_m_ak1 = transform_tensor_descriptor(
                 a_lds_block_desc_permuted,
-                make_tuple(make_unmerge_transform(make_tuple(K0, number<MLdsLayer>{})),
+                make_tuple(make_unmerge_transform(make_tuple(KIterPerWarp, number<MLdsLayer>{})),
                            make_pass_through_transform(number<MPerBlock / MLdsLayer>{}),
-                           make_pass_through_transform(K1)),
+                           make_pass_through_transform(KPerWarp)),
                 make_tuple(sequence<0>{}, sequence<1>{}, sequence<2>{}),
                 make_tuple(sequence<0, 2>{}, sequence<1>{}, sequence<3>{}));
 
             constexpr auto a_lds_block_desc_m_k = transform_tensor_descriptor(
                 a_lds_block_desc_ak0_kMLdsLayer_m_ak1,
-                make_tuple(make_merge_transform_v3_division_mod(make_tuple(K0, K1)),
+                make_tuple(make_merge_transform_v3_division_mod(make_tuple(KIterPerWarp, KPerWarp)),
                            make_merge_transform_v3_division_mod(
                                make_tuple(number<MPerBlock / MLdsLayer>{}, number<MLdsLayer>{}))),
                 make_tuple(sequence<0, 3>{}, sequence<1, 2>{}),
@@ -86,24 +88,25 @@ struct UniversalGemmPipelineAgBgCrPolicy
             static_assert(MPerBlock == MThreads * MPerThread);
 
             constexpr auto KThreadWrite     = Problem::kBlockSize / MThreads;
-            constexpr auto K0PerThreadWrite = K0 / KThreadWrite;
+            constexpr auto K0PerThreadWrite = KIterPerWarp / KThreadWrite;
             constexpr auto KThreadRead      = 64 / WarpGemm::kM;
-            constexpr auto K0PerThreadRead  = K0 / KThreadRead;
+            constexpr auto K0PerThreadRead  = KIterPerWarp / KThreadRead;
 
-            constexpr auto kfold = (K1 * MThreads * sizeof(ADataType) > 128)
+            constexpr auto kfold = (KPerWarp * MThreads * sizeof(ADataType) > 128)
                                        ? 1
-                                       : 128 / (K1 * MThreads * sizeof(ADataType));
+                                       : 128 / (KPerWarp * MThreads * sizeof(ADataType));
             constexpr auto KThreadReadPerm =
                 (kfold * K0PerThreadWrite / K0PerThreadRead) > 1
                     ? KThreadRead / (kfold * K0PerThreadWrite / K0PerThreadRead)
                     : KThreadRead;
 
             // 1<=mpair<=kN0
-            constexpr auto mpair = (K1 * WarpGemm::kM * sizeof(ADataType) > 128)
-                                       ? 1
-                                       : ((128 / (K1 * WarpGemm::kM * sizeof(ADataType))) > MThreads
-                                              ? MThreads
-                                              : 128 / (K1 * WarpGemm::kM * sizeof(ADataType)));
+            constexpr auto mpair =
+                (KPerWarp * WarpGemm::kM * sizeof(ADataType) > 128)
+                    ? 1
+                    : ((128 / (KPerWarp * WarpGemm::kM * sizeof(ADataType))) > MThreads
+                           ? MThreads
+                           : 128 / (KPerWarp * WarpGemm::kM * sizeof(ADataType)));
 
             constexpr auto a_lds_block_desc = make_naive_tensor_descriptor_packed(
                 make_tuple(number<KThreadWrite / kfold / KThreadReadPerm>{},
@@ -111,7 +114,7 @@ struct UniversalGemmPipelineAgBgCrPolicy
                            number<KThreadReadPerm * MPerThread>{},
                            number<kfold * MThreads / mpair>{},
                            number<mpair>{},
-                           K1));
+                           KPerWarp));
 
             constexpr auto a_lds_block_desc_permuted = transform_tensor_descriptor(
                 a_lds_block_desc,
@@ -121,7 +124,7 @@ struct UniversalGemmPipelineAgBgCrPolicy
                     make_xor_transform(make_tuple(number<KThreadReadPerm * MPerThread>{},
                                                   number<kfold * MThreads / mpair>{})),
                     make_pass_through_transform(number<mpair>{}),
-                    make_pass_through_transform(K1)),
+                    make_pass_through_transform(KPerWarp)),
                 make_tuple(
                     sequence<0>{}, sequence<1>{}, sequence<2, 3>{}, sequence<4>{}, sequence<5>{}),
                 make_tuple(
@@ -136,7 +139,7 @@ struct UniversalGemmPipelineAgBgCrPolicy
                         make_tuple(number<KThreadReadPerm>{}, number<MPerThread>{})),
                     make_unmerge_transform(make_tuple(number<kfold>{}, number<MThreads / mpair>{})),
                     make_pass_through_transform(number<mpair>{}),
-                    make_pass_through_transform(K1)),
+                    make_pass_through_transform(KPerWarp)),
                 make_tuple(sequence<0>{},
                            sequence<1>{},
                            sequence<2>{},
@@ -157,7 +160,7 @@ struct UniversalGemmPipelineAgBgCrPolicy
                                           number<KThreadWrite / kfold / KThreadReadPerm>{},
                                           number<kfold>{},
                                           number<K0PerThreadWrite>{},
-                                          K1)),
+                                          KPerWarp)),
                            make_merge_transform_v3_division_mod(make_tuple(
                                number<MThreads / mpair>{}, number<mpair>{}, number<MPerThread>{}))),
                 make_tuple(sequence<0, 1, 4, 2, 7>{}, sequence<5, 6, 3>{}),
@@ -183,40 +186,41 @@ struct UniversalGemmPipelineAgBgCrPolicy
         constexpr index_t NPerBlock = Problem::BlockGemmShape::kN;
         constexpr index_t KPerBlock = Problem::BlockGemmShape::kK;
 
-        constexpr index_t K1 = WarpGemm::kK;
-        constexpr index_t K0 = KPerBlock / K1;
-        static_assert(KPerBlock == K0 * K1);
+        constexpr index_t KPerWarp     = WarpGemm::kK;
+        constexpr index_t KIterPerWarp = KPerBlock / KPerWarp;
+        static_assert(KPerBlock == KIterPerWarp * KPerWarp);
 
         if constexpr(std::is_same<tensor_layout::gemm::ColumnMajor, LayoutB>::value)
         {
-            // NLdsLayer * K0 as logical Bank
+            // NLdsLayer * KIterPerWarp as logical Bank
             constexpr auto NLdsLayer = 32 * 4 / KPerBlock / sizeof(BDataType) < 1
                                            ? 1
                                            : 32 * 4 / KPerBlock / sizeof(BDataType);
             ;
             constexpr auto b_lds_block_desc = make_naive_tensor_descriptor(
-                make_tuple(K0 * number<NLdsLayer>{}, number<NPerBlock / NLdsLayer>{}, K1),
-                make_tuple(K1, number<KPerBlock * NLdsLayer>{}, I1));
+                make_tuple(
+                    KIterPerWarp * number<NLdsLayer>{}, number<NPerBlock / NLdsLayer>{}, KPerWarp),
+                make_tuple(KPerWarp, number<KPerBlock * NLdsLayer>{}, I1));
 
             constexpr auto b_lds_block_desc_permuted = transform_tensor_descriptor(
                 b_lds_block_desc,
                 make_tuple(make_xor_transform(make_tuple(number<NPerBlock / NLdsLayer>{},
-                                                         number<K0 * NLdsLayer>{})),
-                           make_pass_through_transform(K1)),
+                                                         number<KIterPerWarp * NLdsLayer>{})),
+                           make_pass_through_transform(KPerWarp)),
                 make_tuple(sequence<1, 0>{}, sequence<2>{}),
                 make_tuple(sequence<1, 0>{}, sequence<2>{}));
 
             constexpr auto b_lds_block_desc_bk0_kNLdsLayer_n_bk1 = transform_tensor_descriptor(
                 b_lds_block_desc_permuted,
-                make_tuple(make_unmerge_transform(make_tuple(K0, number<NLdsLayer>{})),
+                make_tuple(make_unmerge_transform(make_tuple(KIterPerWarp, number<NLdsLayer>{})),
                            make_pass_through_transform(number<NPerBlock / NLdsLayer>{}),
-                           make_pass_through_transform(K1)),
+                           make_pass_through_transform(KPerWarp)),
                 make_tuple(sequence<0>{}, sequence<1>{}, sequence<2>{}),
                 make_tuple(sequence<0, 2>{}, sequence<1>{}, sequence<3>{}));
 
             constexpr auto b_lds_block_desc_n_k = transform_tensor_descriptor(
                 b_lds_block_desc_bk0_kNLdsLayer_n_bk1,
-                make_tuple(make_merge_transform_v3_division_mod(make_tuple(K0, K1)),
+                make_tuple(make_merge_transform_v3_division_mod(make_tuple(KIterPerWarp, KPerWarp)),
                            make_merge_transform_v3_division_mod(
                                make_tuple(number<NPerBlock / NLdsLayer>{}, number<NLdsLayer>{}))),
                 make_tuple(sequence<0, 3>{}, sequence<1, 2>{}),
@@ -231,24 +235,25 @@ struct UniversalGemmPipelineAgBgCrPolicy
             static_assert(NPerBlock == NThreads * NPerThread);
 
             constexpr auto KThreadWrite     = Problem::kBlockSize / NThreads;
-            constexpr auto K0PerThreadWrite = K0 / KThreadWrite;
+            constexpr auto K0PerThreadWrite = KIterPerWarp / KThreadWrite;
             constexpr auto KThreadRead      = 64 / WarpGemm::kN;
-            constexpr auto K0PerThreadRead  = K0 / KThreadRead;
+            constexpr auto K0PerThreadRead  = KIterPerWarp / KThreadRead;
 
-            constexpr auto kfold = (K1 * NThreads * sizeof(BDataType) > 128)
+            constexpr auto kfold = (KPerWarp * NThreads * sizeof(BDataType) > 128)
                                        ? 1
-                                       : 128 / (K1 * NThreads * sizeof(BDataType));
+                                       : 128 / (KPerWarp * NThreads * sizeof(BDataType));
             constexpr auto KThreadReadPerm =
                 (kfold * K0PerThreadWrite / K0PerThreadRead) > 1
                     ? KThreadRead / (kfold * K0PerThreadWrite / K0PerThreadRead)
                     : KThreadRead;
 
             // 1<=npair<=kN0
-            constexpr auto npair = (K1 * WarpGemm::kN * sizeof(BDataType) > 128)
-                                       ? 1
-                                       : ((128 / (K1 * WarpGemm::kN * sizeof(BDataType))) > NThreads
-                                              ? NThreads
-                                              : 128 / (K1 * WarpGemm::kN * sizeof(BDataType)));
+            constexpr auto npair =
+                (KPerWarp * WarpGemm::kN * sizeof(BDataType) > 128)
+                    ? 1
+                    : ((128 / (KPerWarp * WarpGemm::kN * sizeof(BDataType))) > NThreads
+                           ? NThreads
+                           : 128 / (KPerWarp * WarpGemm::kN * sizeof(BDataType)));
 
             constexpr auto b_lds_block_desc = make_naive_tensor_descriptor_packed(
                 make_tuple(number<KThreadWrite / kfold / KThreadReadPerm>{},
@@ -256,7 +261,7 @@ struct UniversalGemmPipelineAgBgCrPolicy
                            number<KThreadReadPerm * NPerThread>{},
                            number<kfold * NThreads / npair>{},
                            number<npair>{},
-                           K1));
+                           KPerWarp));
 
             constexpr auto b_lds_block_desc_permuted = transform_tensor_descriptor(
                 b_lds_block_desc,
@@ -266,7 +271,7 @@ struct UniversalGemmPipelineAgBgCrPolicy
                     make_xor_transform(make_tuple(number<KThreadReadPerm * NPerThread>{},
                                                   number<kfold * NThreads / npair>{})),
                     make_pass_through_transform(number<npair>{}),
-                    make_pass_through_transform(K1)),
+                    make_pass_through_transform(KPerWarp)),
                 make_tuple(
                     sequence<0>{}, sequence<1>{}, sequence<2, 3>{}, sequence<4>{}, sequence<5>{}),
                 make_tuple(
@@ -281,7 +286,7 @@ struct UniversalGemmPipelineAgBgCrPolicy
                         make_tuple(number<KThreadReadPerm>{}, number<NPerThread>{})),
                     make_unmerge_transform(make_tuple(number<kfold>{}, number<NThreads / npair>{})),
                     make_pass_through_transform(number<npair>{}),
-                    make_pass_through_transform(K1)),
+                    make_pass_through_transform(KPerWarp)),
                 make_tuple(sequence<0>{},
                            sequence<1>{},
                            sequence<2>{},
@@ -302,7 +307,7 @@ struct UniversalGemmPipelineAgBgCrPolicy
                                           number<KThreadWrite / kfold / KThreadReadPerm>{},
                                           number<kfold>{},
                                           number<K0PerThreadWrite>{},
-                                          K1)),
+                                          KPerWarp)),
                            make_merge_transform_v3_division_mod(make_tuple(
                                number<NThreads / npair>{}, number<npair>{}, number<NPerThread>{}))),
                 make_tuple(sequence<0, 1, 4, 2, 7>{}, sequence<5, 6, 3>{}),
@@ -355,18 +360,19 @@ struct UniversalGemmPipelineAgBgCrPolicy
         constexpr index_t MPerBlock = Problem::BlockGemmShape::kM;
         constexpr index_t KPerBlock = Problem::BlockGemmShape::kK;
 
-        constexpr index_t K1 = WarpGemm::kK;
-        constexpr index_t K0 = KPerBlock / K1;
-        constexpr index_t M2 = get_warp_size() / K0;
-        static_assert(KPerBlock == K0 * K1);
+        constexpr index_t KPerWarp     = WarpGemm::kK;
+        constexpr index_t KIterPerWarp = KPerBlock / KPerWarp;
+        static_assert(KPerBlock == KIterPerWarp * KPerWarp);
 
-        constexpr index_t M1 = BlockSize / get_warp_size();
-        constexpr index_t M0 = MPerBlock / (M2 * M1);
-        static_assert(MPerBlock == M0 * M1 * M2);
+        constexpr index_t MThreadPerWarp = get_warp_size() / KIterPerWarp;
+        constexpr index_t NumWarps       = BlockSize / get_warp_size();
+        constexpr index_t MPerThread     = MPerBlock / (MThreadPerWarp * NumWarps);
+        static_assert(MPerBlock == MPerThread * NumWarps * MThreadPerWarp);
 
         return make_static_tile_distribution(
             tile_distribution_encoding<sequence<1>,
-                                       tuple<sequence<M0, M1, M2>, sequence<K0, K1>>,
+                                       tuple<sequence<MPerThread, NumWarps, MThreadPerWarp>,
+                                             sequence<KIterPerWarp, KPerWarp>>,
                                        tuple<sequence<1>, sequence<1, 2>>,
                                        tuple<sequence<1>, sequence<2, 0>>,
                                        sequence<1, 2>,
@@ -389,18 +395,19 @@ struct UniversalGemmPipelineAgBgCrPolicy
         constexpr index_t NPerBlock = Problem::BlockGemmShape::kN;
         constexpr index_t KPerBlock = Problem::BlockGemmShape::kK;
 
-        constexpr index_t K1 = WarpGemm::kK;
-        constexpr index_t K0 = KPerBlock / K1;
-        constexpr index_t N2 = get_warp_size() / K0;
-        static_assert(KPerBlock == K0 * K1);
+        constexpr index_t KPerWarp     = WarpGemm::kK;
+        constexpr index_t KIterPerWarp = KPerBlock / KPerWarp;
+        static_assert(KPerBlock == KIterPerWarp * KPerWarp);
 
-        constexpr index_t N1 = BlockSize / get_warp_size();
-        constexpr index_t N0 = NPerBlock / (N2 * N1);
-        static_assert(NPerBlock == N0 * N1 * N2);
+        constexpr index_t NThreadPerWarp = get_warp_size() / KIterPerWarp;
+        constexpr index_t NumWarps       = BlockSize / get_warp_size();
+        constexpr index_t NPerThread     = NPerBlock / (NThreadPerWarp * NumWarps);
+        static_assert(NPerBlock == NPerThread * NumWarps * NThreadPerWarp);
 
         return make_static_tile_distribution(
             tile_distribution_encoding<sequence<1>,
-                                       tuple<sequence<N0, N1, N2>, sequence<K0, K1>>,
+                                       tuple<sequence<NPerThread, NumWarps, NThreadPerWarp>,
+                                             sequence<KIterPerWarp, KPerWarp>>,
                                        tuple<sequence<1>, sequence<1, 2>>,
                                        tuple<sequence<1>, sequence<2, 0>>,
                                        sequence<1, 2>,

--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -94,18 +94,24 @@ struct UniversalGemmPipelineAgBgCrPolicy
             constexpr auto MPerThread = MPerBlock / MThreads;
             static_assert(MPerBlock == MThreads * MPerThread);
 
-            constexpr auto KThreadWrite     = Problem::kBlockSize / MThreads;
-            constexpr auto K0PerThreadWrite = KIterPerWarp / KThreadWrite;
-            constexpr auto KThreadRead      = 64 / WarpGemm::kM;
-            constexpr auto K0PerThreadRead  = KIterPerWarp / KThreadRead;
+            constexpr auto KPerThreadForWrite  = Problem::kBlockSize / MThreads;
+            constexpr auto K0PerThreadForWrite = KIterPerWarp / KPerThreadForWrite;
+            constexpr auto KPerThreadForRead   = 64 / WarpGemm::kM;
+            constexpr auto K0PerThreadForRead  = KIterPerWarp / KPerThreadForRead;
+
+            static_assert(KPerThreadForRead <= KIterPerWarp,
+                          "GEMM M warp tile size (WarpTile[0]) is too small");
+
+            static_assert(KIterPerWarp == K0PerThreadForWrite * KPerThreadForWrite);
+            static_assert(KIterPerWarp == K0PerThreadForRead * KPerThreadForRead);
 
             constexpr auto kfold = (KPerWarp * MThreads * sizeof(ADataType) > 128)
                                        ? 1
                                        : 128 / (KPerWarp * MThreads * sizeof(ADataType));
-            constexpr auto KThreadReadPerm =
-                (kfold * K0PerThreadWrite / K0PerThreadRead) > 1
-                    ? KThreadRead / (kfold * K0PerThreadWrite / K0PerThreadRead)
-                    : KThreadRead;
+            constexpr auto KPerThreadForReadPerm =
+                (kfold * K0PerThreadForWrite / K0PerThreadForRead) > 1
+                    ? KPerThreadForRead / (kfold * K0PerThreadForWrite / K0PerThreadForRead)
+                    : KPerThreadForRead;
 
             // 1<=mpair<=kN0
             constexpr auto mpair =
@@ -116,9 +122,9 @@ struct UniversalGemmPipelineAgBgCrPolicy
                            : 128 / (KPerWarp * WarpGemm::kM * sizeof(ADataType)));
 
             constexpr auto a_lds_block_desc = make_naive_tensor_descriptor_packed(
-                make_tuple(number<KThreadWrite / kfold / KThreadReadPerm>{},
-                           number<K0PerThreadWrite>{},
-                           number<KThreadReadPerm * MPerThread>{},
+                make_tuple(number<KPerThreadForWrite / kfold / KPerThreadForReadPerm>{},
+                           number<K0PerThreadForWrite>{},
+                           number<KPerThreadForReadPerm * MPerThread>{},
                            number<kfold * MThreads / mpair>{},
                            number<mpair>{},
                            KPerWarp));
@@ -126,9 +132,10 @@ struct UniversalGemmPipelineAgBgCrPolicy
             constexpr auto a_lds_block_desc_permuted = transform_tensor_descriptor(
                 a_lds_block_desc,
                 make_tuple(
-                    make_pass_through_transform(number<KThreadWrite / kfold / KThreadReadPerm>{}),
-                    make_pass_through_transform(number<K0PerThreadWrite>{}),
-                    make_xor_transform(make_tuple(number<KThreadReadPerm * MPerThread>{},
+                    make_pass_through_transform(
+                        number<KPerThreadForWrite / kfold / KPerThreadForReadPerm>{}),
+                    make_pass_through_transform(number<K0PerThreadForWrite>{}),
+                    make_xor_transform(make_tuple(number<KPerThreadForReadPerm * MPerThread>{},
                                                   number<kfold * MThreads / mpair>{})),
                     make_pass_through_transform(number<mpair>{}),
                     make_pass_through_transform(KPerWarp)),
@@ -140,10 +147,11 @@ struct UniversalGemmPipelineAgBgCrPolicy
             constexpr auto a_lds_block_desc_unmerged = transform_tensor_descriptor(
                 a_lds_block_desc_permuted,
                 make_tuple(
-                    make_pass_through_transform(number<KThreadWrite / kfold / KThreadReadPerm>{}),
-                    make_pass_through_transform(number<K0PerThreadWrite>{}),
+                    make_pass_through_transform(
+                        number<KPerThreadForWrite / kfold / KPerThreadForReadPerm>{}),
+                    make_pass_through_transform(number<K0PerThreadForWrite>{}),
                     make_unmerge_transform(
-                        make_tuple(number<KThreadReadPerm>{}, number<MPerThread>{})),
+                        make_tuple(number<KPerThreadForReadPerm>{}, number<MPerThread>{})),
                     make_unmerge_transform(make_tuple(number<kfold>{}, number<MThreads / mpair>{})),
                     make_pass_through_transform(number<mpair>{}),
                     make_pass_through_transform(KPerWarp)),
@@ -162,12 +170,12 @@ struct UniversalGemmPipelineAgBgCrPolicy
 
             constexpr auto a_lds_block_desc_m_k = transform_tensor_descriptor(
                 a_lds_block_desc_unmerged,
-                make_tuple(make_merge_transform_v3_division_mod(
-                               make_tuple(number<KThreadReadPerm>{},
-                                          number<KThreadWrite / kfold / KThreadReadPerm>{},
-                                          number<kfold>{},
-                                          number<K0PerThreadWrite>{},
-                                          KPerWarp)),
+                make_tuple(make_merge_transform_v3_division_mod(make_tuple(
+                               number<KPerThreadForReadPerm>{},
+                               number<KPerThreadForWrite / kfold / KPerThreadForReadPerm>{},
+                               number<kfold>{},
+                               number<K0PerThreadForWrite>{},
+                               KPerWarp)),
                            make_merge_transform_v3_division_mod(make_tuple(
                                number<MThreads / mpair>{}, number<mpair>{}, number<MPerThread>{}))),
                 make_tuple(sequence<0, 1, 4, 2, 7>{}, sequence<5, 6, 3>{}),

--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -96,7 +96,7 @@ struct UniversalGemmPipelineAgBgCrPolicy
 
             constexpr auto KPerThreadForWrite  = Problem::kBlockSize / MThreads;
             constexpr auto K0PerThreadForWrite = KIterPerWarp / KPerThreadForWrite;
-            constexpr auto KPerThreadForRead   = 64 / WarpGemm::kM;
+            constexpr auto KPerThreadForRead   = get_warp_size() / WarpGemm::kM;
             constexpr auto K0PerThreadForRead  = KIterPerWarp / KPerThreadForRead;
 
             static_assert(KPerThreadForRead <= KIterPerWarp,
@@ -258,7 +258,7 @@ struct UniversalGemmPipelineAgBgCrPolicy
 
             constexpr auto KPerThreadForWrite  = Problem::kBlockSize / NThreads;
             constexpr auto K0PerThreadForWrite = KIterPerWarp / KPerThreadForWrite;
-            constexpr auto KPerThreadForRead   = 64 / WarpGemm::kN;
+            constexpr auto KPerThreadForRead   = get_warp_size() / WarpGemm::kN;
             constexpr auto K0PerThreadForRead  = KIterPerWarp / KPerThreadForRead;
 
             static_assert(KPerThreadForRead <= KIterPerWarp,

--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -39,6 +39,7 @@ struct UniversalGemmPipelineAgBgCrPolicy
         constexpr index_t KPerBlock = Problem::BlockGemmShape::kK;
         constexpr index_t K1        = WarpGemm::kK;
         constexpr index_t K0        = KPerBlock / K1;
+        static_assert(KPerBlock == K0 * K1);
 
         if constexpr(std::is_same<tensor_layout::gemm::RowMajor, LayoutA>::value)
         {
@@ -82,6 +83,7 @@ struct UniversalGemmPipelineAgBgCrPolicy
             // for compiler.
             constexpr auto M0 = get_warp_size() * Problem::BlockGemmShape::BlockWarps::at(I0);
             constexpr auto M1 = MPerBlock / M0;
+            static_assert(MPerBlock == M0 * M1);
 
             constexpr auto KThreadWrite     = Problem::kBlockSize / M0;
             constexpr auto K0PerThreadWrite = K0 / KThreadWrite;
@@ -181,6 +183,7 @@ struct UniversalGemmPipelineAgBgCrPolicy
 
         constexpr index_t K1 = WarpGemm::kK;
         constexpr index_t K0 = KPerBlock / K1;
+        static_assert(KPerBlock == K0 * K1);
 
         if constexpr(std::is_same<tensor_layout::gemm::ColumnMajor, LayoutB>::value)
         {
@@ -223,6 +226,7 @@ struct UniversalGemmPipelineAgBgCrPolicy
         {
             constexpr auto N0 = get_warp_size() * Problem::BlockGemmShape::BlockWarps::at(I1);
             constexpr auto N1 = NPerBlock / N0;
+            static_assert(NPerBlock == N0 * N1);
 
             constexpr auto KThreadWrite     = Problem::kBlockSize / N0;
             constexpr auto K0PerThreadWrite = K0 / KThreadWrite;

--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -105,9 +105,12 @@ struct UniversalGemmPipelineAgBgCrPolicy
             static_assert(KIterPerWarp == K0PerThreadForWrite * KPerThreadForWrite);
             static_assert(KIterPerWarp == K0PerThreadForRead * KPerThreadForRead);
 
-            constexpr auto kfold = (KPerWarp * MThreads * sizeof(ADataType) > 128)
+            // # bytes per 32 LDS banks: 32 * 4 bytes
+            constexpr auto BankLength = 128;
+
+            constexpr auto kfold = (KPerWarp * MThreads * sizeof(ADataType) > BankLength)
                                        ? 1
-                                       : 128 / (KPerWarp * MThreads * sizeof(ADataType));
+                                       : BankLength / (KPerWarp * MThreads * sizeof(ADataType));
             constexpr auto KPerThreadForReadPerm =
                 (kfold * K0PerThreadForWrite / K0PerThreadForRead) > 1
                     ? KPerThreadForRead / (kfold * K0PerThreadForWrite / K0PerThreadForRead)
@@ -115,11 +118,11 @@ struct UniversalGemmPipelineAgBgCrPolicy
 
             // 1<=mpair<=kN0
             constexpr auto mpair =
-                (KPerWarp * WarpGemm::kM * sizeof(ADataType) > 128)
+                (KPerWarp * WarpGemm::kM * sizeof(ADataType) > BankLength)
                     ? 1
-                    : ((128 / (KPerWarp * WarpGemm::kM * sizeof(ADataType))) > MThreads
+                    : ((BankLength / (KPerWarp * WarpGemm::kM * sizeof(ADataType))) > MThreads
                            ? MThreads
-                           : 128 / (KPerWarp * WarpGemm::kM * sizeof(ADataType)));
+                           : BankLength / (KPerWarp * WarpGemm::kM * sizeof(ADataType)));
 
             constexpr auto a_lds_block_desc = make_naive_tensor_descriptor_packed(
                 make_tuple(number<KPerThreadForWrite / kfold / KPerThreadForReadPerm>{},
@@ -267,9 +270,12 @@ struct UniversalGemmPipelineAgBgCrPolicy
             static_assert(KIterPerWarp == K0PerThreadForWrite * KPerThreadForWrite);
             static_assert(KIterPerWarp == K0PerThreadForRead * KPerThreadForRead);
 
-            constexpr auto kfold = (KPerWarp * NThreads * sizeof(BDataType) > 128)
+            // # bytes per 32 LDS banks: 32 * 4 bytes
+            constexpr auto BankLength = 128;
+
+            constexpr auto kfold = (KPerWarp * NThreads * sizeof(BDataType) > BankLength)
                                        ? 1
-                                       : 128 / (KPerWarp * NThreads * sizeof(BDataType));
+                                       : BankLength / (KPerWarp * NThreads * sizeof(BDataType));
             constexpr auto KPerThreadForReadPerm =
                 (kfold * K0PerThreadForWrite / K0PerThreadForRead) > 1
                     ? KPerThreadForRead / (kfold * K0PerThreadForWrite / K0PerThreadForRead)
@@ -277,11 +283,11 @@ struct UniversalGemmPipelineAgBgCrPolicy
 
             // 1<=npair<=kN0
             constexpr auto npair =
-                (KPerWarp * WarpGemm::kN * sizeof(BDataType) > 128)
+                (KPerWarp * WarpGemm::kN * sizeof(BDataType) > BankLength)
                     ? 1
-                    : ((128 / (KPerWarp * WarpGemm::kN * sizeof(BDataType))) > NThreads
+                    : ((BankLength / (KPerWarp * WarpGemm::kN * sizeof(BDataType))) > NThreads
                            ? NThreads
-                           : 128 / (KPerWarp * WarpGemm::kN * sizeof(BDataType)));
+                           : BankLength / (KPerWarp * WarpGemm::kN * sizeof(BDataType)));
 
             constexpr auto b_lds_block_desc = make_naive_tensor_descriptor_packed(
                 make_tuple(number<KPerThreadForWrite / kfold / KPerThreadForReadPerm>{},

--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -81,17 +81,18 @@ struct UniversalGemmPipelineAgBgCrPolicy
             // kfold and mpair dimension is not always required.
             // more dimension in merge_transform increase the difficulty of generating immarg offset
             // for compiler.
-            constexpr auto M0 = get_warp_size() * Problem::BlockGemmShape::BlockWarps::at(I0);
-            constexpr auto M1 = MPerBlock / M0;
-            static_assert(MPerBlock == M0 * M1);
+            constexpr auto MThreads = get_warp_size() * Problem::BlockGemmShape::BlockWarps::at(I0);
+            constexpr auto MPerThread = MPerBlock / MThreads;
+            static_assert(MPerBlock == MThreads * MPerThread);
 
-            constexpr auto KThreadWrite     = Problem::kBlockSize / M0;
+            constexpr auto KThreadWrite     = Problem::kBlockSize / MThreads;
             constexpr auto K0PerThreadWrite = K0 / KThreadWrite;
             constexpr auto KThreadRead      = 64 / WarpGemm::kM;
             constexpr auto K0PerThreadRead  = K0 / KThreadRead;
 
-            constexpr auto kfold =
-                (K1 * M0 * sizeof(ADataType) > 128) ? 1 : 128 / (K1 * M0 * sizeof(ADataType));
+            constexpr auto kfold = (K1 * MThreads * sizeof(ADataType) > 128)
+                                       ? 1
+                                       : 128 / (K1 * MThreads * sizeof(ADataType));
             constexpr auto KThreadReadPerm =
                 (kfold * K0PerThreadWrite / K0PerThreadRead) > 1
                     ? KThreadRead / (kfold * K0PerThreadWrite / K0PerThreadRead)
@@ -100,15 +101,15 @@ struct UniversalGemmPipelineAgBgCrPolicy
             // 1<=mpair<=kN0
             constexpr auto mpair = (K1 * WarpGemm::kM * sizeof(ADataType) > 128)
                                        ? 1
-                                       : ((128 / (K1 * WarpGemm::kM * sizeof(ADataType))) > M0
-                                              ? M0
+                                       : ((128 / (K1 * WarpGemm::kM * sizeof(ADataType))) > MThreads
+                                              ? MThreads
                                               : 128 / (K1 * WarpGemm::kM * sizeof(ADataType)));
 
             constexpr auto a_lds_block_desc = make_naive_tensor_descriptor_packed(
                 make_tuple(number<KThreadWrite / kfold / KThreadReadPerm>{},
                            number<K0PerThreadWrite>{},
-                           number<KThreadReadPerm * M1>{},
-                           number<kfold * M0 / mpair>{},
+                           number<KThreadReadPerm * MPerThread>{},
+                           number<kfold * MThreads / mpair>{},
                            number<mpair>{},
                            K1));
 
@@ -117,8 +118,8 @@ struct UniversalGemmPipelineAgBgCrPolicy
                 make_tuple(
                     make_pass_through_transform(number<KThreadWrite / kfold / KThreadReadPerm>{}),
                     make_pass_through_transform(number<K0PerThreadWrite>{}),
-                    make_xor_transform(
-                        make_tuple(number<KThreadReadPerm * M1>{}, number<kfold * M0 / mpair>{})),
+                    make_xor_transform(make_tuple(number<KThreadReadPerm * MPerThread>{},
+                                                  number<kfold * MThreads / mpair>{})),
                     make_pass_through_transform(number<mpair>{}),
                     make_pass_through_transform(K1)),
                 make_tuple(
@@ -131,8 +132,9 @@ struct UniversalGemmPipelineAgBgCrPolicy
                 make_tuple(
                     make_pass_through_transform(number<KThreadWrite / kfold / KThreadReadPerm>{}),
                     make_pass_through_transform(number<K0PerThreadWrite>{}),
-                    make_unmerge_transform(make_tuple(number<KThreadReadPerm>{}, number<M1>{})),
-                    make_unmerge_transform(make_tuple(number<kfold>{}, number<M0 / mpair>{})),
+                    make_unmerge_transform(
+                        make_tuple(number<KThreadReadPerm>{}, number<MPerThread>{})),
+                    make_unmerge_transform(make_tuple(number<kfold>{}, number<MThreads / mpair>{})),
                     make_pass_through_transform(number<mpair>{}),
                     make_pass_through_transform(K1)),
                 make_tuple(sequence<0>{},
@@ -156,8 +158,8 @@ struct UniversalGemmPipelineAgBgCrPolicy
                                           number<kfold>{},
                                           number<K0PerThreadWrite>{},
                                           K1)),
-                           make_merge_transform_v3_division_mod(
-                               make_tuple(number<M0 / mpair>{}, number<mpair>{}, number<M1>{}))),
+                           make_merge_transform_v3_division_mod(make_tuple(
+                               number<MThreads / mpair>{}, number<mpair>{}, number<MPerThread>{}))),
                 make_tuple(sequence<0, 1, 4, 2, 7>{}, sequence<5, 6, 3>{}),
                 make_tuple(sequence<1>{}, sequence<0>{}));
 
@@ -224,17 +226,18 @@ struct UniversalGemmPipelineAgBgCrPolicy
         }
         else // RowMajor B
         {
-            constexpr auto N0 = get_warp_size() * Problem::BlockGemmShape::BlockWarps::at(I1);
-            constexpr auto N1 = NPerBlock / N0;
-            static_assert(NPerBlock == N0 * N1);
+            constexpr auto NThreads = get_warp_size() * Problem::BlockGemmShape::BlockWarps::at(I1);
+            constexpr auto NPerThread = NPerBlock / NThreads;
+            static_assert(NPerBlock == NThreads * NPerThread);
 
-            constexpr auto KThreadWrite     = Problem::kBlockSize / N0;
+            constexpr auto KThreadWrite     = Problem::kBlockSize / NThreads;
             constexpr auto K0PerThreadWrite = K0 / KThreadWrite;
             constexpr auto KThreadRead      = 64 / WarpGemm::kN;
             constexpr auto K0PerThreadRead  = K0 / KThreadRead;
 
-            constexpr auto kfold =
-                (K1 * N0 * sizeof(BDataType) > 128) ? 1 : 128 / (K1 * N0 * sizeof(BDataType));
+            constexpr auto kfold = (K1 * NThreads * sizeof(BDataType) > 128)
+                                       ? 1
+                                       : 128 / (K1 * NThreads * sizeof(BDataType));
             constexpr auto KThreadReadPerm =
                 (kfold * K0PerThreadWrite / K0PerThreadRead) > 1
                     ? KThreadRead / (kfold * K0PerThreadWrite / K0PerThreadRead)
@@ -243,15 +246,15 @@ struct UniversalGemmPipelineAgBgCrPolicy
             // 1<=npair<=kN0
             constexpr auto npair = (K1 * WarpGemm::kN * sizeof(BDataType) > 128)
                                        ? 1
-                                       : ((128 / (K1 * WarpGemm::kN * sizeof(BDataType))) > N0
-                                              ? N0
+                                       : ((128 / (K1 * WarpGemm::kN * sizeof(BDataType))) > NThreads
+                                              ? NThreads
                                               : 128 / (K1 * WarpGemm::kN * sizeof(BDataType)));
 
             constexpr auto b_lds_block_desc = make_naive_tensor_descriptor_packed(
                 make_tuple(number<KThreadWrite / kfold / KThreadReadPerm>{},
                            number<K0PerThreadWrite>{},
-                           number<KThreadReadPerm * N1>{},
-                           number<kfold * N0 / npair>{},
+                           number<KThreadReadPerm * NPerThread>{},
+                           number<kfold * NThreads / npair>{},
                            number<npair>{},
                            K1));
 
@@ -260,8 +263,8 @@ struct UniversalGemmPipelineAgBgCrPolicy
                 make_tuple(
                     make_pass_through_transform(number<KThreadWrite / kfold / KThreadReadPerm>{}),
                     make_pass_through_transform(number<K0PerThreadWrite>{}),
-                    make_xor_transform(
-                        make_tuple(number<KThreadReadPerm * N1>{}, number<kfold * N0 / npair>{})),
+                    make_xor_transform(make_tuple(number<KThreadReadPerm * NPerThread>{},
+                                                  number<kfold * NThreads / npair>{})),
                     make_pass_through_transform(number<npair>{}),
                     make_pass_through_transform(K1)),
                 make_tuple(
@@ -274,8 +277,9 @@ struct UniversalGemmPipelineAgBgCrPolicy
                 make_tuple(
                     make_pass_through_transform(number<KThreadWrite / kfold / KThreadReadPerm>{}),
                     make_pass_through_transform(number<K0PerThreadWrite>{}),
-                    make_unmerge_transform(make_tuple(number<KThreadReadPerm>{}, number<N1>{})),
-                    make_unmerge_transform(make_tuple(number<kfold>{}, number<N0 / npair>{})),
+                    make_unmerge_transform(
+                        make_tuple(number<KThreadReadPerm>{}, number<NPerThread>{})),
+                    make_unmerge_transform(make_tuple(number<kfold>{}, number<NThreads / npair>{})),
                     make_pass_through_transform(number<npair>{}),
                     make_pass_through_transform(K1)),
                 make_tuple(sequence<0>{},
@@ -299,8 +303,8 @@ struct UniversalGemmPipelineAgBgCrPolicy
                                           number<kfold>{},
                                           number<K0PerThreadWrite>{},
                                           K1)),
-                           make_merge_transform_v3_division_mod(
-                               make_tuple(number<N0 / npair>{}, number<npair>{}, number<N1>{}))),
+                           make_merge_transform_v3_division_mod(make_tuple(
+                               number<NThreads / npair>{}, number<npair>{}, number<NPerThread>{}))),
                 make_tuple(sequence<0, 1, 4, 2, 7>{}, sequence<5, 6, 3>{}),
                 make_tuple(sequence<1>{}, sequence<0>{}));
 
@@ -354,11 +358,11 @@ struct UniversalGemmPipelineAgBgCrPolicy
         constexpr index_t K1 = WarpGemm::kK;
         constexpr index_t K0 = KPerBlock / K1;
         constexpr index_t M2 = get_warp_size() / K0;
+        static_assert(KPerBlock == K0 * K1);
 
         constexpr index_t M1 = BlockSize / get_warp_size();
-        static_assert(M2 != 0, "M2 is zero, which will lead to a division by zero error.");
-        static_assert(M1 != 0, "M1 is zero, which will lead to a division by zero error.");
         constexpr index_t M0 = MPerBlock / (M2 * M1);
+        static_assert(MPerBlock == M0 * M1 * M2);
 
         return make_static_tile_distribution(
             tile_distribution_encoding<sequence<1>,
@@ -388,11 +392,11 @@ struct UniversalGemmPipelineAgBgCrPolicy
         constexpr index_t K1 = WarpGemm::kK;
         constexpr index_t K0 = KPerBlock / K1;
         constexpr index_t N2 = get_warp_size() / K0;
+        static_assert(KPerBlock == K0 * K1);
 
         constexpr index_t N1 = BlockSize / get_warp_size();
-        static_assert(N2 != 0, "M2 is zero, which will lead to a division by zero error.");
-        static_assert(N1 != 0, "M1 is zero, which will lead to a division by zero error.");
         constexpr index_t N0 = NPerBlock / (N2 * N1);
+        static_assert(NPerBlock == N0 * N1 * N2);
 
         return make_static_tile_distribution(
             tile_distribution_encoding<sequence<1>,


### PR DESCRIPTION
1. `UniversalGemmPipelineAgBgCrPolicy<>` related changes
   -  Sync variable naming style
   - Add more static assertions and provide diagnostic error messages
2. `GemmPipelineAGmemBGmemCRegV1DefaultPolicy<>` related changes
   - Avoid using default block gemm policies (which use hard-coded # of warps)
   - Allow using read vector size < 8 for data type=fp16/bf16
3. Example
   - Allow using default pipeline policy (to do this, define the macro `EXAMPLE_USE_UNIVERSAL_GEMM_PIPELINE_POLICY` as `0`)
4. Test scripts
   - Automatically find dependent script in _run_full_test.sh_
   - Remove invalid command argument in _smoke_test.sh_
5. Minor refactorings