### PR TITLE
device_prop.hpp - replace map with compile time hash and switch

### DIFF
--- a/include/ck/host_utility/device_prop.hpp
+++ b/include/ck/host_utility/device_prop.hpp
@@ -11,25 +11,27 @@ namespace ck {
 
 constexpr unsigned int fnv1a_hash(std::string_view str, unsigned int h = 2166136261u)
 {
-    return str.empty() ? h : fnv1a_hash(str.substr(1), (h ^ static_cast<unsigned char>(str.front())) * 16777619u);
+    return str.empty() ? h
+                       : fnv1a_hash(str.substr(1),
+                                    (h ^ static_cast<unsigned char>(str.front())) * 16777619u);
 }
 inline std::string get_device_name()
 {
     hipDeviceProp_t props{};
     int device;
     auto status = hipGetDevice(&device);
-    if (status != hipSuccess)
+    if(status != hipSuccess)
     {
         return std::string();
     }
     status = hipGetDeviceProperties(&props, device);
-    if (status != hipSuccess)
+    if(status != hipSuccess)
     {
         return std::string();
     }
     const std::string raw_name(props.gcnArchName);
     const auto name = raw_name.substr(0, raw_name.find(':')); // str.substr(0, npos) returns str.
-    switch (fnv1a_hash(name))
+    switch(fnv1a_hash(name))
     {
     // https://github.com/ROCm/MIOpen/blob/8498875aef84878e04c1eabefdf6571514891086/src/target_properties.cpp#L40
     case fnv1a_hash("Ellesmere"):
@@ -41,15 +43,11 @@ inline std::string get_device_name()
     case fnv1a_hash("Fiji"):
     case fnv1a_hash("gfx800"):
     case fnv1a_hash("gfx802"):
-    case fnv1a_hash("gfx804"):
-        return "gfx803";
+    case fnv1a_hash("gfx804"): return "gfx803";
     case fnv1a_hash("Vega10"):
-    case fnv1a_hash("gfx901"):
-        return "gfx900";
-    case fnv1a_hash("10.3.0 Sienna_Cichlid 18"):
-        return "gfx1030";
-    default:
-        return name;
+    case fnv1a_hash("gfx901"): return "gfx900";
+    case fnv1a_hash("10.3.0 Sienna_Cichlid 18"): return "gfx1030";
+    default: return name;
     }
 }
 

--- a/include/ck/host_utility/device_prop.hpp
+++ b/include/ck/host_utility/device_prop.hpp
@@ -4,51 +4,53 @@
 #pragma once
 
 #include <string>
-#include <map>
+#include <string_view>
 #include <hip/hip_runtime.h>
 
 namespace ck {
 
+constexpr unsigned int fnv1a_hash(std::string_view str, unsigned int h = 2166136261u)
+{
+    return str.empty() ? h : fnv1a_hash(str.substr(1), (h ^ static_cast<unsigned char>(str.front())) * 16777619u);
+}
 inline std::string get_device_name()
 {
     hipDeviceProp_t props{};
     int device;
     auto status = hipGetDevice(&device);
-    if(status != hipSuccess)
+    if (status != hipSuccess)
     {
         return std::string();
     }
-
     status = hipGetDeviceProperties(&props, device);
-    if(status != hipSuccess)
+    if (status != hipSuccess)
     {
         return std::string();
     }
     const std::string raw_name(props.gcnArchName);
-
-    // https://github.com/ROCm/MIOpen/blob/8498875aef84878e04c1eabefdf6571514891086/src/target_properties.cpp#L40
-    static std::map<std::string, std::string> device_name_map = {
-        {"Ellesmere", "gfx803"},
-        {"Baffin", "gfx803"},
-        {"RacerX", "gfx803"},
-        {"Polaris10", "gfx803"},
-        {"Polaris11", "gfx803"},
-        {"Tonga", "gfx803"},
-        {"Fiji", "gfx803"},
-        {"gfx800", "gfx803"},
-        {"gfx802", "gfx803"},
-        {"gfx804", "gfx803"},
-        {"Vega10", "gfx900"},
-        {"gfx901", "gfx900"},
-        {"10.3.0 Sienna_Cichlid 18", "gfx1030"},
-    };
-
     const auto name = raw_name.substr(0, raw_name.find(':')); // str.substr(0, npos) returns str.
-
-    auto match = device_name_map.find(name);
-    if(match != device_name_map.end())
-        return match->second;
-    return name;
+    switch (fnv1a_hash(name))
+    {
+    // https://github.com/ROCm/MIOpen/blob/8498875aef84878e04c1eabefdf6571514891086/src/target_properties.cpp#L40
+    case fnv1a_hash("Ellesmere"):
+    case fnv1a_hash("Baffin"):
+    case fnv1a_hash("RacerX"):
+    case fnv1a_hash("Polaris10"):
+    case fnv1a_hash("Polaris11"):
+    case fnv1a_hash("Tonga"):
+    case fnv1a_hash("Fiji"):
+    case fnv1a_hash("gfx800"):
+    case fnv1a_hash("gfx802"):
+    case fnv1a_hash("gfx804"):
+        return "gfx803";
+    case fnv1a_hash("Vega10"):
+    case fnv1a_hash("gfx901"):
+        return "gfx900";
+    case fnv1a_hash("10.3.0 Sienna_Cichlid 18"):
+        return "gfx1030";
+    default:
+        return name;
+    }
 }
 
 inline bool is_xdl_supported()


### PR DESCRIPTION
## Proposed changes

### Why:

This causes hard to debug segfaults when running in inductor without ASan for some reason, and loading/unloading libraries compiled with this library as a dependency

### What:

Replace the static lookup map with just a compile time hash & switch system that should be faster, and most importantly not require dynamic memory allocation

### Test Plan:

Something like this without ASan
```
import torch

import torch.nn as nn
from torch._inductor import config as inductor_config
from torch._inductor.utils import fresh_inductor_cache

class SimpleModel(nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, x, y):
        return torch.mm(x, y)

M, N, K = 128, 128, 128
dtype = torch.float16
A = torch.randn(M, K, dtype=dtype).cuda()
B = torch.randn(K, N, dtype=dtype).cuda()

# create a fresh inductor cache
with fresh_inductor_cache():
    # sample the different backends independently
    with inductor_config.patch(
        {"max_autotune_gemm_backends": f"ATEN,CK"}
    ):
        # compile the model
        compiled_model = torch.compile(SimpleModel(), mode="max-autotune")
        # run the compiled model
        _ = compiled_model(A, B)
```

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

This is attempt #2 after, superseding #1763 as that approach still occasionally ran into issues. Feedback there is appreciated and I figured instead of trying for a larger change, just keeping it simple with the lookup even though the names are effectively archaic

