### PR TITLE
Fix compile errors on Windows and Linux

### DIFF
--- a/include/ck/utility/amd_ck_fp8.hpp
+++ b/include/ck/utility/amd_ck_fp8.hpp
@@ -243,7 +243,7 @@ __host__ __device__ static inline T cast_from_f8(fp8_storage_t x)
 
 #if CK_FP8_CVT_FAST_PATH
 template <ck_fp8_interpretation_t interpret>
-static __device__ float cast_to_f32_from_f8(fp8_storage_t v)
+static __host__ __device__ float cast_to_f32_from_f8(fp8_storage_t v)
 {
     union
     {

--- a/include/ck/utility/data_type.hpp
+++ b/include/ck/utility/data_type.hpp
@@ -2479,7 +2479,11 @@ struct vector_type<T, 64, typename ck::enable_if_t<!is_native_type<T>()>>
     }
 };
 
+#if defined(_WIN32)
+using int64_t = long long;
+#else
 using int64_t = long;
+#endif
 
 // fp64
 using double2_t = typename vector_type<double, 2>::type;


### PR DESCRIPTION
This PR fixes two compile errors when using AMD HIP SDK for Windows 6.2.4 (latest version) and ROCm 6.3.4 on Linux (latest version):

1. `call to 'amd_wave_read_first_lane' is ambiguous`

This is a Windows-only error, which seems to be the same as https://github.com/ROCm/composable_kernel/issues/1551, which was supposed to be fixed by https://github.com/ROCm/composable_kernel/pull/1631 but the error is still present. The root cause is the incorrect assumption that `long` is a 64-bit type on Windows. This is the proper fix. I think https://github.com/ROCm/composable_kernel/pull/1631 can be safely reverted.

2. `no matching function for call to 'cast_to_f32_from_f8'`

This error happens on both Windows and Linux. The issue is that this function isn't declared as `___host___` as well even though it is actually called from host code too.
