### PR TITLE
fix: preprocessor directives logic error if/else

### DIFF
--- a/profiler/src/profile_grouped_gemm_fixed_nk.cpp
+++ b/profiler/src/profile_grouped_gemm_fixed_nk.cpp
@@ -89,53 +89,7 @@ int profile_grouped_gemm_fixed_nk(int argc, char* argv[])
         n_iter   = std::stoi(argv[16]);
     }
 
-    if(data_type == GemmDataType::BF16_I8_BF16 && layout == GemmMatrixLayout::MK_KN_MN)
-    {
-        ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::bhalf_t,
-                                                         int8_t,
-                                                         ck::bhalf_t,
-                                                         float,
-                                                         ck::tensor_layout::gemm::RowMajor,
-                                                         ck::tensor_layout::gemm::RowMajor,
-                                                         ck::tensor_layout::gemm::RowMajor>(
-            do_verification,
-            init_method,
-            do_log,
-            time_kernel,
-            Ms,
-            Ns,
-            Ks,
-            StrideAs,
-            StrideBs,
-            StrideCs,
-            kbatch,
-            n_warmup,
-            n_iter);
-    }
-    else if(data_type == GemmDataType::BF16_I8_BF16 && layout == GemmMatrixLayout::MK_NK_MN)
-    {
-        ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::bhalf_t,
-                                                         int8_t,
-                                                         ck::bhalf_t,
-                                                         float,
-                                                         ck::tensor_layout::gemm::RowMajor,
-                                                         ck::tensor_layout::gemm::ColumnMajor,
-                                                         ck::tensor_layout::gemm::RowMajor>(
-            do_verification,
-            init_method,
-            do_log,
-            time_kernel,
-            Ms,
-            Ns,
-            Ks,
-            StrideAs,
-            StrideBs,
-            StrideCs,
-            kbatch,
-            n_warmup,
-            n_iter);
-    }
-    else if(data_type == GemmDataType::F16_F16_F16 && layout == GemmMatrixLayout::MK_KN_MN)
+    if(data_type == GemmDataType::F16_F16_F16 && layout == GemmMatrixLayout::MK_KN_MN)
     {
         ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::half_t,
                                                          ck::half_t,
@@ -181,6 +135,7 @@ int profile_grouped_gemm_fixed_nk(int argc, char* argv[])
             n_warmup,
             n_iter);
     }
+#if defined(CK_ENABLE_FP8)
     else if(data_type == GemmDataType::F16_F8_F16 && layout == GemmMatrixLayout::MK_KN_MN)
     {
         ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::half_t,
@@ -227,6 +182,8 @@ int profile_grouped_gemm_fixed_nk(int argc, char* argv[])
             n_warmup,
             n_iter);
     }
+#endif
+#if defined(CK_ENABLE_INT8)
     else if(data_type == GemmDataType::F16_I8_F16 && layout == GemmMatrixLayout::MK_KN_MN)
     {
         ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::half_t,
@@ -273,6 +230,57 @@ int profile_grouped_gemm_fixed_nk(int argc, char* argv[])
             n_warmup,
             n_iter);
     }
+#endif
+#if defined(CK_ENABLE_BF16)
+#if defined(CK_ENABLE_INT8)
+    else if(data_type == GemmDataType::BF16_I8_BF16 && layout == GemmMatrixLayout::MK_KN_MN)
+    {
+        ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::bhalf_t,
+                                                         int8_t,
+                                                         ck::bhalf_t,
+                                                         float,
+                                                         ck::tensor_layout::gemm::RowMajor,
+                                                         ck::tensor_layout::gemm::RowMajor,
+                                                         ck::tensor_layout::gemm::RowMajor>(
+            do_verification,
+            init_method,
+            do_log,
+            time_kernel,
+            Ms,
+            Ns,
+            Ks,
+            StrideAs,
+            StrideBs,
+            StrideCs,
+            kbatch,
+            n_warmup,
+            n_iter);
+    }
+    else if(data_type == GemmDataType::BF16_I8_BF16 && layout == GemmMatrixLayout::MK_NK_MN)
+    {
+        ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::bhalf_t,
+                                                         int8_t,
+                                                         ck::bhalf_t,
+                                                         float,
+                                                         ck::tensor_layout::gemm::RowMajor,
+                                                         ck::tensor_layout::gemm::ColumnMajor,
+                                                         ck::tensor_layout::gemm::RowMajor>(
+            do_verification,
+            init_method,
+            do_log,
+            time_kernel,
+            Ms,
+            Ns,
+            Ks,
+            StrideAs,
+            StrideBs,
+            StrideCs,
+            kbatch,
+            n_warmup,
+            n_iter);
+    }
+#endif
+#endif
     else
     {
         throw std::runtime_error("wrong! this GEMM data_type & layout is not implemented");

--- a/profiler/src/profile_grouped_gemm_fixed_nk.cpp
+++ b/profiler/src/profile_grouped_gemm_fixed_nk.cpp
@@ -21,7 +21,6 @@ enum struct GemmDataType
     F16_F16_F16,  // 1
     F16_F8_F16,   // 2
     F16_I8_F16,   // 3
-
 };
 
 #define OP_NAME "grouped_gemm_fixed_nk"
