### PR TITLE
Conditionally log a DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle warning

### DIFF
--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_xdl_cshuffle.hpp
@@ -1495,10 +1495,13 @@ struct DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle
         // if workspace is not allocated
         if(!arg.p_workspace_)
         {
-            std::cerr << "Warning: Workspace for "
-                         "DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle::Argument is not "
-                         "allocated, use SetWorkSpacePointer."
-                      << std::endl;
+            if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
+            {
+                std::cout << "Warning: Workspace for "
+                             "DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle::Argument is not "
+                             "allocated, use SetWorkSpacePointer."
+                          << std::endl;
+            }
             return false;
         }
         if(!ck::is_xdl_supported())


### PR DESCRIPTION
The code was emitting a warning if MIOpen did not create a workspace
prior to invoking the IsSupportedArgument method, but the condition for
MIOpen to create a workspace was not met, and so this condition was not
really an error but more of a log message.  

## Proposed changes

This commit addresses this issue by using the CK_LOGGING facility to only generate the
log message if the CK_LOGGING environment variable is set.

