### PR TITLE
Fix typo: Missing _ in __HIPCC__

### DIFF
--- a/include/ck_tile/core/config.hpp
+++ b/include/ck_tile/core/config.hpp
@@ -45,7 +45,7 @@
 
 // implementing the "memory address space" attribute
 // https://llvm.org/docs/AMDGPUUsage.html#amdgpu-address-spaces-table
-#ifdef __HIPCC_
+#ifdef __HIPCC__
 #define CK_TILE_GENERIC_ADDR __attribute__((address_space(0)))
 #define CK_TILE_GLOBAL_ADDR __attribute__((address_space(1)))
 #define CK_TILE_LDS_ADDR __attribute__((address_space(3)))


### PR DESCRIPTION
## Proposed changes

The macro definition is `__HIPCC__` and not `__HIPCC_`. This was likely a typo.

## Checklist

- [x] I have run `clang-format` on all changed files
