### PR TITLE
[BUGFix] Reorder GetSmemSize Related API

### DIFF
--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp
@@ -90,47 +90,6 @@ struct GemmPipelineAGmemBGmemCRegV1DefaultPolicy
 
         return b_lds_block_desc;
     }
-
-    template <typename Problem>
-    CK_TILE_HOST_DEVICE static constexpr index_t GetSmemSizeA()
-    {
-        constexpr index_t smem_size_a = sizeof(typename Problem::ADataType) *
-                                        MakeALdsBlockDescriptor<Problem>().get_element_space_size();
-        return smem_size_a;
-    }
-
-    template <typename Problem>
-    CK_TILE_HOST_DEVICE static constexpr index_t GetSmemSizeB()
-    {
-        constexpr index_t smem_size_b = sizeof(typename Problem::BDataType) *
-                                        MakeBLdsBlockDescriptor<Problem>().get_element_space_size();
-        return smem_size_b;
-    }
-
-    template <typename Problem>
-    CK_TILE_HOST_DEVICE static constexpr index_t GetSmemSize()
-    {
-        constexpr index_t smem_size_a = GetSmemSizeA<Problem>();
-        constexpr index_t smem_size_b = GetSmemSizeB<Problem>();
-        index_t smem_size             = 0;
-        smem_size += smem_size_a + smem_size_b;
-
-        return smem_size;
-    }
-
-    template <typename Problem>
-    CK_TILE_HOST_DEVICE static constexpr auto GetSmemPackA()
-    {
-        using ADataType = remove_cvref_t<typename Problem::ADataType>;
-        return Problem::VectorLoadSize / sizeof(ADataType);
-    }
-
-    template <typename Problem>
-    CK_TILE_HOST_DEVICE static constexpr auto GetSmemPackB()
-    {
-        using BDataType = remove_cvref_t<typename Problem::BDataType>;
-        return Problem::VectorLoadSize / sizeof(BDataType);
-    }
 #elif 1
     // fake XOR
     template <typename Problem>
@@ -202,6 +161,48 @@ struct GemmPipelineAGmemBGmemCRegV1DefaultPolicy
         return b_lds_block_desc_n_k;
     }
 #endif
+
+
+    template <typename Problem>
+    CK_TILE_HOST_DEVICE static constexpr index_t GetSmemSizeA()
+    {
+        constexpr index_t smem_size_a = sizeof(typename Problem::ADataType) *
+                                        MakeALdsBlockDescriptor<Problem>().get_element_space_size();
+        return smem_size_a;
+    }
+
+    template <typename Problem>
+    CK_TILE_HOST_DEVICE static constexpr index_t GetSmemSizeB()
+    {
+        constexpr index_t smem_size_b = sizeof(typename Problem::BDataType) *
+                                        MakeBLdsBlockDescriptor<Problem>().get_element_space_size();
+        return smem_size_b;
+    }
+
+    template <typename Problem>
+    CK_TILE_HOST_DEVICE static constexpr index_t GetSmemSize()
+    {
+        constexpr index_t smem_size_a = GetSmemSizeA<Problem>();
+        constexpr index_t smem_size_b = GetSmemSizeB<Problem>();
+        index_t smem_size             = 0;
+        smem_size += smem_size_a + smem_size_b;
+
+        return smem_size;
+    }
+
+    template <typename Problem>
+    CK_TILE_HOST_DEVICE static constexpr auto GetSmemPackA()
+    {
+        using ADataType = remove_cvref_t<typename Problem::ADataType>;
+        return Problem::VectorLoadSize / sizeof(ADataType);
+    }
+
+    template <typename Problem>
+    CK_TILE_HOST_DEVICE static constexpr auto GetSmemPackB()
+    {
+        using BDataType = remove_cvref_t<typename Problem::BDataType>;
+        return Problem::VectorLoadSize / sizeof(BDataType);
+    }
 
     template <typename Problem>
     CK_TILE_HOST_DEVICE static constexpr auto MakeADramTileDistribution()


### PR DESCRIPTION
This pull request involves significant changes to the `struct GemmPipelineAGmemBGmemCRegV1DefaultPolicy` in the file `include/ck_tile/ops/gemm/pipeline/gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp`. The changes mainly focus on the reintroduction of several methods: 
  * [`GetSmemSizeA`](diffhunk://#diff-207b3fd02ef0ab589b6f40b3c2e2b04148f741e49e5ee458f4ce874f06361845R165-R206): Calculates the shared memory size for matrix A.
  * [`GetSmemSizeB`](diffhunk://#diff-207b3fd02ef0ab589b6f40b3c2e2b04148f741e49e5ee458f4ce874f06361845R165-R206): Calculates the shared memory size for matrix B.
  * [`GetSmemSize`](diffhunk://#diff-207b3fd02ef0ab589b6f40b3c2e2b04148f741e49e5ee458f4ce874f06361845R165-R206): Computes the total shared memory size by summing the sizes of matrices A and B.
  * [`GetSmemPackA`](diffhunk://#diff-207b3fd02ef0ab589b6f40b3c2e2b04148f741e49e5ee458f4ce874f06361845R165-R206): Determines the packing size for matrix A based on the vector load size.
  * [`GetSmemPackB`](diffhunk://#diff-207b3fd02ef0ab589b6f40b3c2e2b04148f741e49e5ee458f4ce874f06361845R165-R206): Determines the packing size for matrix B based on the vector load size.


Currently they're put only when the 3d+pad descriptor is enabled.
