### PR TITLE
hneg: explicit cast to half to remove ambiguity error

### DIFF
--- a/include/ck/utility/math_v2.hpp
+++ b/include/ck/utility/math_v2.hpp
@@ -611,7 +611,7 @@ inline __device__ int8_t neg<int8_t>(int8_t x)
 template <>
 inline __device__ half_t neg<half_t>(half_t x)
 {
-    return __hneg(x);
+    return __hneg(static_cast<__half>(x));
 };
 
 template <typename T>


### PR DESCRIPTION
HIP recently added host conversions of __half. This causes ambiguity between __half and __hip_bfloat16. Explicit cast to __half to remove the error.