### PR TITLE
Fix ck_tile gemm benchmarking scripts

### DIFF
--- a/example/ck_tile/03_gemm/script/benchmark_basic.sh
+++ b/example/ck_tile/03_gemm/script/benchmark_basic.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 EXE="$(find . -name tile_example_gemm_basic -type f | head -n 1)"
-VALID=0
+VALID=1
 
 for b_matrix_layout in "R" "C"; do
     for m in "64" "512" "1024" "2048"; do
         for n in "512" "1024" "2048"; do
             for k in "64" "512" "1024" "2048"; do
-                $EXE -prec=fp16 -b=1 -m=$m -n=$n -k=$k -a_layout="R" -b_layout="$b_matrix_layout" -c_layout="R" -v=$VALID
+                $EXE -prec=fp16 -m=$m -n=$n -k=$k -a_layout="R" -b_layout="$b_matrix_layout" -c_layout="R" -v=$VALID
             done
         done
     done

--- a/example/ck_tile/03_gemm/script/benchmark_mem_pipeline.sh
+++ b/example/ck_tile/03_gemm/script/benchmark_mem_pipeline.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 EXE="$(find . -name tile_example_gemm_universal -type f | head -n 1)"
-VALID=0
+VALID=1
 
 for b_matrix_layout in "R" "C"; do
     for m in "64" "512" "1024" "2048"; do
         for n in "512" "1024" "2048"; do
             for k in "64" "512" "1024" "2048"; do
-                $EXE -prec=fp16 -b=1 -m=$m -n=$n -k=$k -a_layout="R" -b_layout="$b_matrix_layout" -c_layout="R" -v=$VALID
+                $EXE -prec=fp16 -m=$m -n=$n -k=$k -a_layout="R" -b_layout="$b_matrix_layout" -c_layout="R" -v=$VALID
             done
         done
     done


### PR DESCRIPTION
Apparently, there was an obsolete parameter in the ck_tile gemm benchmark scripts that was causing the scripts to output garbage.
Also, turned on the verification.

