### PR TITLE
Add CK_TIME_KERNEL as toggleable CMake Variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,9 +108,9 @@ endif()
 
 option(CK_TIME_KERNEL "Enable kernel time tracking" ON)
 if(CK_TIME_KERNEL)
-    add_definitions(-DCK_TIME_KERNEL=ON)
+    add_definitions(-DCK_TIME_KERNEL=1)
 else()
-    add_definitions(-DCK_TIME_KERNEL=OFF)
+    add_definitions(-DCK_TIME_KERNEL=0)
 endif()
 
 include(getopt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,11 @@ if(CK_USE_CODEGEN)
     add_definitions(-DCK_USE_CODEGEN)
 endif()
 
+option(CK_TIME_KERNEL "Enable kernel time tracking" OFF)
+if(CK_TIME_KERNEL)
+    add_definitions(-DCK_TIME_KERNEL)
+endif()
+
 include(getopt)
 
 # CK version file to record release version as well as git commit hash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,9 +106,11 @@ if(CK_USE_CODEGEN)
     add_definitions(-DCK_USE_CODEGEN)
 endif()
 
-option(CK_TIME_KERNEL "Enable kernel time tracking" OFF)
+option(CK_TIME_KERNEL "Enable kernel time tracking" ON)
 if(CK_TIME_KERNEL)
-    add_definitions(-DCK_TIME_KERNEL)
+    add_definitions(-DCK_TIME_KERNEL=ON)
+else()
+    add_definitions(-DCK_TIME_KERNEL=OFF)
 endif()
 
 include(getopt)

--- a/include/ck/ck.hpp
+++ b/include/ck/ck.hpp
@@ -18,7 +18,7 @@ CK_DECLARE_ENV_VAR_BOOL(CK_LOGGING)
 // to do: add various levels of logging with CK_LOG_LEVEL
 
 #ifndef CK_TIME_KERNEL
-#define CK_TIME_KERNEL 0
+#define CK_TIME_KERNEL 1
 #endif
 
 // constant address space for kernel parameter

--- a/include/ck/ck.hpp
+++ b/include/ck/ck.hpp
@@ -17,7 +17,9 @@ CK_DECLARE_ENV_VAR_BOOL(CK_LOGGING)
 
 // to do: add various levels of logging with CK_LOG_LEVEL
 
-#define CK_TIME_KERNEL 1
+#ifndef CK_TIME_KERNEL
+#define CK_TIME_KERNEL 0
+#endif
 
 // constant address space for kernel parameter
 // https://llvm.org/docs/AMDGPUUsage.html#address-spaces


### PR DESCRIPTION
Allow CK_TIME_KERNEL to be toggled through CMake variable during build, maintaining default enablement

Example:
`cmake <...> -D CK_TIME_KERNEL=OFF ..`