### PR TITLE
[CK_TILE] Fix fmha fwd splitkv codegen error

### DIFF
--- a/example/ck_tile/01_fmha/codegen/ops/fmha_fwd_splitkv.py
+++ b/example/ck_tile/01_fmha/codegen/ops/fmha_fwd_splitkv.py
@@ -261,7 +261,7 @@ FMHA_FWD_SPLITKV_API_INNER_DISPATCH="""            {F_if}((t.is_group_mode == {F
                 static_assert({F_bn1} % 32 == 0);
 
                 if (t.has_lse) {{
-                    if constexpr (std::is_same_v<{F_dtype}, ck_tile::fp8_t>) {{
+                    if constexpr (std::is_same_v<{F_dtype}, FmhaFwdFp8>) {{
                         return -1;
                     }} else {{
                         using traits2_ = fmha_fwd_splitkv_combine_traits_<{F_hdim}, {F_dtype}, {F_mode}, /*F_bn1=*/32, true, {F_squant}, {F_spad}, {F_dvpad}>;
@@ -614,7 +614,7 @@ def get_fmha_fwd_splitkv_combine_tile_dict_from_dtype(dtype : str) -> Optional[d
     }
     elif dtype == 'fp8' or dtype == 'bf8':
         return {
-            '64'  : FmhaFwdSplitKVCombineTileSize(32,   -1),
+            '64'  : FmhaFwdSplitKVCombineTileSize(32,  -1),
             '128' : FmhaFwdSplitKVCombineTileSize(32,  -1),
             '256' : FmhaFwdSplitKVCombineTileSize(32,  -1),
         }


### PR DESCRIPTION
## Proposed changes

Rocking introduced new type tags for `FmhaFwdTypeConfig<>` in #1731. After this PR, the `FmhaFwdTypeConfig<>` type argument is no longer a real data type used in kernels. I was assuming the type tag could be `ck_tile::fp8_t`, but it's not true now. And the wrong assumption will cause link error if we enable the `fmha_fwd_splitkv()`

## Checklist
- [x] run script _cmake-ck-dev.sh_ by adding CMake option, `-DFMHA_FWD_ENABLE_APIS="all"`, to the end
- [x] run command: `make -j $(nproc) tile_example_fmha_fwd` to build the affected target
- [x] see if the build is successful

