### PR TITLE
Remove PRIVATE from rocm_install_targets in codegen/CMakeLists.txt

### DIFF
--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -46,7 +46,6 @@ rocm_install_targets(
     TARGETS ck_host ck_headers
     EXPORT ck_host_targets
     INCLUDE include
-    PRIVATE
 )
 rocm_export_targets(
     EXPORT ck_host_targets


### PR DESCRIPTION
Small cmake change in order for the MIGraphX build to work correctly.

Related PR: https://github.com/ROCm/AMDMIGraphX/pull/3595
