### PR TITLE
Add zstd lib for building hipTensor.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-
     nano \
     zlib1g-dev \
     zip \
-    zstd \
+    libzstd-dev \
     openssh-server \
     clang-format-12 \
     kmod && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-
     nano \
     zlib1g-dev \
     zip \
+    zstd \
     openssh-server \
     clang-format-12 \
     kmod && \


### PR DESCRIPTION
Need to add libzstd to our docker in order to build hipTensor.