### PR TITLE
turn on the ck_tile gemm tests by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -796,7 +796,7 @@ pipeline {
         booleanParam(
             name: "RUN_CK_TILE_GEMM_TESTS",
             defaultValue: false,
-            description: "Run the ck_tile GEMM tests (default: OFF)")
+            description: "Run the ck_tile GEMM tests (default: ON)")
         booleanParam(
             name: "BUILD_INSTANCES_ONLY",
             defaultValue: false,


### PR DESCRIPTION
## Proposed changes

This change will turn on the ck_tile gemm tests in every CI build instead of a single daily build.


