### PR TITLE
Prevent instantiation of undefined FP8 operators.

### DIFF
--- a/example/44_elementwise_permute/elementwise_scale_permute_amax_2D_fp16_fp8.cpp
+++ b/example/44_elementwise_permute/elementwise_scale_permute_amax_2D_fp16_fp8.cpp
@@ -68,7 +68,7 @@ using DeviceElementwisePermuteInstance = ck::tensor_operation::device::DeviceEle
 
 using DeviceReduceInstance =
     ck::tensor_operation::device::DeviceReduceMultiBlock<OutputDataType,
-                                                         OutputDataType,
+                                                         ScaleDataType,
                                                          OutputDataType,
                                                          NumDim,
                                                          NumDim,
@@ -108,7 +108,8 @@ void reference_scale_permute_amax(Tensor<InputDataType>& input,
             host_output_scaled_casted_transposed(m, k) = y1;
             const OutputDataType y_fabs =
                 ck::type_convert<OutputDataType>(ck::math::abs(ck::type_convert<float>(y0)));
-            host_output_amax(0) = ck::math::max(y_fabs, host_output_amax(0));
+            host_output_amax(0) = ck::type_convert<OutputDataType>(ck::math::max(
+                ck::type_convert<float>(y_fabs), ck::type_convert<float>(host_output_amax(0))));
         }
     }
 }


### PR DESCRIPTION
Update the `44_elementwise_permute example/elementwise_scale_permute_amax_2D_fp16_fp8` example to prevent the instantiation of operators that are not defined on the FP8 data types.
Specifically, 
 1. `ck::math::max` is not correct as x > y operator is not defined for FP8 data types.
 2. `*=` `+=` `*` operators are not defined for FP8 operands but can be instantiated in gridwise_2d_reduction_multiblock.hpp (lines 241, 274)

The solution is to use FP32 as the accumulation data type.

Proposed changes improve reported performance by a factor of 3.7 (Perf: 0.396982 ms VS Perf: 1.45243 ms)