### PR TITLE
Fix typo: v_offset used in initialization of v_offset

### DIFF
--- a/include/ck_tile/core/arch/amd_buffer_addressing.hpp
+++ b/include/ck_tile/core/arch/amd_buffer_addressing.hpp
@@ -1549,7 +1549,7 @@ CK_TILE_DEVICE void amd_async_buffer_load(CK_TILE_LDS_ADDR T* smem,
 
     if constexpr(oob_conditional_check)
     {
-        index_t v_offset = flag ? v_offset : src_wave_buffer_resource[2];
+        index_t v_offset = flag ? src_thread_addr_offset : src_wave_buffer_resource[2];
         llvm_amdgcn_raw_buffer_load_lds(src_wave_buffer_resource,
                                         smem,
                                         sizeof(uint32_t),


### PR DESCRIPTION
## Proposed changes

Using a value in its own initialization is undefined. I suspect this was a typo and that `src_thread_addr_offset` which is the value `v_offset` would take if there was no conditional check is the appropriate initialization value.

## Checklist

- [x] I have run `clang-format` on all changed files
