### PR TITLE
device_prop.hpp: move static map to helper function and initialize there

### DIFF
--- a/include/ck/host_utility/device_prop.hpp
+++ b/include/ck/host_utility/device_prop.hpp
@@ -9,6 +9,29 @@
 
 namespace ck {
 
+// https://github.com/ROCm/MIOpen/blob/8498875aef84878e04c1eabefdf6571514891086/src/target_properties.cpp#L40
+// broken out and guarded with function call to avoid issues with initialization and
+// dynamic linking that can corrupt the map's contents
+inline const std::map<std::string, std::string>& get_device_name_map()
+{
+    static const std::map<std::string, std::string> device_name_map = {
+        {"Ellesmere", "gfx803"},
+        {"Baffin", "gfx803"},
+        {"RacerX", "gfx803"},
+        {"Polaris10", "gfx803"},
+        {"Polaris11", "gfx803"},
+        {"Tonga", "gfx803"},
+        {"Fiji", "gfx803"},
+        {"gfx800", "gfx803"},
+        {"gfx802", "gfx803"},
+        {"gfx804", "gfx803"},
+        {"Vega10", "gfx900"},
+        {"gfx901", "gfx900"},
+        {"10.3.0 Sienna_Cichlid 18", "gfx1030"},
+    };
+    return device_name_map;
+}
+
 inline std::string get_device_name()
 {
     hipDeviceProp_t props{};
@@ -25,27 +48,10 @@ inline std::string get_device_name()
         return std::string();
     }
     const std::string raw_name(props.gcnArchName);
-
-    // https://github.com/ROCm/MIOpen/blob/8498875aef84878e04c1eabefdf6571514891086/src/target_properties.cpp#L40
-    static std::map<std::string, std::string> device_name_map = {
-        {"Ellesmere", "gfx803"},
-        {"Baffin", "gfx803"},
-        {"RacerX", "gfx803"},
-        {"Polaris10", "gfx803"},
-        {"Polaris11", "gfx803"},
-        {"Tonga", "gfx803"},
-        {"Fiji", "gfx803"},
-        {"gfx800", "gfx803"},
-        {"gfx802", "gfx803"},
-        {"gfx804", "gfx803"},
-        {"Vega10", "gfx900"},
-        {"gfx901", "gfx900"},
-        {"10.3.0 Sienna_Cichlid 18", "gfx1030"},
-    };
-
     const auto name = raw_name.substr(0, raw_name.find(':')); // str.substr(0, npos) returns str.
 
-    auto match = device_name_map.find(name);
+    const auto& device_name_map = get_device_name_map();
+    auto match                  = device_name_map.find(name);
     if(match != device_name_map.end())
         return match->second;
     return name;


### PR DESCRIPTION
Summary:

# Why
  - This causes hard to debug segfaults when running in inductor without ASan for some reason with the helper, it's still a static const, so it should only initialize once: on the first call

# What
  - move the static name lookup map up to file scope and out of the inline'd get_device_name function

Test Plan:

Something like this without ASan

```
import torch

import torch.nn as nn
from torch._inductor import config as inductor_config
from torch._inductor.utils import fresh_inductor_cache

class SimpleModel(nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, x, y):
        return torch.mm(x, y)

M, N, K = 128, 128, 128
dtype = torch.float16
A = torch.randn(M, K, dtype=dtype).cuda()
B = torch.randn(K, N, dtype=dtype).cuda()

# create a fresh inductor cache
with fresh_inductor_cache():
    # sample the different backends independently
    with inductor_config.patch(
        {"max_autotune_gemm_backends": f"ATEN,CK"}
    ):
        # compile the model
        compiled_model = torch.compile(SimpleModel(), mode="max-autotune")
        # run the compiled model
        _ = compiled_model(A, B)
```

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

