### PR TITLE
Add receipt 4 option to codegen

### DIFF
--- a/example/ck_tile/01_fmha/codegen/ops/fmha_bwd.py
+++ b/example/ck_tile/01_fmha/codegen/ops/fmha_bwd.py
@@ -506,6 +506,14 @@ def get_bwd_dq_dk_dv_blobs(kernel_filter : Optional[str], receipt, mask_impl) ->
                     cond &= deterministic == "f"
                     if not cond:
                         continue
+            if receipt == 4:
+                    cond = dtype in ['fp16', 'bf16']
+                    cond &= bias in ['no', 'bias']
+                    cond &= dropout in ['no', 'dropout_wg32',  'dropout_wg16']
+                    cond &= dpad == dvpad
+                    cond &= deterministic == "f"
+                    if not cond:
+                        continue
             api_pool.register_dq_dk_dv_traits(k.api_trait())
             gen.append(k)
 

--- a/example/ck_tile/01_fmha/codegen/ops/fmha_fwd.py
+++ b/example/ck_tile/01_fmha/codegen/ops/fmha_fwd.py
@@ -494,6 +494,20 @@ def get_fwd_blobs(kernel_filter : Optional[str], receipt, mask_impl) -> Tuple[Fm
                     cond &= pipeline.F_squant == 'f'
                     if not cond:
                         continue
+                if receipt == 3:
+                    cond = dtype in ['fp16', 'bf16']
+                    cond &= pipeline.F_vlayout == 'row'
+                    cond &= pipeline.F_bias in ['no', 'alibi']
+                    cond &= pipeline.F_squant == 'f'
+                    if not cond:
+                        continue
+                if receipt == 4:
+                    cond = dtype in ['fp16', 'bf16']
+                    cond &= pipeline.F_vlayout == 'row'
+                    cond &= pipeline.F_bias in ['no', 'bias']
+                    cond &= pipeline.F_squant == 'f'
+                    if not cond:
+                        continue
                 api_pool.register_traits(k.api_trait())
                 gen.append(k)
 


### PR DESCRIPTION
## Proposed changes

Recently, PyTorch has added CK as a backend. With this, came some tricky workarounds that required us to check in all of the generated kernel instances. Originally, I naively used `--receipt 2` when generating the kernels via example/ck_tile/01_fmha/generate.py because it created the smallest amount of files that i could actually push to upstream PyTorch. I have recently learned that the `2` option does not create kernel instances that support elementwise bias, only alibi. PyTorch only supports the former. I attempted to use the other options (no receipt, 1, and 3) but each of those generated many more files which would take us further away from landing any additional CK support in PyTorch. So I am adding another receipt option in this PR to generate a cross-section of kernels that PyTorch can use with it's own attention bias implementation. I have tested the generated kernels via ./example/ck_tile/01_fmha/script/run_full_test.sh and observed no errors. Additionally, i integrated the receipt == 4 kernels into PyTorch and was able to pass those sanity tests as well. This feature is non invasive and won't affect any incumbent CK functionality. Path is only hit if the user intentionally passes `--receipt 4` to `generate.py`.


p.s. I noticed there was a `3` option for backward but not forward. In an attempt to make the user only have to remember one number for that option, i added a `3` option for forward. Please feel free to shoot that down. Intent was to make my life easier :)


