### PR TITLE
Enable ClangBuildAnalizer when doing ninja build traces.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,11 @@ RUN pip install --upgrade cmake==3.27.5 && \
     gunzip /usr/local/bin/ninja.gz && \
     chmod a+x /usr/local/bin/ninja && \
     git clone https://github.com/nico/ninjatracing.git && \
+#Install ClangBuildAnalyzer
+    git clone https://github.com/aras-p/ClangBuildAnalyzer.git && \
+    cd ClangBuildAnalyzer/ && \
+    make -f projects/make/Makefile && \
+    cd / && \
 #Install latest cppcheck
     git clone https://github.com/danmar/cppcheck.git && \
     cd cppcheck && mkdir build && cd build && cmake .. && cmake --build . && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -288,7 +288,7 @@ def cmake_build(Map conf=[:]){
     if(!setup_args.contains("NO_CK_BUILD")){
         if (setup_args.contains("gfx90a") && params.NINJA_BUILD_TRACE){
             echo "running ninja build trace"
-            setup_cmd = conf.get("setup_cmd", "${cmake_envs} cmake -G Ninja ${setup_args}   .. ")
+            setup_cmd = conf.get("setup_cmd", """${cmake_envs} cmake -G Ninja ${setup_args} -DCMAKE_CXX_FLAGS=" -O3 -ftime-trace "  .. """)
             build_cmd = conf.get("build_cmd", "${build_envs} ninja -j${nt} ${config_targets}")
         }
         else{
@@ -316,7 +316,10 @@ def cmake_build(Map conf=[:]){
         if(!setup_args.contains("NO_CK_BUILD") && !params.BUILD_LEGACY_OS){
             if (setup_args.contains("gfx90a") && params.NINJA_BUILD_TRACE){
                 sh "/ninjatracing/ninjatracing .ninja_log > ck_build_trace.json"
+                sh "/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --all . clang_build.log"
+                sh "/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --analyze clang_build.log > clang_build_analysis.log"
                 archiveArtifacts "ck_build_trace.json"
+                archiveArtifacts "clang_build_analysis.log"
                 // do not run unit tests when building instances only
                 if(!params.BUILD_INSTANCES_ONLY){
                     sh "ninja test"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -317,9 +317,9 @@ def cmake_build(Map conf=[:]){
             if (setup_args.contains("gfx90a") && params.NINJA_BUILD_TRACE){
                 sh "/ninjatracing/ninjatracing .ninja_log > ck_build_trace.json"
                 sh "/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --all . clang_build.log"
-                sh "/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --analyze clang_build.log > clang_build_analysis-$GIT_BRANCH.log"
+                sh "/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --analyze clang_build.log > clang_build_analysis.log"
                 archiveArtifacts "ck_build_trace.json"
-                archiveArtifacts "clang_build_analysis-$GIT_BRANCH.log"
+                archiveArtifacts "clang_build_analysis.log"
                 // do not run unit tests when building instances only
                 if(!params.BUILD_INSTANCES_ONLY){
                     sh "ninja test"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -317,9 +317,9 @@ def cmake_build(Map conf=[:]){
             if (setup_args.contains("gfx90a") && params.NINJA_BUILD_TRACE){
                 sh "/ninjatracing/ninjatracing .ninja_log > ck_build_trace.json"
                 sh "/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --all . clang_build.log"
-                sh """/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --analyze clang_build.log > clang_build_analysis-$GIT_BRANCH-$(date "+%d-%m-%y").log"""
+                sh """/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --analyze clang_build.log > clang_build_analysis-$GIT_BRANCH-\$(date "+%d-%m-%y").log"""
                 archiveArtifacts "ck_build_trace.json"
-                archiveArtifacts """clang_build_analysis-$GIT_BRANCH-$(date "+%d-%m-%y").log"""
+                archiveArtifacts """clang_build_analysis-$GIT_BRANCH-\$(date "+%d-%m-%y").log"""
                 // do not run unit tests when building instances only
                 if(!params.BUILD_INSTANCES_ONLY){
                     sh "ninja test"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -317,9 +317,9 @@ def cmake_build(Map conf=[:]){
             if (setup_args.contains("gfx90a") && params.NINJA_BUILD_TRACE){
                 sh "/ninjatracing/ninjatracing .ninja_log > ck_build_trace.json"
                 sh "/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --all . clang_build.log"
-                sh "/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --analyze clang_build.log > clang_build_analysis.log"
+                sh "/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --analyze clang_build.log > clang_build_analysis-$GIT_BRANCH-$(date "+%d-%m-%y").log"
                 archiveArtifacts "ck_build_trace.json"
-                archiveArtifacts "clang_build_analysis.log"
+                archiveArtifacts "clang_build_analysis-$GIT_BRANCH-$(date "+%d-%m-%y").log"
                 // do not run unit tests when building instances only
                 if(!params.BUILD_INSTANCES_ONLY){
                     sh "ninja test"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -317,9 +317,9 @@ def cmake_build(Map conf=[:]){
             if (setup_args.contains("gfx90a") && params.NINJA_BUILD_TRACE){
                 sh "/ninjatracing/ninjatracing .ninja_log > ck_build_trace.json"
                 sh "/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --all . clang_build.log"
-                sh "/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --analyze clang_build.log > clang_build_analysis-$GIT_BRANCH-$(date "+%d-%m-%y").log"
+                sh """/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --analyze clang_build.log > clang_build_analysis-$GIT_BRANCH-$(date "+%d-%m-%y").log"""
                 archiveArtifacts "ck_build_trace.json"
-                archiveArtifacts "clang_build_analysis-$GIT_BRANCH-$(date "+%d-%m-%y").log"
+                archiveArtifacts """clang_build_analysis-$GIT_BRANCH-$(date "+%d-%m-%y").log"""
                 // do not run unit tests when building instances only
                 if(!params.BUILD_INSTANCES_ONLY){
                     sh "ninja test"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -317,9 +317,9 @@ def cmake_build(Map conf=[:]){
             if (setup_args.contains("gfx90a") && params.NINJA_BUILD_TRACE){
                 sh "/ninjatracing/ninjatracing .ninja_log > ck_build_trace.json"
                 sh "/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --all . clang_build.log"
-                sh """/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --analyze clang_build.log > clang_build_analysis-$GIT_BRANCH-\$(date "+%d-%m-%y").log"""
+                sh """/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --analyze clang_build.log > clang_build_analysis-$GIT_BRANCH-${date "+%d-%m-%y"}.log"""
                 archiveArtifacts "ck_build_trace.json"
-                archiveArtifacts """clang_build_analysis-$GIT_BRANCH-\$(date "+%d-%m-%y").log"""
+                archiveArtifacts """clang_build_analysis-$GIT_BRANCH-${date "+%d-%m-%y"}.log"""
                 // do not run unit tests when building instances only
                 if(!params.BUILD_INSTANCES_ONLY){
                     sh "ninja test"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -317,9 +317,9 @@ def cmake_build(Map conf=[:]){
             if (setup_args.contains("gfx90a") && params.NINJA_BUILD_TRACE){
                 sh "/ninjatracing/ninjatracing .ninja_log > ck_build_trace.json"
                 sh "/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --all . clang_build.log"
-                sh """/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --analyze clang_build.log > clang_build_analysis-$GIT_BRANCH-${date "+%d-%m-%y"}.log"""
+                sh "/ClangBuildAnalyzer/build/ClangBuildAnalyzer  --analyze clang_build.log > clang_build_analysis-$GIT_BRANCH.log"
                 archiveArtifacts "ck_build_trace.json"
-                archiveArtifacts """clang_build_analysis-$GIT_BRANCH-${date "+%d-%m-%y"}.log"""
+                archiveArtifacts "clang_build_analysis-$GIT_BRANCH.log"
                 // do not run unit tests when building instances only
                 if(!params.BUILD_INSTANCES_ONLY){
                     sh "ninja test"


### PR DESCRIPTION
## Proposed changes

This will also generate the ClangBuildAnalyzer report every time we build CK without ccache and use ninja trace.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ x] I have added inline documentation which enables the maintainers with understanding the motivation
- [ x] I have removed the stale documentation which is no longer relevant after this pull request
- [ x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ x] I have run `clang-format` on all changed files
- [ x] Any dependent changes have been merged



