### PR TITLE
fix typo for CK_USE_OCP_FP8

### DIFF
--- a/include/ck/config.h.in
+++ b/include/ck/config.h.in
@@ -115,8 +115,8 @@
 #cmakedefine CK_USE_GFX94 @CK_USE_GFX94@
 #endif
 
-#ifndef DCK_USE_OCP_FP8
-#cmakedefine DCK_USE_OCP_FP8 @DCK_USE_OCP_FP8@
+#ifndef CK_USE_OCP_FP8
+#cmakedefine CK_USE_OCP_FP8 @CK_USE_OCP_FP8@
 #endif
 
 #ifndef CK_USE_FNUZ_FP8


### PR DESCRIPTION
This is required for the hipTensor to build correctly.
