### PR TITLE
Fix parsing instances for pt inductor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN pip install --upgrade cmake==3.27.5 && \
     dpkg -i dumb-init_*.deb && rm dumb-init_*.deb && \
 # Install packages for processing the performance results
     pip3 install --upgrade pip && \
-    pip3 install sqlalchemy==2.0.36 pymysql pandas==2.2.3 setuptools-rust sshtunnel==0.4.0 && \
+    pip3 install --upgrade pytest sqlalchemy==2.0.36 pymysql pandas==2.2.3 setuptools-rust setuptools>=75 sshtunnel==0.4.0 && \
 # Add render group
     groupadd -f render && \
 # Install the new rocm-cmake version

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -512,6 +512,13 @@ def Build_CK(Map conf=[:]){
                         arch_type = 5
                     }
                     cmake_build(conf)
+                    if ( arch_type == 1 ){
+                            echo "Run inductor codegen tests"
+                            sh """
+                                  pip install --verbose .
+                                  pytest python/test/test_gen_instances.py
+                            """
+                    }
                     dir("build"){
                         if (params.RUN_FULL_QA && arch_type == 1 ){
                             // build deb packages for all gfx9 targets on gfx90a system and prepare to export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,16 +21,19 @@ dependencies = []
 "Bug Tracker" = "https://github.com/rocm/composable_kernel/issues"
 
 [tool.setuptools]
-packages = ["ck4inductor", "ck4inductor.include", "ck4inductor.library"]
+packages = ["ck4inductor", "ck4inductor.include", "ck4inductor.library", "ck4inductor.universal_gemm", "ck4inductor.batched_universal_gemm", "ck4inductor.grouped_conv_fwd"]
 
 [tool.setuptools.package-dir]
 ck4inductor = "python/ck4inductor"
+"ck4inductor.universal_gemm" = "python/ck4inductor/universal_gemm"
+"ck4inductor.batched_universal_gemm" = "python/ck4inductor/batched_universal_gemm"
+"ck4inductor.grouped_conv_fwd" = "python/ck4inductor/grouped_conv_fwd"
 "ck4inductor.include" = "include"
 "ck4inductor.library" = "library"
 
 [tool.setuptools.package-data]
 "ck4inductor.include" = ["ck/**/*.hpp"]
-"ck4inductor.library" = ["src/tensor_operation_instance/gpu/gemm_universal/**/*.hpp"]
+"ck4inductor.library" = ["src/tensor_operation_instance/gpu/gemm_universal/**/*.hpp", "src/tensor_operation_instance/gpu/gemm_universal_batched/**/*.hpp", "include/ck/library/tensor_operation_instance/gpu/grouped_conv_fwd/**/*.hpp"]
 
 [tool.setuptools.dynamic]
 version = { attr = "setuptools_scm.get_version" }

--- a/python/ck4inductor/universal_gemm/gen_instances.py
+++ b/python/ck4inductor/universal_gemm/gen_instances.py
@@ -68,12 +68,13 @@ def parse_instances(str_instances: List[str]) -> List[CKGemmOperation]:
 
         template_args.insert(2, tuple())  # ds layout
         template_args.insert(6, tuple())  # ds dtype
-
-        new_instance = CKGemmOperation(
-            *template_args,  # type: ignore[arg-type]
-        )
-
-        op_instances.append(new_instance)
+        try:
+            new_instance = CKGemmOperation(
+                *template_args,  # type: ignore[arg-type]
+            )
+            op_instances.append(new_instance)
+        except TypeError as e:
+            log.debug(f"{e} when parsing {line}")
     return op_instances
 
 

--- a/python/test/test_gen_instances.py
+++ b/python/test/test_gen_instances.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
+import logging
+
+import unittest
+
+from ck4inductor.universal_gemm.gen_instances import (
+    gen_ops_library as gen_gemm_ops_library,
+)
+from ck4inductor.universal_gemm.gen_instances import (
+    gen_ops_preselected as gen_gemm_ops_preselected,
+)
+from ck4inductor.grouped_conv_fwd.gen_instances import (
+    gen_conv_ops_library as gen_conv_ops_library,
+)
+from ck4inductor.batched_universal_gemm.gen_instances import (
+    gen_ops_library as gen_batched_gemm_ops_library,
+)
+
+log = logging.getLogger(__name__)
+
+
+class TestGenInstances(unittest.TestCase):
+    def test_gen_gemm_instances(self):
+        instances = gen_gemm_ops_library()
+
+        log.debug("%d gemm instances from library" % len(instances))
+        self.assertTrue(instances)
+
+    def test_preselected_gemm_instances(self):
+        instances = gen_gemm_ops_preselected()
+
+        log.debug("%d preselected gemm instances" % len(instances))
+        self.assertTrue(instances)
+
+    def test_gen_conv_instances(self):
+        instances = gen_conv_ops_library()
+
+        log.debug("%d gemm instances from library" % len(instances))
+        self.assertTrue(instances)
+
+    def test_gen_batched_gemm_instances(self):
+        instances = gen_batched_gemm_ops_library()
+
+        log.debug("%d gemm instances from library" % len(instances))
+        self.assertTrue(instances)


### PR DESCRIPTION
## Proposed changes

Bug: freshly added I4 instances are parsed incorrectly
Fix: ignore instances which can't be parsed

## Testing

With pytorch: `pytest test/inductor/test_ck_backend.py`
Standalone: `python -m ck4inductor.universal_gemm.gen_instances` doesn't crash

Added unit test: `pytest test/test_gen_instances.py --log-cli-level=DEBUG`

Results: https://gist.github.com/tenpercent/ac158212aaddd38fd211eb4fa470c636

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

