### PR TITLE
add -Wno-unique-object-duplication compiler option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ endif()
 add_compile_options(-Wno-bit-int-extension)
 add_compile_options(-Wno-pass-failed)
 add_compile_options(-Wno-switch-default)
+add_compile_options(-Wno-unique-object-duplication)
 
 if(DL_KERNELS)
     add_definitions(-DDL_KERNELS)


### PR DESCRIPTION
## Proposed changes

This is a workaround to allow CK to build correctly with Clang21.0.
I have verified that the build completes successfully.

