### PR TITLE
Ck flex - accuracy fix for pre_softmax operator

### DIFF
--- a/example/ck_tile/18_flexattn/CMakeLists.txt
+++ b/example/ck_tile/18_flexattn/CMakeLists.txt
@@ -11,7 +11,7 @@ set(FMHA_SCORE_MOD_F [[s + static_cast<decltype(s)>((q_idx - v_idx) % 8)]])
 # set(FMHA_SCORE_MOD_F [[s]])
 
 variable_watch(FMHA_PRE_SOFTMAX_F)
-set(FMHA_PRE_SOFTMAX_F [[static_cast<decltype(s)>(tanh(s*1.0)/1.0)]])
+set(FMHA_PRE_SOFTMAX_F [[static_cast<decltype(s)>( tanh(1.1f * s) / 1.1f )]])
 #set(FMHA_PRE_SOFTMAX_F [[s]])
 
 foreach(api ${FMHA_FWD_ENABLE_APIS})

--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_flex_qr_ks_vs_async.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_flex_qr_ks_vs_async.hpp
@@ -430,6 +430,7 @@ struct BlockFmhaPipelineQRKSVSAsync
                 });
             }
 
+	    s_acc = tile_elementwise_in(ps_acc_element_func, s_acc);
             if constexpr(BiasEnum == BlockAttentionBiasEnum::ELEMENTWISE_BIAS)
             {
                 s_acc = tile_elementwise_in(s_acc_element_func, s_acc);
@@ -472,7 +473,9 @@ struct BlockFmhaPipelineQRKSVSAsync
                 tile_elementwise_inout([&scale_s](auto& x) { x = x * scale_s; }, s_acc);
 #endif
             }
-            move_tile_window(bias_dram_window, {0, kN0});
+            
+            
+	    move_tile_window(bias_dram_window, {0, kN0});
             if constexpr(kPadSeqLenK || FmhaMask::IsMasking)
             {
                 const auto k_origin      = k_dram_block_window.get_window_origin();
@@ -560,7 +563,6 @@ struct BlockFmhaPipelineQRKSVSAsync
                 }
             };
 
-            s_acc = tile_elementwise_in(ps_acc_element_func, s_acc);
             constexpr auto p_spans = decltype(p_compute)::get_distributed_spans();
             sweep_tile_span(p_spans[number<0>{}], [&](auto idx0) {
                 constexpr auto i_idx = make_tuple(idx0);


### PR DESCRIPTION
## Proposed changes

Please describe the motivation behind the pull request, whether it enables a new feature or fixes a bug. If there are associated pull requests or issues, please link them to the pull request.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