@@ -39,7 +38,6 @@ std::vector<int> argToIntArray(char* input)
     {
         out.push_back(std::stoi(item));
     }
-
     return out;
 }
 
@@ -83,14 +81,6 @@ int profile_grouped_gemm_fixed_nk(int argc, char* argv[])
     const auto StrideCs = argToIntArray(argv[13]);
     const int kbatch    = argc >= 15 ? std::stoi(argv[14]) : 1;
 
-    using F32 = float;
-    using F16 = ck::half_t;
-#if defined(CK_ENABLE_FP8)
-    using F8 = ck::f8_t;
-#endif
-    using BF16 = ck::bhalf_t;
-    using I8   = int8_t;
-
     int n_warmup = 1;
     int n_iter   = 10;
     if(argc == 17)
@@ -99,13 +89,12 @@ int profile_grouped_gemm_fixed_nk(int argc, char* argv[])
         n_iter   = std::stoi(argv[16]);
     }
 
-#if defined(CK_ENABLE_BF16) && defined(CK_ENABLE_INT8)
     if(data_type == GemmDataType::BF16_I8_BF16 && layout == GemmMatrixLayout::MK_KN_MN)
     {
-        ck::profiler::profile_grouped_gemm_fixed_nk_impl<BF16,
-                                                         I8,
-                                                         BF16,
-                                                         F32,
+        ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::bhalf_t,
+                                                         int8_t,
+                                                         ck::bhalf_t,
+                                                         float,
                                                          ck::tensor_layout::gemm::RowMajor,
                                                          ck::tensor_layout::gemm::RowMajor,
                                                          ck::tensor_layout::gemm::RowMajor>(
@@ -125,10 +114,10 @@ int profile_grouped_gemm_fixed_nk(int argc, char* argv[])
     }
     else if(data_type == GemmDataType::BF16_I8_BF16 && layout == GemmMatrixLayout::MK_NK_MN)
     {
-        ck::profiler::profile_grouped_gemm_fixed_nk_impl<BF16,
-                                                         I8,
-                                                         BF16,
-                                                         F32,
+        ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::bhalf_t,
+                                                         int8_t,
+                                                         ck::bhalf_t,
+                                                         float,
                                                          ck::tensor_layout::gemm::RowMajor,
                                                          ck::tensor_layout::gemm::ColumnMajor,
                                                          ck::tensor_layout::gemm::RowMajor>(
@@ -146,14 +135,12 @@ int profile_grouped_gemm_fixed_nk(int argc, char* argv[])
             n_warmup,
             n_iter);
     }
-#endif
-#if defined(CK_ENABLE_FP16)
     else if(data_type == GemmDataType::F16_F16_F16 && layout == GemmMatrixLayout::MK_KN_MN)
     {
-        ck::profiler::profile_grouped_gemm_fixed_nk_impl<F16,
-                                                         F16,
-                                                         F16,
-                                                         F32,
+        ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::half_t,
+                                                         ck::half_t,
+                                                         ck::half_t,
+                                                         float,
                                                          ck::tensor_layout::gemm::RowMajor,
                                                          ck::tensor_layout::gemm::RowMajor,
                                                          ck::tensor_layout::gemm::RowMajor>(
@@ -173,10 +160,10 @@ int profile_grouped_gemm_fixed_nk(int argc, char* argv[])
     }
     else if(data_type == GemmDataType::F16_F16_F16 && layout == GemmMatrixLayout::MK_NK_MN)
     {
-        ck::profiler::profile_grouped_gemm_fixed_nk_impl<F16,
-                                                         F16,
-                                                         F16,
-                                                         F32,
+        ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::half_t,
+                                                         ck::half_t,
+                                                         ck::half_t,
+                                                         float,
                                                          ck::tensor_layout::gemm::RowMajor,
                                                          ck::tensor_layout::gemm::ColumnMajor,
                                                          ck::tensor_layout::gemm::RowMajor>(
@@ -194,14 +181,12 @@ int profile_grouped_gemm_fixed_nk(int argc, char* argv[])
             n_warmup,
             n_iter);
     }
-#endif
-#if defined(CK_ENABLE_FP16) && defined(CK_ENABLE_FP8)
     else if(data_type == GemmDataType::F16_F8_F16 && layout == GemmMatrixLayout::MK_KN_MN)
     {
-        ck::profiler::profile_grouped_gemm_fixed_nk_impl<F16,
-                                                         F8,
-                                                         F16,
-                                                         F32,
+        ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::half_t,
+                                                         ck::f8_t,
+                                                         ck::half_t,
+                                                         float,
                                                          ck::tensor_layout::gemm::RowMajor,
                                                          ck::tensor_layout::gemm::RowMajor,
                                                          ck::tensor_layout::gemm::RowMajor>(
@@ -221,10 +206,10 @@ int profile_grouped_gemm_fixed_nk(int argc, char* argv[])
     }
     else if(data_type == GemmDataType::F16_F8_F16 && layout == GemmMatrixLayout::MK_NK_MN)
     {
-        ck::profiler::profile_grouped_gemm_fixed_nk_impl<F16,
-                                                         F8,
-                                                         F16,
-                                                         F32,
+        ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::half_t,
+                                                         ck::f8_t,
+                                                         ck::half_t,
+                                                         float,
                                                          ck::tensor_layout::gemm::RowMajor,
                                                          ck::tensor_layout::gemm::ColumnMajor,
                                                          ck::tensor_layout::gemm::RowMajor>(
@@ -242,14 +227,12 @@ int profile_grouped_gemm_fixed_nk(int argc, char* argv[])
             n_warmup,
             n_iter);
     }
-#endif
-#if defined(CK_ENABLE_FP16) && defined(CK_ENABLE_INT8)
     else if(data_type == GemmDataType::F16_I8_F16 && layout == GemmMatrixLayout::MK_KN_MN)
     {
-        ck::profiler::profile_grouped_gemm_fixed_nk_impl<F16,
-                                                         I8,
-                                                         F16,
-                                                         F32,
+        ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::half_t,
+                                                         int8_t,
+                                                         ck::half_t,
+                                                         float,
                                                          ck::tensor_layout::gemm::RowMajor,
                                                          ck::tensor_layout::gemm::RowMajor,
                                                          ck::tensor_layout::gemm::RowMajor>(
@@ -269,10 +252,10 @@ int profile_grouped_gemm_fixed_nk(int argc, char* argv[])
     }
     else if(data_type == GemmDataType::F16_I8_F16 && layout == GemmMatrixLayout::MK_NK_MN)
     {
-        ck::profiler::profile_grouped_gemm_fixed_nk_impl<F16,
-                                                         I8,
-                                                         F16,
-                                                         F32,
+        ck::profiler::profile_grouped_gemm_fixed_nk_impl<ck::half_t,
+                                                         int8_t,
+                                                         ck::half_t,
+                                                         float,
                                                          ck::tensor_layout::gemm::RowMajor,
                                                          ck::tensor_layout::gemm::ColumnMajor,
                                                          ck::tensor_layout::gemm::RowMajor>(
@@ -290,7 +273,6 @@ int profile_grouped_gemm_fixed_nk(int argc, char* argv[])
             n_warmup,
             n_iter);
     }
-#endif
     else
     {
         throw std::runtime_error("wrong! this GEMM data_type & layout is not implemented");


### PR DESCRIPTION
Fix for a bug in the ck profiler code for grouped_gemm_fixed_nk

line 102, 150.. 
If CK_ENABLE_BF16 or CK_ENABLE_INT8 is not defined and CK_ENABLE_F16 is defined, the code would still compile because it's still syntactically correct due to a preceding if condition for the if/else block. 
But the logic breaks.

Couple of ways to solve this that I'm thinking of:

1. break down the if/else block and keep them as separate if/else statements with preprocessor macro since the args are on user inputs. 
2. Just remove the preprocessor directives all together. I'm leaning toward this because it's user facing code, lower lvl fns will/should handle the wrong input if someone requests bf16 when lib doesn't support it. 
3. just move the preprocessors into the if else conditions, that way the codeblock won't do anything. maybe add a #error for each within to handle it better

I've implemented the second solution. But we can choose another approach if preferred.