### PR TITLE
Ping pong scheduler, 2-warp solution, for GEMM kernel

### DIFF
--- a/example/ck_tile/03_gemm/gemm_utils.hpp
+++ b/example/ck_tile/03_gemm/gemm_utils.hpp
@@ -100,7 +100,7 @@ struct GemmConfig
     // Using the ping pong reader in the lds level
     static constexpr ck_tile::index_t M_Tile = 64;
     static constexpr ck_tile::index_t N_Tile = 32;
-    static constexpr ck_tile::index_t K_Tile = 8;
+    static constexpr ck_tile::index_t K_Tile = 16;
 
     static constexpr ck_tile::index_t M_Warp = 2;
     static constexpr ck_tile::index_t N_Warp = 1;
@@ -108,7 +108,7 @@ struct GemmConfig
 
     static constexpr ck_tile::index_t M_Warp_Tile = 32;
     static constexpr ck_tile::index_t N_Warp_Tile = 32;
-    static constexpr ck_tile::index_t K_Warp_Tile = 8;
+    static constexpr ck_tile::index_t K_Warp_Tile = 16;
 
     static constexpr bool DoubleSmemBuffer          = false;
     static constexpr ck_tile::index_t NumWaveGroups = 2;

--- a/example/ck_tile/03_gemm/gemm_utils.hpp
+++ b/example/ck_tile/03_gemm/gemm_utils.hpp
@@ -56,7 +56,7 @@ struct GemmConfig
     static constexpr ck_tile::index_t N_Warp_Tile = 32;
     static constexpr ck_tile::index_t K_Warp_Tile = 8;
 
-    static constexpr bool DoubleSmemBuffer = false;
+    static constexpr bool DoubleSmemBuffer          = false;
     static constexpr ck_tile::index_t NumWaveGroups = 1;
 
 #endif
@@ -74,7 +74,7 @@ struct GemmConfig
     static constexpr ck_tile::index_t N_Warp_Tile = 32;
     static constexpr ck_tile::index_t K_Warp_Tile = 16;
 
-    static constexpr bool DoubleSmemBuffer = false;
+    static constexpr bool DoubleSmemBuffer          = false;
     static constexpr ck_tile::index_t NumWaveGroups = 1;
 
 #elif(CK_TILE_PIPELINE_DEFAULT == CK_TILE_PIPELINE_COMPUTE_V4)
@@ -92,7 +92,7 @@ struct GemmConfig
     static constexpr ck_tile::index_t N_Warp_Tile = 32;
     static constexpr ck_tile::index_t K_Warp_Tile = 16;
 
-    static constexpr bool DoubleSmemBuffer = true;
+    static constexpr bool DoubleSmemBuffer          = true;
     static constexpr ck_tile::index_t NumWaveGroups = 1;
 
 #elif(CK_TILE_PIPELINE_DEFAULT == CK_TILE_PIPELINE_COMPUTE_V5)
@@ -110,7 +110,7 @@ struct GemmConfig
     static constexpr ck_tile::index_t N_Warp_Tile = 32;
     static constexpr ck_tile::index_t K_Warp_Tile = 8;
 
-    static constexpr bool DoubleSmemBuffer = false; 
+    static constexpr bool DoubleSmemBuffer          = false;
     static constexpr ck_tile::index_t NumWaveGroups = 2;
 #endif
 

--- a/example/ck_tile/03_gemm/gemm_utils.hpp
+++ b/example/ck_tile/03_gemm/gemm_utils.hpp
@@ -100,7 +100,7 @@ struct GemmConfig
     // Using the ping pong reader in the lds level
     static constexpr ck_tile::index_t M_Tile = 64;
     static constexpr ck_tile::index_t N_Tile = 32;
-    static constexpr ck_tile::index_t K_Tile = 16;
+    static constexpr ck_tile::index_t K_Tile = 8;
 
     static constexpr ck_tile::index_t M_Warp = 2;
     static constexpr ck_tile::index_t N_Warp = 1;
@@ -108,7 +108,7 @@ struct GemmConfig
 
     static constexpr ck_tile::index_t M_Warp_Tile = 32;
     static constexpr ck_tile::index_t N_Warp_Tile = 32;
-    static constexpr ck_tile::index_t K_Warp_Tile = 16;
+    static constexpr ck_tile::index_t K_Warp_Tile = 8;
 
     static constexpr bool DoubleSmemBuffer          = false;
     static constexpr ck_tile::index_t NumWaveGroups = 2;

--- a/example/ck_tile/03_gemm/gemm_utils.hpp
+++ b/example/ck_tile/03_gemm/gemm_utils.hpp
@@ -14,9 +14,10 @@
 #define CK_TILE_PIPELINE_COMPUTE_V3 1
 #define CK_TILE_PIPELINE_MEMORY 2
 #define CK_TILE_PIPELINE_COMPUTE_V4 3
+#define CK_TILE_PIPELINE_COMPUTE_V5 4
 
 #ifndef CK_TILE_PIPELINE_DEFAULT
-#define CK_TILE_PIPELINE_DEFAULT CK_TILE_PIPELINE_COMPUTE_V3
+#define CK_TILE_PIPELINE_DEFAULT CK_TILE_PIPELINE_COMPUTE_V5
 #endif
 
 #if(CK_TILE_PIPELINE_DEFAULT == CK_TILE_PIPELINE_MEMORY)
@@ -30,6 +31,10 @@
 #elif(CK_TILE_PIPELINE_DEFAULT == CK_TILE_PIPELINE_COMPUTE_V4)
 #define GEMM_PIPELINE ck_tile::GemmPipelineAgBgCrCompV4
 #define UNIVERSAL_GEMM_PIPELINE ck_tile::BaseGemmPipelineAgBgCrCompV4
+#define GEMM_PIPELINE_SCHEDULER ck_tile::GemmPipelineScheduler::Intrawave
+#elif(CK_TILE_PIPELINE_DEFAULT == CK_TILE_PIPELINE_COMPUTE_V5)
+#define GEMM_PIPELINE ck_tile::GemmPipelineAgBgCrCompV5
+#define UNIVERSAL_GEMM_PIPELINE ck_tile::BaseGemmPipelineAgBgCrCompV5
 #define GEMM_PIPELINE_SCHEDULER ck_tile::GemmPipelineScheduler::Intrawave
 #else
 #error "unsupported CK_TILE_PIPELINE_DEFAULT value"
@@ -52,6 +57,8 @@ struct GemmConfig
     static constexpr ck_tile::index_t K_Warp_Tile = 8;
 
     static constexpr bool DoubleSmemBuffer = false;
+    static constexpr ck_tile::index_t NumWaveGroups = 1;
+
 #endif
 #if(CK_TILE_PIPELINE_DEFAULT == CK_TILE_PIPELINE_COMPUTE_V3)
     // Compute friendly for Intrawave scheduler
@@ -68,6 +75,8 @@ struct GemmConfig
     static constexpr ck_tile::index_t K_Warp_Tile = 16;
 
     static constexpr bool DoubleSmemBuffer = false;
+    static constexpr ck_tile::index_t NumWaveGroups = 1;
+
 #elif(CK_TILE_PIPELINE_DEFAULT == CK_TILE_PIPELINE_COMPUTE_V4)
     // Compute friendly for Intrawave scheduler
     // Using the ping pong reader in the lds level
@@ -84,6 +93,25 @@ struct GemmConfig
     static constexpr ck_tile::index_t K_Warp_Tile = 16;
 
     static constexpr bool DoubleSmemBuffer = true;
+    static constexpr ck_tile::index_t NumWaveGroups = 1;
+
+#elif(CK_TILE_PIPELINE_DEFAULT == CK_TILE_PIPELINE_COMPUTE_V5)
+    // Compute friendly for Intrawave scheduler
+    // Using the ping pong reader in the lds level
+    static constexpr ck_tile::index_t M_Tile = 64;
+    static constexpr ck_tile::index_t N_Tile = 32;
+    static constexpr ck_tile::index_t K_Tile = 8;
+
+    static constexpr ck_tile::index_t M_Warp = 2;
+    static constexpr ck_tile::index_t N_Warp = 1;
+    static constexpr ck_tile::index_t K_Warp = 1;
+
+    static constexpr ck_tile::index_t M_Warp_Tile = 32;
+    static constexpr ck_tile::index_t N_Warp_Tile = 32;
+    static constexpr ck_tile::index_t K_Warp_Tile = 8;
+
+    static constexpr bool DoubleSmemBuffer = false; 
+    static constexpr ck_tile::index_t NumWaveGroups = 2;
 #endif
 
     static constexpr bool kPadM = false;

--- a/example/ck_tile/03_gemm/run_gemm_example.inc
+++ b/example/ck_tile/03_gemm/run_gemm_example.inc
@@ -259,19 +259,25 @@ int run_gemm_example_with_layouts(int argc,
         b_k_n.SetZero();
     }
 
-  
+/*
     for (ck_tile::index_t i = 0; i < M; i ++)
     {
             a_m_k(i, 0) = static_cast<ck_tile::half_t>(i+1);
-            //a_m_k(i, 8) = static_cast<ck_tile::half_t>(i+1);
+            a_m_k(i, 8) = static_cast<ck_tile::half_t>(i+1);
+            a_m_k(i, 16) = static_cast<ck_tile::half_t>(i+1);
+            a_m_k(i, 24) = static_cast<ck_tile::half_t>(i+1);
+
     }
 
     for (ck_tile::index_t j = 0; j < N; j ++)
     {
             b_k_n(0, j) = static_cast<ck_tile::half_t>(j+1);
-            //b_k_n(8, j) = static_cast<ck_tile::half_t>(j+1);
-    }
+            b_k_n(8, j) = static_cast<ck_tile::half_t>(j+1);
+            b_k_n(16, j) = static_cast<ck_tile::half_t>(j+1);
+            b_k_n(24, j) = static_cast<ck_tile::half_t>(j+1);
 
+    }
+*/
 
 
     ck_tile::DeviceMem a_m_k_dev_buf(a_m_k.get_element_space_size_in_bytes());

--- a/example/ck_tile/03_gemm/run_gemm_example.inc
+++ b/example/ck_tile/03_gemm/run_gemm_example.inc
@@ -259,6 +259,21 @@ int run_gemm_example_with_layouts(int argc,
         b_k_n.SetZero();
     }
 
+  
+    for (ck_tile::index_t i = 0; i < M; i ++)
+    {
+            a_m_k(i, 0) = static_cast<ck_tile::half_t>(i+1);
+            //a_m_k(i, 8) = static_cast<ck_tile::half_t>(i+1);
+    }
+
+    for (ck_tile::index_t j = 0; j < N; j ++)
+    {
+            b_k_n(0, j) = static_cast<ck_tile::half_t>(j+1);
+            //b_k_n(8, j) = static_cast<ck_tile::half_t>(j+1);
+    }
+
+
+
     ck_tile::DeviceMem a_m_k_dev_buf(a_m_k.get_element_space_size_in_bytes());
     ck_tile::DeviceMem b_k_n_dev_buf(b_k_n.get_element_space_size_in_bytes());
     ck_tile::DeviceMem c_m_n_dev_buf(c_m_n_dev_result.get_element_space_size_in_bytes());
@@ -335,6 +350,17 @@ int run_gemm_example_with_layouts(int argc,
                   << " Absolute error threshold: " << rtol_atol.at(ck_tile::number<1>{})
                   << std::endl;
         std::cout << "The CPU verification result is:" << (pass ? "correct" : "fail") << std::endl;
+
+        ck_tile::index_t i, j;
+
+        for (i = 0; i < M; i ++)
+        {
+            for (j = 0; j < N; j ++)
+            {
+                std::cout << std::setw(6) << static_cast<float>(c_m_n_dev_result(i, j)); 
+            }
+            std::cout << std::endl;
+        }
     }
     else if(arg_parser.get_int("v") == 2)
     {

--- a/example/ck_tile/03_gemm/universal_gemm.cpp
+++ b/example/ck_tile/03_gemm/universal_gemm.cpp
@@ -46,7 +46,7 @@ float gemm_calc(const ck_tile::GemmHostArgs& args, const ck_tile::stream_config&
                                                                  ALayout,
                                                                  BLayout,
                                                                  CLayout,
-                                                                 GemmConfig::TransposeC, 
+                                                                 GemmConfig::TransposeC,
                                                                  GemmConfig::NumWaveGroups>;
     using GemmPipelineProblem =
         ck_tile::GemmPipelineProblem<ADataType, BDataType, AccDataType, GemmShape, Traits>;
@@ -78,15 +78,15 @@ float gemm_calc(const ck_tile::GemmHostArgs& args, const ck_tile::stream_config&
         using GemmPipeline = GEMM_PIPELINE<UniversalGemmProblem>;
 
         using GemmEpilogue = ck_tile::DefaultGemm2DEpilogue<
-            ck_tile::DefaultGemm2DEpilogueProblem<AccDataType, 
-                                                CDataType, 
-                                                CLayout, 
-                                                GemmConfig::kPadM, 
-                                                GemmConfig::kPadN, 
-                                                GemmConfig::M_Warp_Tile, 
-                                                GemmConfig::N_Warp_Tile,
-                                                GemmConfig::K_Warp_Tile, 
-                                                UniversalGemmProblem::TransposeC>>; 
+            ck_tile::DefaultGemm2DEpilogueProblem<AccDataType,
+                                                  CDataType,
+                                                  CLayout,
+                                                  GemmConfig::kPadM,
+                                                  GemmConfig::kPadN,
+                                                  GemmConfig::M_Warp_Tile,
+                                                  GemmConfig::N_Warp_Tile,
+                                                  GemmConfig::K_Warp_Tile,
+                                                  UniversalGemmProblem::TransposeC>>;
 
         /*
         using GemmEpilogue = ck_tile::CShuffleEpilogue<
@@ -103,7 +103,7 @@ float gemm_calc(const ck_tile::GemmHostArgs& args, const ck_tile::stream_config&
                                              GemmConfig::M_Warp_Tile,
                                              GemmConfig::N_Warp_Tile,
                                              GemmConfig::K_Warp_Tile,
-                                             UniversalGemmProblem::TransposeC, 
+                                             UniversalGemmProblem::TransposeC,
                                              GemmConfig::NumWaveGroups>>;
         */
         using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;
@@ -326,9 +326,9 @@ int run_gemm_example(int argc, char* argv[])
     std::string a_layout  = arg_parser.get_str("a_layout");
     std::string b_layout  = arg_parser.get_str("b_layout");
 
-    //if(data_type == "fp16")
+    // if(data_type == "fp16")
     //{
-        return run_gemm_example_prec_type<ck_tile::half_t>(a_layout, b_layout, argc, argv);
+    return run_gemm_example_prec_type<ck_tile::half_t>(a_layout, b_layout, argc, argv);
     /*
     }
     else if(data_type == "bf16")

--- a/example/ck_tile/03_gemm/universal_gemm.cpp
+++ b/example/ck_tile/03_gemm/universal_gemm.cpp
@@ -77,6 +77,7 @@ float gemm_calc(const ck_tile::GemmHostArgs& args, const ck_tile::stream_config&
 
         using GemmPipeline = GEMM_PIPELINE<UniversalGemmProblem>;
 
+        
         using GemmEpilogue = ck_tile::DefaultGemm2DEpilogue<
             ck_tile::DefaultGemm2DEpilogueProblem<AccDataType,
                                                   CDataType,
@@ -86,8 +87,9 @@ float gemm_calc(const ck_tile::GemmHostArgs& args, const ck_tile::stream_config&
                                                   GemmConfig::M_Warp_Tile,
                                                   GemmConfig::N_Warp_Tile,
                                                   GemmConfig::K_Warp_Tile,
-                                                  UniversalGemmProblem::TransposeC>>;
-
+                                                  UniversalGemmProblem::TransposeC, 
+                                                  false>>;
+        
         /*
         using GemmEpilogue = ck_tile::CShuffleEpilogue<
             ck_tile::CShuffleEpilogueProblem<ADataType,
@@ -286,6 +288,7 @@ int run_gemm_example_prec_type(std::string a_layout, std::string b_layout, int a
             return run_gemm_example_with_layouts<APrecType, BPrecType, CPrecType>(
                 argc, argv, Row{}, Col{}, Row{});
         }
+        /*
         else if(a_layout == "R" && b_layout == "C")
         {
             return run_gemm_example_with_layouts<APrecType, BPrecType, CPrecType>(
@@ -301,6 +304,7 @@ int run_gemm_example_prec_type(std::string a_layout, std::string b_layout, int a
             return run_gemm_example_with_layouts<APrecType, BPrecType, CPrecType>(
                 argc, argv, Col{}, Col{}, Row{});
         }
+        */
         else
         {
             throw std::runtime_error("Unsupported memory layout for the input matrices!");
@@ -322,6 +326,7 @@ int run_gemm_example(int argc, char* argv[])
     {
         return run_gemm_example_prec_type<ck_tile::half_t>(a_layout, b_layout, argc, argv);
     }
+    /*
     else if(data_type == "bf16")
     {
         return run_gemm_example_prec_type<ck_tile::bf16_t>(a_layout, b_layout, argc, argv);
@@ -345,6 +350,7 @@ int run_gemm_example(int argc, char* argv[])
             a_layout, b_layout, argc, argv);
     }
 #endif
+    */
     else
     {
         throw std::runtime_error("Unsupported data type for this operation !!!");

--- a/example/ck_tile/03_gemm/universal_gemm.cpp
+++ b/example/ck_tile/03_gemm/universal_gemm.cpp
@@ -46,7 +46,8 @@ float gemm_calc(const ck_tile::GemmHostArgs& args, const ck_tile::stream_config&
                                                                  ALayout,
                                                                  BLayout,
                                                                  CLayout,
-                                                                 GemmConfig::TransposeC>;
+                                                                 GemmConfig::TransposeC, 
+                                                                 GemmConfig::NumWaveGroups>;
     using GemmPipelineProblem =
         ck_tile::GemmPipelineProblem<ADataType, BDataType, AccDataType, GemmShape, Traits>;
 
@@ -75,6 +76,19 @@ float gemm_calc(const ck_tile::GemmHostArgs& args, const ck_tile::stream_config&
                                                                            tail_number_v>;
 
         using GemmPipeline = GEMM_PIPELINE<UniversalGemmProblem>;
+
+        using GemmEpilogue = ck_tile::DefaultGemm2DEpilogue<
+            ck_tile::DefaultGemm2DEpilogueProblem<AccDataType, 
+                                                CDataType, 
+                                                CLayout, 
+                                                GemmConfig::kPadM, 
+                                                GemmConfig::kPadN, 
+                                                GemmConfig::M_Warp_Tile, 
+                                                GemmConfig::N_Warp_Tile,
+                                                GemmConfig::K_Warp_Tile, 
+                                                UniversalGemmProblem::TransposeC>>; 
+
+        /*
         using GemmEpilogue = ck_tile::CShuffleEpilogue<
             ck_tile::CShuffleEpilogueProblem<ADataType,
                                              BDataType,
@@ -89,7 +103,9 @@ float gemm_calc(const ck_tile::GemmHostArgs& args, const ck_tile::stream_config&
                                              GemmConfig::M_Warp_Tile,
                                              GemmConfig::N_Warp_Tile,
                                              GemmConfig::K_Warp_Tile,
-                                             UniversalGemmProblem::TransposeC>>;
+                                             UniversalGemmProblem::TransposeC, 
+                                             GemmConfig::NumWaveGroups>>;
+        */
         using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;
         auto kargs   = Kernel::MakeKernelArgs(args);
 
@@ -310,9 +326,10 @@ int run_gemm_example(int argc, char* argv[])
     std::string a_layout  = arg_parser.get_str("a_layout");
     std::string b_layout  = arg_parser.get_str("b_layout");
 
-    if(data_type == "fp16")
-    {
+    //if(data_type == "fp16")
+    //{
         return run_gemm_example_prec_type<ck_tile::half_t>(a_layout, b_layout, argc, argv);
+    /*
     }
     else if(data_type == "bf16")
     {
@@ -341,6 +358,7 @@ int run_gemm_example(int argc, char* argv[])
     {
         throw std::runtime_error("Unsupported data type for this operation !!!");
     }
+        */
 }
 
 int main(int argc, char* argv[])

--- a/example/ck_tile/03_gemm/universal_gemm.cpp
+++ b/example/ck_tile/03_gemm/universal_gemm.cpp
@@ -229,6 +229,17 @@ float gemm_calc(const ck_tile::GemmHostArgs& args, const ck_tile::stream_config&
             Run(ck_tile::bool_constant<true>{},
                 ck_tile::integral_constant<ck_tile::TailNumber, ck_tile::TailNumber::Two>{});
         }
+#elif(CK_TILE_PIPELINE_DEFAULT == CK_TILE_PIPELINE_COMPUTE_V5)
+        if(tail_num == ck_tile::TailNumber::One)
+        {
+            Run(ck_tile::bool_constant<true>{},
+                ck_tile::integral_constant<ck_tile::TailNumber, ck_tile::TailNumber::One>{});
+        }
+        else
+        {
+            Run(ck_tile::bool_constant<true>{},
+                ck_tile::integral_constant<ck_tile::TailNumber, ck_tile::TailNumber::Two>{});
+        }             
 #endif
     }
     else
@@ -269,30 +280,11 @@ int run_gemm_example_prec_type(std::string a_layout, std::string b_layout, int a
     using Row = ck_tile::tensor_layout::gemm::RowMajor;
     using Col = ck_tile::tensor_layout::gemm::ColumnMajor;
 
-    if constexpr(std::is_same_v<BPrecType, ck_tile::pk_int4_t>)
-    {
+
         if(a_layout == "R" && b_layout == "C")
         {
             return run_gemm_example_with_layouts<APrecType, BPrecType, CPrecType>(
                 argc, argv, Row{}, Col{}, Row{});
-        }
-        else if(a_layout == "C" && b_layout == "C")
-        {
-            return run_gemm_example_with_layouts<APrecType, BPrecType, CPrecType>(
-                argc, argv, Col{}, Col{}, Row{});
-        }
-        else
-        {
-            throw std::runtime_error("Unsupported memory layout for the input matrices when "
-                                     "BPrecType is ck_tile::pk_int4_t!");
-        }
-    }
-    else
-    {
-        if(a_layout == "R" && b_layout == "R")
-        {
-            return run_gemm_example_with_layouts<APrecType, BPrecType, CPrecType>(
-                argc, argv, Row{}, Row{}, Row{});
         }
         else if(a_layout == "R" && b_layout == "C")
         {
@@ -313,7 +305,7 @@ int run_gemm_example_prec_type(std::string a_layout, std::string b_layout, int a
         {
             throw std::runtime_error("Unsupported memory layout for the input matrices!");
         }
-    }
+
 }
 
 int run_gemm_example(int argc, char* argv[])
@@ -326,10 +318,9 @@ int run_gemm_example(int argc, char* argv[])
     std::string a_layout  = arg_parser.get_str("a_layout");
     std::string b_layout  = arg_parser.get_str("b_layout");
 
-    // if(data_type == "fp16")
-    //{
-    return run_gemm_example_prec_type<ck_tile::half_t>(a_layout, b_layout, argc, argv);
-    /*
+     if(data_type == "fp16")
+    {
+        return run_gemm_example_prec_type<ck_tile::half_t>(a_layout, b_layout, argc, argv);
     }
     else if(data_type == "bf16")
     {
@@ -358,7 +349,6 @@ int run_gemm_example(int argc, char* argv[])
     {
         throw std::runtime_error("Unsupported data type for this operation !!!");
     }
-        */
 }
 
 int main(int argc, char* argv[])

--- a/include/ck_tile/core/algorithm/static_encoding_pattern.hpp
+++ b/include/ck_tile/core/algorithm/static_encoding_pattern.hpp
@@ -56,20 +56,24 @@ template <index_t BlockSize,
           index_t YPerTile,
           index_t XPerTile,
           index_t VecSize,
+          index_t NumWaveGroups,
           tile_distribution_pattern DistributionPattern>
 struct TileDistributionEncodingPattern2D : public TileDistributionEncodingPattern
 {
 };
 
 // Thread raked
-template <index_t BlockSize, index_t YPerTile, index_t XPerTile, index_t VecSize>
+template <index_t BlockSize, index_t YPerTile, index_t XPerTile, index_t VecSize, index_t NumWaveGroups>
 struct TileDistributionEncodingPattern2D<BlockSize,
                                          YPerTile,
                                          XPerTile,
                                          VecSize,
+                                         NumWaveGroups,
                                          tile_distribution_pattern::thread_raked>
     : public TileDistributionEncodingPattern
 {
+
+    static_assert(NumWaveGroups == 2);
 
     // TODO: make pattern where below condition does not need to hold - GGemmMultiDSplitk!
     static_assert(XPerTile % VecSize == 0, "XPerTile must be a multiple of VecSize!");
@@ -82,12 +86,12 @@ struct TileDistributionEncodingPattern2D<BlockSize,
     static constexpr index_t Y1 = warp_size / X0;
     static_assert(X0 * Y1 == warp_size, "X0 * Y1 must cover whole wavefront!");
 
-    static constexpr index_t Y0 = num_warps;
+    static constexpr index_t Y0 = num_warps / NumWaveGroups;
     //  YPerWarp = YPerTile / Y0;
     //  Y2 = YPerWarp / Y1;
     static constexpr index_t Y2 = YPerTile / (Y1 * Y0); // # of iters within wavefront
 
-    static_assert(X0 * Y1 * Y0 == BlockSize, "X0 * warp_ys * Y0 must cover whole workgroup!");
+    static_assert(X0 * Y1 * Y0 * NumWaveGroups == BlockSize, "X0 * warp_ys * Y0 must cover whole workgroup!");
     static_assert(Y0 * Y1 * Y2 == YPerTile, "Y0, Y1, Y2 must cover whole YPerTile");
 
     CK_TILE_HOST_DEVICE static constexpr auto Make2DStaticTileDistribution()
@@ -119,6 +123,7 @@ struct TileDistributionEncodingPattern2D<BlockSize,
                                          YPerTile,
                                          XPerTile,
                                          VecSize,
+                                         1,
                                          tile_distribution_pattern::warp_raked>
     : public TileDistributionEncodingPattern
 {
@@ -167,6 +172,7 @@ struct TileDistributionEncodingPattern2D<BlockSize,
                                          YPerTile,
                                          XPerTile,
                                          VecSize,
+                                         1,
                                          tile_distribution_pattern::block_raked>
     : public TileDistributionEncodingPattern
 {

--- a/include/ck_tile/core/algorithm/static_encoding_pattern.hpp
+++ b/include/ck_tile/core/algorithm/static_encoding_pattern.hpp
@@ -98,24 +98,51 @@ struct TileDistributionEncodingPattern2D<BlockSize,
 
     CK_TILE_HOST_DEVICE static constexpr auto Make2DStaticTileDistribution()
     {
-        return make_static_tile_distribution(
-            tile_distribution_encoding<sequence<1>,
-                                       tuple<sequence<Y0, Y1, Y2>, sequence<X0, X1>>,
-                                       tuple<sequence<1>, sequence<1, 2>>,
-                                       tuple<sequence<0>, sequence<1, 0>>,
-                                       sequence<1, 2>,
-                                       sequence<2, 1>>{});
+        if constexpr(NumWaveGroups != 1)
+        {
+            return make_static_tile_distribution(
+                tile_distribution_encoding<sequence<Y0>,                                
+                                        tuple<sequence<Y1, Y2>, sequence<X0, X1>>,   
+                                        tuple<sequence<0>, sequence<1, 2>>,          
+                                        tuple<sequence<0>, sequence<0, 0>>,          
+                                        sequence<1, 2>,                              
+                                        sequence<1, 1>>{});                              
+
+        }
+        else
+        {
+            return make_static_tile_distribution(
+                tile_distribution_encoding<sequence<1>,                                
+                                        tuple<sequence<Y0, Y1, Y2>, sequence<X0, X1>>,   
+                                        tuple<sequence<1>, sequence<1, 2>>,          
+                                        tuple<sequence<0>, sequence<1, 0>>,          
+                                        sequence<1, 2>,                              
+                                        sequence<2, 1>>{});                              
+        }
     }
 
     CK_TILE_HOST_DEVICE static constexpr auto MakeShuffled2DStaticTileDistribution()
     {
-        return make_static_tile_distribution(
-            tile_distribution_encoding<sequence<1>,
+        if constexpr(NumWaveGroups != 1)
+        {
+            return make_static_tile_distribution(
+                tile_distribution_encoding<sequence<Y0>, 
+                                        tuple<sequence<X0, X1>, sequence<Y1, Y2>>,
+                                        tuple<sequence<0>, sequence<2, 1>>, 
+                                        tuple<sequence<0>, sequence<0, 0>>,
+                                        sequence<1, 2>,
+                                        sequence<1, 1>>{});            
+        }
+        else
+        {
+            return make_static_tile_distribution(
+                tile_distribution_encoding<sequence<1>,
                                        tuple<sequence<X0, X1>, sequence<Y0, Y1, Y2>>,
                                        tuple<sequence<2>, sequence<2, 1>>,
                                        tuple<sequence<0>, sequence<1, 0>>,
                                        sequence<1, 2>,
                                        sequence<1, 2>>{});
+        }
     }
 };
 

--- a/include/ck_tile/core/algorithm/static_encoding_pattern.hpp
+++ b/include/ck_tile/core/algorithm/static_encoding_pattern.hpp
@@ -76,9 +76,6 @@ struct TileDistributionEncodingPattern2D<BlockSize,
                                          tile_distribution_pattern::thread_raked>
     : public TileDistributionEncodingPattern
 {
-
-    static_assert(NumWaveGroups == 2);
-
     // TODO: make pattern where below condition does not need to hold - GGemmMultiDSplitk!
     static_assert(XPerTile % VecSize == 0, "XPerTile must be a multiple of VecSize!");
     static constexpr index_t warp_size = get_warp_size();

--- a/include/ck_tile/core/algorithm/static_encoding_pattern.hpp
+++ b/include/ck_tile/core/algorithm/static_encoding_pattern.hpp
@@ -63,7 +63,11 @@ struct TileDistributionEncodingPattern2D : public TileDistributionEncodingPatter
 };
 
 // Thread raked
-template <index_t BlockSize, index_t YPerTile, index_t XPerTile, index_t VecSize, index_t NumWaveGroups>
+template <index_t BlockSize,
+          index_t YPerTile,
+          index_t XPerTile,
+          index_t VecSize,
+          index_t NumWaveGroups>
 struct TileDistributionEncodingPattern2D<BlockSize,
                                          YPerTile,
                                          XPerTile,
@@ -91,7 +95,8 @@ struct TileDistributionEncodingPattern2D<BlockSize,
     //  Y2 = YPerWarp / Y1;
     static constexpr index_t Y2 = YPerTile / (Y1 * Y0); // # of iters within wavefront
 
-    static_assert(X0 * Y1 * Y0 * NumWaveGroups == BlockSize, "X0 * warp_ys * Y0 must cover whole workgroup!");
+    static_assert(X0 * Y1 * Y0 * NumWaveGroups == BlockSize,
+                  "X0 * warp_ys * Y0 must cover whole workgroup!");
     static_assert(Y0 * Y1 * Y2 == YPerTile, "Y0, Y1, Y2 must cover whole YPerTile");
 
     CK_TILE_HOST_DEVICE static constexpr auto Make2DStaticTileDistribution()

--- a/include/ck_tile/core/algorithm/static_encoding_pattern.hpp
+++ b/include/ck_tile/core/algorithm/static_encoding_pattern.hpp
@@ -87,7 +87,9 @@ struct TileDistributionEncodingPattern2D<BlockSize,
     static constexpr index_t Y1 = warp_size / X0;
     static_assert(X0 * Y1 == warp_size, "X0 * Y1 must cover whole wavefront!");
 
+    // Y0 - should be total available number of wavegroups.
     static constexpr index_t Y0 = num_warps / NumWaveGroups;
+    //static constexpr index_t Y0 = num_warps;
     //  YPerWarp = YPerTile / Y0;
     //  Y2 = YPerWarp / Y1;
     static constexpr index_t Y2 = YPerTile / (Y1 * Y0); // # of iters within wavefront

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -58,6 +58,7 @@ struct CShuffleEpilogue
     static constexpr index_t kMPerBlock     = Problem::kMPerBlock;
     static constexpr index_t kNPerBlock     = Problem::kNPerBlock;
     static constexpr index_t kMWave         = Problem::kMWave / Problem::kNumWaveGroups;
+    //static constexpr index_t kMWave         = Problem::kMWave;
     static constexpr index_t kNWave         = Problem::kNWave;
     static constexpr index_t kMPerXdl       = Problem::kMPerXdl;
     static constexpr index_t kNPerXdl       = Problem::kNPerXdl;

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -22,24 +22,24 @@ template <typename ADataType_,
           index_t kMPerXdl_,
           index_t kNPerXdl_,
           index_t kKPerXdl_,
-          bool isCTransposed_, 
+          bool isCTransposed_,
           index_t kNumWaveGroups_>
 struct CShuffleEpilogueProblem
 {
-    using ADataType                        = remove_cvref_t<ADataType_>;
-    using BDataType                        = remove_cvref_t<BDataType_>;
-    using AccDataType                      = remove_cvref_t<AccDataType_>;
-    using ODataType                        = remove_cvref_t<ODataType_>;
-    using CLayout                          = remove_cvref_t<CLayout_>;
-    static constexpr index_t kBlockSize    = kBlockSize_;
-    static constexpr index_t kMPerBlock    = kM_;
-    static constexpr index_t kNPerBlock    = kN_;
-    static constexpr index_t kMWave        = kMWave_;
-    static constexpr index_t kNWave        = kNWave_;
-    static constexpr index_t kMPerXdl      = kMPerXdl_;
-    static constexpr index_t kNPerXdl      = kNPerXdl_;
-    static constexpr index_t kKPerXdl      = kKPerXdl_;
-    static constexpr index_t isCTransposed = isCTransposed_;
+    using ADataType                         = remove_cvref_t<ADataType_>;
+    using BDataType                         = remove_cvref_t<BDataType_>;
+    using AccDataType                       = remove_cvref_t<AccDataType_>;
+    using ODataType                         = remove_cvref_t<ODataType_>;
+    using CLayout                           = remove_cvref_t<CLayout_>;
+    static constexpr index_t kBlockSize     = kBlockSize_;
+    static constexpr index_t kMPerBlock     = kM_;
+    static constexpr index_t kNPerBlock     = kN_;
+    static constexpr index_t kMWave         = kMWave_;
+    static constexpr index_t kNWave         = kNWave_;
+    static constexpr index_t kMPerXdl       = kMPerXdl_;
+    static constexpr index_t kNPerXdl       = kNPerXdl_;
+    static constexpr index_t kKPerXdl       = kKPerXdl_;
+    static constexpr index_t isCTransposed  = isCTransposed_;
     static constexpr index_t kNumWaveGroups = kNumWaveGroups_;
 };
 

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -22,7 +22,8 @@ template <typename ADataType_,
           index_t kMPerXdl_,
           index_t kNPerXdl_,
           index_t kKPerXdl_,
-          bool isCTransposed_>
+          bool isCTransposed_, 
+          index_t kNumWaveGroups_>
 struct CShuffleEpilogueProblem
 {
     using ADataType                        = remove_cvref_t<ADataType_>;
@@ -39,6 +40,7 @@ struct CShuffleEpilogueProblem
     static constexpr index_t kNPerXdl      = kNPerXdl_;
     static constexpr index_t kKPerXdl      = kKPerXdl_;
     static constexpr index_t isCTransposed = isCTransposed_;
+    static constexpr index_t kNumWaveGroups = kNumWaveGroups_;
 };
 
 template <typename Problem_, typename Policy_ = void>
@@ -55,7 +57,7 @@ struct CShuffleEpilogue
     static constexpr index_t kBlockSize     = Problem::kBlockSize;
     static constexpr index_t kMPerBlock     = Problem::kMPerBlock;
     static constexpr index_t kNPerBlock     = Problem::kNPerBlock;
-    static constexpr index_t kMWave         = Problem::kMWave;
+    static constexpr index_t kMWave         = Problem::kMWave / Problem::kNumWaveGroups;
     static constexpr index_t kNWave         = Problem::kNWave;
     static constexpr index_t kMPerXdl       = Problem::kMPerXdl;
     static constexpr index_t kNPerXdl       = Problem::kNPerXdl;
@@ -146,11 +148,14 @@ struct CShuffleEpilogue
                                         sequence<kMPerXdl * kMWave, kNPerXdl * kNWave>>;
         constexpr index_t num_access = SFC::get_num_of_access();
 
+        static_assert(Problem::kNumWaveGroups == 2);
+
         using TileEncodingPattern =
             TileDistributionEncodingPattern2D<kBlockSize,
                                               kMPerIteration,
                                               kNPerIteration,
                                               GetVectorSizeC(),
+                                              Problem::kNumWaveGroups,
                                               tile_distribution_pattern::thread_raked>;
         constexpr auto dram_tile_distribution = TileEncodingPattern::Make2DStaticTileDistribution();
 

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -148,8 +148,6 @@ struct CShuffleEpilogue
                                         sequence<kMPerXdl * kMWave, kNPerXdl * kNWave>>;
         constexpr index_t num_access = SFC::get_num_of_access();
 
-        static_assert(Problem::kNumWaveGroups == 2);
-
         using TileEncodingPattern =
             TileDistributionEncodingPattern2D<kBlockSize,
                                               kMPerIteration,

--- a/include/ck_tile/ops/gemm.hpp
+++ b/include/ck_tile/ops/gemm.hpp
@@ -31,6 +31,7 @@
 #include "ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v3.hpp"
 #include "ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v4.hpp"
 #include "ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v4_default_policy.hpp"
+#include "ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp"
 #include "ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_mem.hpp"
 #include "ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_scheduler.hpp"
 #include "ck_tile/ops/gemm/pipeline/gemm_pipeline_agmem_bgmem_creg_v1.hpp"

--- a/include/ck_tile/ops/gemm/block/block_gemm_areg_breg_creg_v1.hpp
+++ b/include/ck_tile/ops/gemm/block/block_gemm_areg_breg_creg_v1.hpp
@@ -65,7 +65,6 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeABlockDistributionEncode()
     {
-        static_assert(MWarp == 1);
 
         constexpr auto a_block_outer_dstr_encoding =
             tile_distribution_encoding<sequence<NWarp>,
@@ -82,7 +81,6 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeBBlockDistributionEncode()
     {
-        static_assert(MWarp == 1);
 
         constexpr auto b_block_outer_dstr_encoding =
             tile_distribution_encoding<sequence<MWarp>,
@@ -99,8 +97,6 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeCBlockDistributionEncode()
     {
-        static_assert(MWarp == 1);
-        static_assert(MIterPerWarp == 2);
 
         constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
             sequence<>,
@@ -121,7 +117,6 @@ struct BlockGemmARegBRegCRegV1
                                    const ABlockTensor& a_block_tensor,
                                    const BBlockTensor& b_block_tensor) const
     {
-        static_assert(Problem::kNumWaveGroups == 2);
 
         static_assert(std::is_same_v<ADataType, remove_cv_t<typename ABlockTensor::DataType>> &&
                           std::is_same_v<BDataType, remove_cv_t<typename BBlockTensor::DataType>> &&
@@ -170,8 +165,6 @@ struct BlockGemmARegBRegCRegV1
         constexpr auto b_warp_y_index_zeros = uniform_sequence_gen_t<BWarpDstr::NDimY, 0>{};
         constexpr auto c_warp_y_index_zeros = uniform_sequence_gen_t<CWarpDstr::NDimY, 0>{};
 
-        static_assert(MIterPerWarp == 2);
-
         // hot loop:
         static_for<0, KIterPerWarp, 1>{}([&](auto kIter) {
             static_for<0, MIterPerWarp, 1>{}([&](auto mIter) {
@@ -212,7 +205,6 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeCBlockTile()
     {
-        static_assert(MIterPerWarp == 2);
 
         constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
             sequence<>,

--- a/include/ck_tile/ops/gemm/block/block_gemm_areg_breg_creg_v1.hpp
+++ b/include/ck_tile/ops/gemm/block/block_gemm_areg_breg_creg_v1.hpp
@@ -34,8 +34,8 @@ struct BlockGemmARegBRegCRegV1
         static constexpr auto config = Policy::template GetWarpGemmMWarpNWarp<Problem>();
         using WarpGemm               = remove_cvref_t<decltype(config.template at<0>())>;
 
-        static constexpr index_t MWarp        = (config.template at<1>()) / (Problem::kNumWaveGroups);
-        static constexpr index_t NWarp        = config.template at<2>();
+        static constexpr index_t MWarp = (config.template at<1>()) / (Problem::kNumWaveGroups);
+        static constexpr index_t NWarp = config.template at<2>();
         static constexpr index_t MIterPerWarp = MPerBlock / (MWarp * WarpGemm::kM);
         static constexpr index_t NIterPerWarp = NPerBlock / (NWarp * WarpGemm::kN);
         static constexpr index_t KIterPerWarp = KPerBlock / WarpGemm::kK;

--- a/include/ck_tile/ops/gemm/block/block_gemm_areg_breg_creg_v1.hpp
+++ b/include/ck_tile/ops/gemm/block/block_gemm_areg_breg_creg_v1.hpp
@@ -74,31 +74,34 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeABlockDistributionEncode()
     {
-        constexpr auto a_block_outer_dstr_encoding =
-            tile_distribution_encoding<sequence<OrigNWarp>,
-                                       tuple<sequence<MIterPerWarp, OrigMWarp>, sequence<KIterPerWarp>>,
-                                       tuple<sequence<1, 0>>,
-                                       tuple<sequence<1, 0>>,
-                                       sequence<1, 2>,
-                                       sequence<0, 0>>{};
         /*
         constexpr auto a_block_outer_dstr_encoding =
             tile_distribution_encoding<sequence<OrigNWarp>,
                                        tuple<sequence<MIterPerWarp, OrigMWarp>, sequence<KIterPerWarp>>,
-                                       tuple<sequence<0, 1>>,
-                                       tuple<sequence<0, 1>>,
+                                       tuple<sequence<1, 0>>,
+                                       tuple<sequence<1, 0>>,
                                        sequence<1, 2>,
                                        sequence<0, 0>>{};
         */
-        /*
+        
         constexpr auto a_block_outer_dstr_encoding = 
-            tile_distribution_encoding<sequence<MWarp>, 
+            tile_distribution_encoding<sequence<NWarp>, 
                                         tuple<sequence<MIterPerWarp>, sequence<KIterPerWarp>>, 
                                         tuple<>, 
                                         tuple<>, 
                                         sequence<1, 2>, 
                                         sequence<0, 0>>{};
-        */
+        
+        /*
+        // Gold standard - Working for all cases
+        constexpr auto a_block_outer_dstr_encoding = 
+            tile_distribution_encoding<sequence<OrigNWarp>, 
+                                        tuple<sequence<MIterPerWarp>, sequence<KIterPerWarp>>, 
+                                        tuple<>, 
+                                        tuple<>, 
+                                        sequence<1, 2>, 
+                                        sequence<0, 0>>{};
+        */        
         constexpr auto a_block_dstr_encode = detail::make_embed_tile_distribution_encoding(
             a_block_outer_dstr_encoding, typename WarpGemm::AWarpDstrEncoding{});
 
@@ -107,6 +110,7 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeBBlockDistributionEncode()
     {
+        /*
         constexpr auto b_block_outer_dstr_encoding =
             tile_distribution_encoding<sequence<OrigMWarp>,
                                        tuple<sequence<NIterPerWarp, OrigNWarp>, sequence<KIterPerWarp>>,
@@ -114,8 +118,8 @@ struct BlockGemmARegBRegCRegV1
                                        tuple<sequence<0, 1>>,
                                        sequence<1, 2>,
                                        sequence<0, 0>>{};
+        */
         
-        /*
         constexpr auto b_block_outer_dstr_encoding =
             tile_distribution_encoding<sequence<MWarp>,                                                 
                                        tuple<sequence<NIterPerWarp>, sequence<KIterPerWarp>>,    
@@ -123,6 +127,16 @@ struct BlockGemmARegBRegCRegV1
                                        tuple<>,
                                        sequence<1, 2>,                                                  
                                        sequence<0, 0>>{};
+        
+        /*
+        // Gold standard - Working for all cases
+        constexpr auto b_block_outer_dstr_encoding =
+            tile_distribution_encoding<sequence<OrigMWarp>,                                                 
+                                       tuple<sequence<NIterPerWarp>, sequence<KIterPerWarp>>,    
+                                       tuple<>,                                           
+                                       tuple<>,
+                                       sequence<1, 2>,                                                  
+                                       sequence<0, 0>>{};        
         */
         constexpr auto b_block_dstr_encode = detail::make_embed_tile_distribution_encoding(
             b_block_outer_dstr_encoding, typename WarpGemm::BWarpDstrEncoding{});
@@ -132,6 +146,7 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeCBlockDistributionEncode()
     {
+        /*
         constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
             sequence<OrigMWarp>,
             tuple<sequence<MIterPerWarp>, sequence<NIterPerWarp, OrigNWarp>>,
@@ -139,8 +154,8 @@ struct BlockGemmARegBRegCRegV1
             tuple<sequence<0, 1>>,
             sequence<1, 2>,
             sequence<0, 0>>{};  
+        */
         
-        /*
         constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
             sequence<MWarp>,
             tuple<sequence<MIterPerWarp>, sequence<NIterPerWarp, NWarp>>,
@@ -148,7 +163,17 @@ struct BlockGemmARegBRegCRegV1
             tuple<>,
             sequence<1, 2>,
             sequence<0, 0>>{};        
-        */
+        
+        /*
+        // Gold standard - Working for all cases.
+        constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
+            sequence<OrigMWarp>,
+            tuple<sequence<MIterPerWarp>, sequence<NIterPerWarp, OrigNWarp>>,
+            tuple<>,
+            tuple<>,
+            sequence<1, 2>,
+            sequence<0, 0>>{};     
+        */      
         constexpr auto c_block_dstr_encode = detail::make_embed_tile_distribution_encoding(
             c_block_outer_dstr_encoding, typename WarpGemm::CWarpDstrEncoding{});
 
@@ -268,7 +293,7 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeCBlockTile()
     {
-        /* Gold standard */
+        /*
         constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
             sequence<OrigMWarp>,
             tuple<sequence<MIterPerWarp>, sequence<NIterPerWarp, OrigNWarp>>,
@@ -276,8 +301,8 @@ struct BlockGemmARegBRegCRegV1
             tuple<sequence<0, 1>>,
             sequence<1, 2>,
             sequence<0, 0>>{};  
+        */
         
-        /*
         constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
             sequence<MWarp>,
             tuple<sequence<MIterPerWarp>, sequence<NIterPerWarp, NWarp>>,
@@ -285,7 +310,17 @@ struct BlockGemmARegBRegCRegV1
             tuple<>,
             sequence<1, 2>,
             sequence<0, 0>>{};        
-        */
+        
+        /*
+        // Gold standard - working for all cases
+        constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
+            sequence<OrigMWarp>,
+            tuple<sequence<MIterPerWarp>, sequence<NIterPerWarp, OrigNWarp>>,
+            tuple<>,
+            tuple<>,
+            sequence<1, 2>,
+            sequence<0, 0>>{};   
+        */       
         constexpr auto c_block_dstr_encode = detail::make_embed_tile_distribution_encoding(
             c_block_outer_dstr_encoding, typename WarpGemm::CWarpDstrEncoding{});
         constexpr auto c_block_dstr = make_static_tile_distribution(c_block_dstr_encode);

--- a/include/ck_tile/ops/gemm/block/block_gemm_areg_breg_creg_v1.hpp
+++ b/include/ck_tile/ops/gemm/block/block_gemm_areg_breg_creg_v1.hpp
@@ -34,7 +34,7 @@ struct BlockGemmARegBRegCRegV1
         static constexpr auto config = Policy::template GetWarpGemmMWarpNWarp<Problem>();
         using WarpGemm               = remove_cvref_t<decltype(config.template at<0>())>;
 
-        static constexpr index_t MWarp        = config.template at<1>();
+        static constexpr index_t MWarp        = (config.template at<1>()) / (Problem::kNumWaveGroups);
         static constexpr index_t NWarp        = config.template at<2>();
         static constexpr index_t MIterPerWarp = MPerBlock / (MWarp * WarpGemm::kM);
         static constexpr index_t NIterPerWarp = NPerBlock / (NWarp * WarpGemm::kN);
@@ -65,6 +65,8 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeABlockDistributionEncode()
     {
+        static_assert(MWarp == 1);
+
         constexpr auto a_block_outer_dstr_encoding =
             tile_distribution_encoding<sequence<NWarp>,
                                        tuple<sequence<MIterPerWarp, MWarp>, sequence<KIterPerWarp>>,
@@ -80,6 +82,8 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeBBlockDistributionEncode()
     {
+        static_assert(MWarp == 1);
+
         constexpr auto b_block_outer_dstr_encoding =
             tile_distribution_encoding<sequence<MWarp>,
                                        tuple<sequence<NIterPerWarp, NWarp>, sequence<KIterPerWarp>>,
@@ -95,6 +99,9 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeCBlockDistributionEncode()
     {
+        static_assert(MWarp == 1);
+        static_assert(MIterPerWarp == 2);
+
         constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
             sequence<>,
             tuple<sequence<MIterPerWarp, MWarp>, sequence<NIterPerWarp, NWarp>>,
@@ -114,6 +121,8 @@ struct BlockGemmARegBRegCRegV1
                                    const ABlockTensor& a_block_tensor,
                                    const BBlockTensor& b_block_tensor) const
     {
+        static_assert(Problem::kNumWaveGroups == 2);
+
         static_assert(std::is_same_v<ADataType, remove_cv_t<typename ABlockTensor::DataType>> &&
                           std::is_same_v<BDataType, remove_cv_t<typename BBlockTensor::DataType>> &&
                           std::is_same_v<CDataType, remove_cv_t<typename CBlockTensor::DataType>>,
@@ -161,6 +170,8 @@ struct BlockGemmARegBRegCRegV1
         constexpr auto b_warp_y_index_zeros = uniform_sequence_gen_t<BWarpDstr::NDimY, 0>{};
         constexpr auto c_warp_y_index_zeros = uniform_sequence_gen_t<CWarpDstr::NDimY, 0>{};
 
+        static_assert(MIterPerWarp == 2);
+
         // hot loop:
         static_for<0, KIterPerWarp, 1>{}([&](auto kIter) {
             static_for<0, MIterPerWarp, 1>{}([&](auto mIter) {
@@ -201,6 +212,8 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeCBlockTile()
     {
+        static_assert(MIterPerWarp == 2);
+
         constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
             sequence<>,
             tuple<sequence<MIterPerWarp, MWarp>, sequence<NIterPerWarp, NWarp>>,

--- a/include/ck_tile/ops/gemm/block/block_gemm_areg_breg_creg_v1.hpp
+++ b/include/ck_tile/ops/gemm/block/block_gemm_areg_breg_creg_v1.hpp
@@ -100,7 +100,7 @@ struct BlockGemmARegBRegCRegV1
 
         constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
             sequence<MWarp>,
-            tuple<sequence<MIterPerWarp, MWarp>, sequence<NIterPerWarp, NWarp>>,
+            tuple<sequence<MIterPerWarp>, sequence<NIterPerWarp, NWarp>>,
             tuple<sequence<1, 2>>,
             tuple<sequence<1, 1>>,
             sequence<1, 2>,

--- a/include/ck_tile/ops/gemm/block/block_gemm_areg_breg_creg_v1.hpp
+++ b/include/ck_tile/ops/gemm/block/block_gemm_areg_breg_creg_v1.hpp
@@ -34,11 +34,14 @@ struct BlockGemmARegBRegCRegV1
         static constexpr auto config = Policy::template GetWarpGemmMWarpNWarp<Problem>();
         using WarpGemm               = remove_cvref_t<decltype(config.template at<0>())>;
 
-        static constexpr index_t MWarp = (config.template at<1>()) / (Problem::kNumWaveGroups);
+        static constexpr index_t MWarp = config.template at<1>() / (Problem::kNumWaveGroups);
         static constexpr index_t NWarp = config.template at<2>();
         static constexpr index_t MIterPerWarp = MPerBlock / (MWarp * WarpGemm::kM);
         static constexpr index_t NIterPerWarp = NPerBlock / (NWarp * WarpGemm::kN);
         static constexpr index_t KIterPerWarp = KPerBlock / WarpGemm::kK;
+
+        static constexpr index_t OrigMWarp = config.template at<1>();
+        static constexpr index_t OrigNWarp = config.template at<2>();
 
         static constexpr index_t KPack = WarpGemm::kKPerThread;
     };
@@ -62,17 +65,40 @@ struct BlockGemmARegBRegCRegV1
 
     static constexpr index_t MWarp = Traits::MWarp;
     static constexpr index_t NWarp = Traits::NWarp;
+    static constexpr index_t OrigMWarp = Traits::OrigMWarp;
+    static constexpr index_t OrigNWarp = Traits::OrigNWarp;
+
+    static constexpr index_t MPerBlock = Traits::MPerBlock;
+    static constexpr index_t NPerBlock = Traits::NPerBlock;
+    static constexpr index_t KPack = Traits::KPack;
 
     CK_TILE_DEVICE static constexpr auto MakeABlockDistributionEncode()
     {
-
         constexpr auto a_block_outer_dstr_encoding =
-            tile_distribution_encoding<sequence<NWarp>,                                                
-                                       tuple<sequence<MIterPerWarp, MWarp>, sequence<KIterPerWarp>>,    
-                                       tuple<sequence<1, 0>>,                                           
+            tile_distribution_encoding<sequence<OrigNWarp>,
+                                       tuple<sequence<MIterPerWarp, OrigMWarp>, sequence<KIterPerWarp>>,
                                        tuple<sequence<1, 0>>,
-                                       sequence<1, 2>,                                                  
+                                       tuple<sequence<1, 0>>,
+                                       sequence<1, 2>,
                                        sequence<0, 0>>{};
+        /*
+        constexpr auto a_block_outer_dstr_encoding =
+            tile_distribution_encoding<sequence<OrigNWarp>,
+                                       tuple<sequence<MIterPerWarp, OrigMWarp>, sequence<KIterPerWarp>>,
+                                       tuple<sequence<0, 1>>,
+                                       tuple<sequence<0, 1>>,
+                                       sequence<1, 2>,
+                                       sequence<0, 0>>{};
+        */
+        /*
+        constexpr auto a_block_outer_dstr_encoding = 
+            tile_distribution_encoding<sequence<MWarp>, 
+                                        tuple<sequence<MIterPerWarp>, sequence<KIterPerWarp>>, 
+                                        tuple<>, 
+                                        tuple<>, 
+                                        sequence<1, 2>, 
+                                        sequence<0, 0>>{};
+        */
         constexpr auto a_block_dstr_encode = detail::make_embed_tile_distribution_encoding(
             a_block_outer_dstr_encoding, typename WarpGemm::AWarpDstrEncoding{});
 
@@ -81,14 +107,23 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeBBlockDistributionEncode()
     {
-
+        constexpr auto b_block_outer_dstr_encoding =
+            tile_distribution_encoding<sequence<OrigMWarp>,
+                                       tuple<sequence<NIterPerWarp, OrigNWarp>, sequence<KIterPerWarp>>,
+                                       tuple<sequence<0, 1>>,
+                                       tuple<sequence<0, 1>>,
+                                       sequence<1, 2>,
+                                       sequence<0, 0>>{};
+        
+        /*
         constexpr auto b_block_outer_dstr_encoding =
             tile_distribution_encoding<sequence<MWarp>,                                                 
-                                       tuple<sequence<NIterPerWarp, NWarp>, sequence<KIterPerWarp>>,    
-                                       tuple<sequence<0, 1>>,                                           
-                                       tuple<sequence<0, 1>>,
+                                       tuple<sequence<NIterPerWarp>, sequence<KIterPerWarp>>,    
+                                       tuple<>,                                           
+                                       tuple<>,
                                        sequence<1, 2>,                                                  
                                        sequence<0, 0>>{};
+        */
         constexpr auto b_block_dstr_encode = detail::make_embed_tile_distribution_encoding(
             b_block_outer_dstr_encoding, typename WarpGemm::BWarpDstrEncoding{});
 
@@ -97,18 +132,46 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeCBlockDistributionEncode()
     {
-
+        constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
+            sequence<OrigMWarp>,
+            tuple<sequence<MIterPerWarp>, sequence<NIterPerWarp, OrigNWarp>>,
+            tuple<sequence<0, 2>>,
+            tuple<sequence<0, 1>>,
+            sequence<1, 2>,
+            sequence<0, 0>>{};  
+        
+        /*
         constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
             sequence<MWarp>,
             tuple<sequence<MIterPerWarp>, sequence<NIterPerWarp, NWarp>>,
-            tuple<sequence<1, 2>>,
-            tuple<sequence<1, 1>>,
+            tuple<>,
+            tuple<>,
             sequence<1, 2>,
-            sequence<0, 0>>{};
+            sequence<0, 0>>{};        
+        */
         constexpr auto c_block_dstr_encode = detail::make_embed_tile_distribution_encoding(
             c_block_outer_dstr_encoding, typename WarpGemm::CWarpDstrEncoding{});
 
         return c_block_dstr_encode;
+    }
+
+    CK_TILE_DEVICE static constexpr auto MakeCBlockLdsDescriptor()
+    {
+        constexpr auto c_lds_block_desc_0 = make_naive_tensor_descriptor(
+            make_tuple(number<NPerBlock / KPack>{}, number<MPerBlock>{}, number<KPack>{}),
+            make_tuple(number<MPerBlock * KPack>{}, number<KPack>{}, number<1>{}),
+            number<KPack>{},
+            number<1>{});
+
+        constexpr auto c_lds_block_desc = transform_tensor_descriptor(
+                c_lds_block_desc_0,
+                make_tuple(
+                    make_pass_through_transform(number<MPerBlock>{}),
+                    make_merge_transform(make_tuple(number<NPerBlock>{} / KPack, number<KPack>{}))),
+                make_tuple(sequence<1>{}, sequence<0, 2>{}),
+                make_tuple(sequence<0>{}, sequence<1>{}));
+
+        return c_lds_block_desc;
     }
 
     // C += A * B
@@ -205,19 +268,39 @@ struct BlockGemmARegBRegCRegV1
 
     CK_TILE_DEVICE static constexpr auto MakeCBlockTile()
     {
-
+        /* Gold standard */
+        constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
+            sequence<OrigMWarp>,
+            tuple<sequence<MIterPerWarp>, sequence<NIterPerWarp, OrigNWarp>>,
+            tuple<sequence<0, 2>>,
+            tuple<sequence<0, 1>>,
+            sequence<1, 2>,
+            sequence<0, 0>>{};  
+        
+        /*
         constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
             sequence<MWarp>,
             tuple<sequence<MIterPerWarp>, sequence<NIterPerWarp, NWarp>>,
-            tuple<sequence<1, 2>>,
-            tuple<sequence<1, 1>>,
+            tuple<>,
+            tuple<>,
             sequence<1, 2>,
-            sequence<0, 0>>{};
-
+            sequence<0, 0>>{};        
+        */
         constexpr auto c_block_dstr_encode = detail::make_embed_tile_distribution_encoding(
             c_block_outer_dstr_encoding, typename WarpGemm::CWarpDstrEncoding{});
         constexpr auto c_block_dstr = make_static_tile_distribution(c_block_dstr_encode);
         auto c_block_tensor         = make_static_distributed_tensor<CDataType>(c_block_dstr);
+        /*
+        auto c_block_tensor_view    = make_naive_tensor_view<address_space_enum::vgpr, 
+                                                              memory_operation_enum::set,
+                                                              amd_buffer_coherence_enum::slc>(
+                                                                c_block_tensor.mData, 
+                                                                make_tuple(MPerBlock, NPerBlock), 
+                                                                make_tuple(NPerBlock, 1), 
+                                                                number<1>{}, number<1>{});
+        */                                               
+
+
         return c_block_tensor;
     }
 

--- a/include/ck_tile/ops/gemm/block/block_gemm_areg_breg_creg_v1.hpp
+++ b/include/ck_tile/ops/gemm/block/block_gemm_areg_breg_creg_v1.hpp
@@ -67,11 +67,11 @@ struct BlockGemmARegBRegCRegV1
     {
 
         constexpr auto a_block_outer_dstr_encoding =
-            tile_distribution_encoding<sequence<NWarp>,
-                                       tuple<sequence<MIterPerWarp, MWarp>, sequence<KIterPerWarp>>,
+            tile_distribution_encoding<sequence<NWarp>,                                                
+                                       tuple<sequence<MIterPerWarp, MWarp>, sequence<KIterPerWarp>>,    
+                                       tuple<sequence<1, 0>>,                                           
                                        tuple<sequence<1, 0>>,
-                                       tuple<sequence<1, 0>>,
-                                       sequence<1, 2>,
+                                       sequence<1, 2>,                                                  
                                        sequence<0, 0>>{};
         constexpr auto a_block_dstr_encode = detail::make_embed_tile_distribution_encoding(
             a_block_outer_dstr_encoding, typename WarpGemm::AWarpDstrEncoding{});
@@ -83,11 +83,11 @@ struct BlockGemmARegBRegCRegV1
     {
 
         constexpr auto b_block_outer_dstr_encoding =
-            tile_distribution_encoding<sequence<MWarp>,
-                                       tuple<sequence<NIterPerWarp, NWarp>, sequence<KIterPerWarp>>,
+            tile_distribution_encoding<sequence<MWarp>,                                                 
+                                       tuple<sequence<NIterPerWarp, NWarp>, sequence<KIterPerWarp>>,    
+                                       tuple<sequence<0, 1>>,                                           
                                        tuple<sequence<0, 1>>,
-                                       tuple<sequence<0, 1>>,
-                                       sequence<1, 2>,
+                                       sequence<1, 2>,                                                  
                                        sequence<0, 0>>{};
         constexpr auto b_block_dstr_encode = detail::make_embed_tile_distribution_encoding(
             b_block_outer_dstr_encoding, typename WarpGemm::BWarpDstrEncoding{});
@@ -99,7 +99,7 @@ struct BlockGemmARegBRegCRegV1
     {
 
         constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
-            sequence<>,
+            sequence<MWarp>,
             tuple<sequence<MIterPerWarp, MWarp>, sequence<NIterPerWarp, NWarp>>,
             tuple<sequence<1, 2>>,
             tuple<sequence<1, 1>>,
@@ -207,8 +207,8 @@ struct BlockGemmARegBRegCRegV1
     {
 
         constexpr auto c_block_outer_dstr_encoding = tile_distribution_encoding<
-            sequence<>,
-            tuple<sequence<MIterPerWarp, MWarp>, sequence<NIterPerWarp, NWarp>>,
+            sequence<MWarp>,
+            tuple<sequence<MIterPerWarp>, sequence<NIterPerWarp, NWarp>>,
             tuple<sequence<1, 2>>,
             tuple<sequence<1, 1>>,
             sequence<1, 2>,

--- a/include/ck_tile/ops/gemm/kernel/gemm_kernel.hpp
+++ b/include/ck_tile/ops/gemm/kernel/gemm_kernel.hpp
@@ -637,12 +637,15 @@ struct GemmKernel
         const auto& c_block_tile = GemmPipeline{}.template operator()(
             a_block_window, b_block_window, num_loop, smem_ptr_0);
 
-        // Run Epilogue Pipeline
-        auto& c_block_window = gemm_tile_windows.at(I2);
+        if (get_warp_id() == 0)
+        {
+            // Run Epilogue Pipeline
+            auto& c_block_window = gemm_tile_windows.at(I2);   
 
-        EpiloguePipeline{}
-            .template operator()<decltype(c_block_window), decltype(c_block_tile), DstInMemOp>(
-                c_block_window, c_block_tile, smem_ptr_0);
+            EpiloguePipeline{}
+                .template operator()<decltype(c_block_window), decltype(c_block_tile), DstInMemOp>(
+                    c_block_window, c_block_tile, smem_ptr_0);
+        }
     }
 
     /**
@@ -689,12 +692,15 @@ struct GemmKernel
         const auto& c_block_tile = GemmPipeline{}.template operator()(
             a_block_window, b_block_window, num_loop, smem_ptr_0, smem_ptr_1);
 
-        // Run Epilogue Pipeline
-        auto& c_block_window = gemm_tile_windows.at(I2);
+        if (get_warp_id() == 0)
+        {
+            // Run Epilogue Pipeline
+            auto& c_block_window = gemm_tile_windows.at(I2);
 
-        EpiloguePipeline{}
-            .template operator()<decltype(c_block_window), decltype(c_block_tile), DstInMemOp>(
-                c_block_window, c_block_tile, smem_ptr_0);
+            EpiloguePipeline{}
+                .template operator()<decltype(c_block_window), decltype(c_block_tile), DstInMemOp>(
+                    c_block_window, c_block_tile, smem_ptr_0);
+        }
     }
 
     CK_TILE_DEVICE void operator()(GemmKernelArgs kargs) const

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v4_default_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v4_default_policy.hpp
@@ -86,8 +86,6 @@ struct GemmPipelineAgBgCrCompV4DefaultPolicy
                                                                     BlockWarps,
                                                                     WarpGemm>;
 
-        static_assert(Problem::Traits::kNumWaveGroups == 2);
-
         return BlockGemmARegBRegCRegV1<Problem, BlockGemmPolicy>{};
     }
 };

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v4_default_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v4_default_policy.hpp
@@ -86,6 +86,8 @@ struct GemmPipelineAgBgCrCompV4DefaultPolicy
                                                                     BlockWarps,
                                                                     WarpGemm>;
 
+        static_assert(Problem::Traits::kNumWaveGroups == 2);
+
         return BlockGemmARegBRegCRegV1<Problem, BlockGemmPolicy>{};
     }
 };

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
@@ -50,11 +50,10 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
 
     static constexpr index_t kNumWaveGroups = Problem::kNumWaveGroups;
 
-    using BlockGemm =
-        remove_cvref_t<decltype(Policy::template GetBlockGemm<Problem>())>;
-    using I0 = number<0>;
-    using I1 = number<1>;
-    using I2 = number<2>;
+    using BlockGemm = remove_cvref_t<decltype(Policy::template GetBlockGemm<Problem>())>;
+    using I0        = number<0>;
+    using I1        = number<1>;
+    using I2        = number<2>;
 
     static constexpr index_t BlockSize = Problem::kBlockSize;
 
@@ -146,18 +145,18 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
             index_t operation_id = __builtin_amdgcn_readfirstlane(get_warp_id() % kNumWaveGroups);
 
             // global memory structures here.
-            auto a_copy_dram_window = make_tile_window(
-                a_dram_block_window_tmp.get_bottom_tensor_view(),
-                make_tuple(number<MPerBlock>{}, number<KPerBlock>{}),
-                a_dram_block_window_tmp.get_window_origin(),
-                Policy::template MakeADramTileDistribution<Problem>());
+            auto a_copy_dram_window =
+                make_tile_window(a_dram_block_window_tmp.get_bottom_tensor_view(),
+                                 make_tuple(number<MPerBlock>{}, number<KPerBlock>{}),
+                                 a_dram_block_window_tmp.get_window_origin(),
+                                 Policy::template MakeADramTileDistribution<Problem>());
 
             // B DRAM tile window for load
-            auto b_copy_dram_window = make_tile_window(
-                b_dram_block_window_tmp.get_bottom_tensor_view(),
-                make_tuple(number<NPerBlock>{}, number<KPerBlock>{}),
-                b_dram_block_window_tmp.get_window_origin(),
-                Policy::template MakeBDramTileDistribution<Problem>());
+            auto b_copy_dram_window =
+                make_tile_window(b_dram_block_window_tmp.get_bottom_tensor_view(),
+                                 make_tuple(number<NPerBlock>{}, number<KPerBlock>{}),
+                                 b_dram_block_window_tmp.get_window_origin(),
+                                 Policy::template MakeBDramTileDistribution<Problem>());
 
             // DRAM window steps.
             using ADramTileWindowStep = typename ADramBlockWindowTmp::BottomTensorIndex;

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
@@ -273,7 +273,7 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
 
             // start the main loop.
             index_t num_compute_steps = __builtin_amdgcn_readfirstlane(num_loop);
-            while(num_compute_steps > 10)
+            while(num_compute_steps > 1)
             {
                 block_sync_lds();
                 operation_id = (operation_id + 1) % kNumWaveGroups;

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
@@ -170,9 +170,9 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
             using ADramTileWindowStep = typename ADramBlockWindowTmp::BottomTensorIndex;
             using BDramTileWindowStep = typename BDramBlockWindowTmp::BottomTensorIndex;
             constexpr ADramTileWindowStep a_dram_tile_window_step = 
-                is_a_col_major ? make_array(KPerBlock, 0) : make_array(0, KPerBlock);
+                is_a_col_major ? make_array(KPerBlock * NumWarps, 0) : make_array(0, KPerBlock * NumWarps);
             constexpr BDramTileWindowStep b_dram_tile_window_step = 
-                is_b_row_major ? make_array(KPerBlock, 0) : make_array(0, KPerBlock);
+                is_b_row_major ? make_array(KPerBlock * NumWarps, 0) : make_array(0, KPerBlock * NumWarps);
 
             constexpr auto AGemmTileDistr = decltype(make_static_tile_distribution(
                 BlockGemm::MakeABlockDistributionEncode())){};

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
@@ -112,7 +112,6 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
                                        index_t num_loop,
                                        void* __restrict__ p_smem_0) const
         {
-            static_assert(kNumWaveGroups == 2);
 
             static_assert(
                 std::is_same_v<ADataType, remove_cvref_t<typename ADramBlockWindowTmp::DataType>> &&

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
@@ -42,6 +42,7 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
     using ADataType      = remove_cvref_t<typename Problem::ADataType>;
     using BDataType      = remove_cvref_t<typename Problem::BDataType>;
     using CDataType      = remove_cvref_t<typename Problem::CDataType>;
+    using ComputeDataType    = remove_cvref_t<typename Problem::ComputeDataType>;
     using BlockGemmShape = remove_cvref_t<typename Problem::BlockGemmShape>;
 
     using ALayout = remove_cvref_t<typename Problem::ALayout>;
@@ -76,6 +77,9 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
     static constexpr auto Scheduler  = Problem::Scheduler;
 
     static constexpr index_t NumWarps = BlockGemmShape::NumWarps;
+    //static constexpr index_t MWarps = BlockGemmShape::BlockWarps::at(I0);
+    //static constexpr index_t NWarps = BlockGemmShape::BlockWarps::at(I1);
+    //static constexpr index_t KWarps = BlockGemmShape::BlockWarps::at(I2);
 
     static constexpr index_t KTileSize = BlockGemmShape::WarpTile::at(I2{});
 
@@ -112,7 +116,6 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
                                        index_t num_loop,
                                        void* __restrict__ p_smem_0) const
         {
-
             static_assert(
                 std::is_same_v<ADataType, remove_cvref_t<typename ADramBlockWindowTmp::DataType>> &&
                     std::is_same_v<BDataType,
@@ -140,11 +143,14 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
                                  KPerBlock == BDramBlockWindowTmp{}.get_window_lengths()[I1{}]),
                           "B block window has incorrect lengths for defined BLayout!");
 
-            index_t group_id     = __builtin_amdgcn_readfirstlane(get_warp_id() % kNumWaveGroups);
-            index_t operation_id = __builtin_amdgcn_readfirstlane(get_warp_id() % kNumWaveGroups);
+            index_t warp_id     = get_warp_id();
+            index_t operation_id = __builtin_amdgcn_readfirstlane(get_warp_id()); // 0 - Memory read, 1 - block-gemm
 
-            auto a_offset = (group_id == 0) ? multi_index<2>{0, 0}: multi_index<2>{0, KPerBlock};
-            auto b_offset = (group_id == 0) ? multi_index<2>{0, 0} : multi_index<2>{KPerBlock, 0};
+            auto a_offset = (warp_id == 0) ? make_array(0, 0) : make_array(0, KPerBlock);
+            auto b_offset = (warp_id == 0) ? make_array(0, 0) : make_array(0, KPerBlock);     // N x K, by definition     
+            
+            //a_offset = make_array(0, 0);
+            //b_offset = make_array(0, 0);
 
             // global memory structures here.
             auto a_copy_dram_window =
@@ -163,10 +169,10 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
             // DRAM window steps.
             using ADramTileWindowStep = typename ADramBlockWindowTmp::BottomTensorIndex;
             using BDramTileWindowStep = typename BDramBlockWindowTmp::BottomTensorIndex;
-            constexpr ADramTileWindowStep a_dram_tile_window_step =
-                is_a_col_major ? make_array(KPerBlock * NumWarps, 0) : make_array(0, KPerBlock * NumWarps);
-            constexpr BDramTileWindowStep b_dram_tile_window_step =
-                is_b_row_major ? make_array(KPerBlock * NumWarps, 0) : make_array(0, KPerBlock * NumWarps);
+            constexpr ADramTileWindowStep a_dram_tile_window_step = 
+                is_a_col_major ? make_array(KPerBlock, 0) : make_array(0, KPerBlock);
+            constexpr BDramTileWindowStep b_dram_tile_window_step = 
+                is_b_row_major ? make_array(KPerBlock, 0) : make_array(0, KPerBlock);
 
             constexpr auto AGemmTileDistr = decltype(make_static_tile_distribution(
                 BlockGemm::MakeABlockDistributionEncode())){};
@@ -189,10 +195,28 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
             // Block GEMM
             auto block_gemm     = BlockGemm();
             auto c_block_tile_0 = block_gemm.MakeCBlockTile(); // Gemm distribution.
-            auto c_block_tile_1 = block_gemm.MakeCBlockTile();
+            auto c_block_tile_1 = block_gemm.MakeCBlockTile(); // Gemm distribution.
 
+            /*
+            C tensor in lds storage for final addition.           
+            */
+            
+            CDataType* __restrict__ p_c_lds = static_cast<CDataType*>(p_smem_0);
+            auto c_lds_block_0 = make_naive_tensor_view<address_space_enum::lds>(p_c_lds, make_tuple(MPerBlock, NPerBlock), make_tuple(NPerBlock, 1), number<1>{}, number<1>{});
+            auto c_window_0 = make_tile_window(c_lds_block_0, make_tuple(number<MPerBlock>{}, number<NPerBlock>{}), {0, 0}, c_block_tile_1.get_tile_distribution());
+
+            /*
+            p_c_lds += integer_least_multiple(MPerBlock * NPerBlock, 16);
+            auto c_lds_block_1 = make_naive_tensor_view<address_space_enum::lds>(p_c_lds, make_tuple(MPerBlock, NPerBlock), make_tuple(NPerBlock, 1), number<GetVectorSizeC()>{}, number<1>{});
+            auto c_window_1 = make_tile_window(c_lds_block_1, make_tuple(number<MPerBlock>{}, number<NPerBlock>{}), {0, 0}, c_block_tile_1.get_tile_distribution());
+            */
+
+            constexpr index_t c_lds_block_space_size_aligned = integer_least_multiple(
+                sizeof(CDataType) * (MPerBlock * NPerBlock) * 2, 16);            
+            
             // Not needed
-            auto&& [a_lds_block, b_lds_block] = Base::GetABLdsTensorViews(p_smem_0);
+            auto&& [a_lds_block, b_lds_block] = Base::GetABLdsTensorViews(
+                static_cast<void*>(static_cast<char*>(p_smem_0) + c_lds_block_space_size_aligned));
 
             auto a_copy_lds_window = make_tile_window(
                 a_lds_block, make_tuple(number<MPerBlock>{}, number<KPerBlock>{}), {0, 0});
@@ -211,8 +235,14 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
                                  BGemmTileDistr);
 
             // initialize C
-            tile_elementwise_inout([](auto& c) { c = 0; }, c_block_tile_0);
-            tile_elementwise_inout([](auto& c) { c = 0; }, c_block_tile_1);
+            if (warp_id == 0)
+            {
+                tile_elementwise_inout([](auto& c) { c = 0; }, c_block_tile_0);
+            }
+            else
+            {
+                tile_elementwise_inout([](auto& c) { c = 0; }, c_block_tile_1);
+            }
 
             // define ping, pong steps here as lambda functions.
             auto MemoryOpsStep = [&](auto idx) {
@@ -246,7 +276,7 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
                     Base::LocalPrefill(b_copy_lds_window, b_global_load_tile, b_element_func);
                 }
 
-                if(idx == 0)
+                if (idx == 0)
                 {
                     Base::LocalPrefetch(a_tile_0, a_lds_window);
                     Base::LocalPrefetch(b_tile_0, b_lds_window);
@@ -259,7 +289,7 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
             };
 
             auto ComputeStep = [&](auto idx) {
-                if(idx == 0)
+                if (idx == 0)
                 {
                     block_gemm(c_block_tile_0, a_tile_0, b_tile_0);
                 }
@@ -269,12 +299,27 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
                 }
             };
 
+            /*
+            auto DramTxStep = [&](auto idx)
+            {
+                // store the tile in LDS for later processing. 
+                if (idx == 0)
+                {
+                    store_tile(c_window_0, c_block_tile_0);
+                }
+                else
+                {
+                    store_tile(c_window_0, c_block_tile_1);
+                }
+            };
+            */
+
             if(operation_id == 0)
             {
-                MemoryOpsStep(group_id);
+                MemoryOpsStep(warp_id);
             }
 
-            // start the main loop.
+            // To by pass compilation errors.
             index_t num_compute_steps = __builtin_amdgcn_readfirstlane(num_loop);
             while(num_compute_steps > 1)
             {
@@ -283,25 +328,68 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
 
                 if(operation_id == 0)
                 {
-                    MemoryOpsStep(group_id);
+                    MemoryOpsStep(warp_id); // (DRAM - reg, reg - lds, lds - reg)
                 }
                 else
                 {
-                    ComputeStep(group_id);
+                    ComputeStep(warp_id); // block-gemm
                 }
                 num_compute_steps -= 1;
-            }
+            }             
 
-            // Handle Tail Number here.
+            block_sync_lds();
             if(operation_id == 0)
             {
-                ComputeStep(group_id);
+                ComputeStep(warp_id);
+            }
+
+            /*
+            if (warp_id == 0)
+            {
+                MemoryOpsStep(0);
+                ComputeStep(0);
+                //DramTxStep(0);                
+
+                // move window
+                //move_tile_window(a_copy_dram_window, a_dram_tile_window_step);
+                //move_tile_window(b_copy_dram_window, b_dram_tile_window_step);
+
+                //MemoryOpsStep(0);
+                //ComputeStep(0);
+            }            
+            block_sync_lds();
+            
+            if (warp_id == 1)
+            {
+                MemoryOpsStep(1);
+                ComputeStep(1);
+                DramTxStep(1);
+
+                //Use this code to test for K = 16
+                //move_tile_window(a_copy_dram_window, a_dram_tile_window_step);
+                //move_tile_window(b_copy_dram_window, b_dram_tile_window_step);
+
+                //MemoryOpsStep(1);
+                //ComputeStep(1);
+            }
+            block_sync_lds();
+            */
+            if (warp_id == 1)
+            {
+                store_tile(c_window_0, c_block_tile_1);
             }
             block_sync_lds();
 
-            // Add both the tiles and return the result.
-            if(group_id == 0)
+            if (warp_id == 0)
             {
+                // add results from warp-1 to local results from warp-0
+                load_tile(c_block_tile_1, c_window_0);
+            }
+            block_sync_lds();
+
+            if (warp_id == 0)
+            {
+                // add to c_block_tile_0 here. 
                 constexpr auto s_spans = decltype(c_block_tile_0)::get_distributed_spans();
                 sweep_tile_span(s_spans[number<0>{}], [&](auto idx0) {
                     sweep_tile_span(s_spans[number<1>{}], [&](auto idx1) {
@@ -311,7 +399,69 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
                 });
             }
 
+            block_sync_lds();            
             return c_block_tile_0;
+
+            /*
+            // This is the code for the hot loop and the rest of the auxiliary code for the
+            // 2 warp ping pong scheduler. 
+            // This code is not working as of now... DO NOT UNCOMMENT IT.
+            if(operation_id == 0)
+            {
+                MemoryOpsStep(warp_id);
+            }
+            
+            // start the main loop.
+            index_t num_compute_steps = __builtin_amdgcn_readfirstlane(num_loop);
+            while(num_compute_steps > 0)
+            {
+                block_sync_lds();
+                operation_id = (operation_id + 1) % kNumWaveGroups;
+
+                if(operation_id == 0)
+                {
+                    MemoryOpsStep(warp_id); // (DRAM - reg, reg - lds, lds - reg)
+                }
+                else
+                {
+                    ComputeStep(warp_id); // block-gemm
+                }
+                num_compute_steps -= 1;
+            }            
+            block_sync_lds();
+
+            // Handle Tail Number here.
+            if(operation_id == 0)
+            {
+                ComputeStep(warp_id);
+            }
+            block_sync_lds();
+
+            if (warp_id == 1)
+            {
+                // move c_block_tile_1 into lds. 
+                store_tile(c_window_0, c_block_tile_1);
+            }
+
+            block_sync_lds();
+            if (warp_id == 0)
+            {
+                // add results from warp-1 to local results from warp-0
+                load_tile(c_block_tile_1, c_window_0);
+
+                // add to c_block_tile_0 here. 
+                constexpr auto s_spans = decltype(c_block_tile_0)::get_distributed_spans();
+                sweep_tile_span(s_spans[number<0>{}], [&](auto idx0) {
+                    sweep_tile_span(s_spans[number<1>{}], [&](auto idx1) {
+                        auto idx2 = make_tuple(idx0, idx1);
+                        c_block_tile_0(idx2) += c_block_tile_1(idx2);
+                    });
+                });                
+            }
+
+            block_sync_lds ();
+            return c_block_tile_0;
+            */
         }
     };
 
@@ -348,7 +498,8 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
             b_dram_block_window_tmp,
             [](const BDataType& b) { return b; },
             num_loop,
-            p_smem_0);
+            p_smem_0
+            );
     }
 };
 

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
@@ -1,0 +1,355 @@
+#include "ck_tile/core.hpp"
+#include "ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp"
+#include "ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_scheduler.hpp"
+#include "ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_base.hpp"
+#include "ck_tile/host/concat.hpp"
+
+namespace ck_tile {
+// A Tile Window: global memory
+// B Tile Window: global memory
+// C Distributed Tensor: register
+
+template <typename Problem>
+struct BaseGemmPipelineAgBgCrCompV5
+{
+    static constexpr index_t PrefetchStages  = 1;
+    static constexpr index_t PrefillStages   = 1;
+    static constexpr index_t GlobalBufferNum = 1;
+
+    CK_TILE_HOST_DEVICE static constexpr auto TransposeC() { return Problem::TransposeC; }
+
+    CK_TILE_HOST_DEVICE static constexpr bool BlockHasHotloop(index_t num_loop)
+    {
+        return num_loop > 0;
+    }
+
+    CK_TILE_HOST_DEVICE static constexpr TailNumber GetBlockLoopTailNum(index_t num_loop)
+    {
+        if(num_loop > 0)
+        {
+            return TailNumber::One;
+        }
+        return TailNumber::One;
+    }
+};
+
+template <typename Problem, typename Policy = GemmPipelineAgBgCrCompV4DefaultPolicy>
+struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
+{
+    using Base             = BaseGemmPipelineAgBgCrCompV5<Problem>;
+    using PipelineImplBase = GemmPipelineAgBgCrImplBase<Problem, Policy>;
+
+    using ADataType      = remove_cvref_t<typename Problem::ADataType>;
+    using BDataType      = remove_cvref_t<typename Problem::BDataType>;
+    using CDataType      = remove_cvref_t<typename Problem::CDataType>;
+    using BlockGemmShape = remove_cvref_t<typename Problem::BlockGemmShape>;
+
+    using ALayout = remove_cvref_t<typename Problem::ALayout>;
+    using BLayout = remove_cvref_t<typename Problem::BLayout>;
+    using CLayout = remove_cvref_t<typename Problem::CLayout>;
+
+    static constexpr index_t kNumWaveGroups = Problem::kNumWaveGroups;
+
+    using BlockGemm =
+        remove_cvref_t<decltype(Policy::template GetBlockGemm<Problem>())>;
+    using I0 = number<0>;
+    using I1 = number<1>;
+    using I2 = number<2>;
+
+    static constexpr index_t BlockSize = Problem::kBlockSize;
+
+    static constexpr index_t MPerBlock = BlockGemmShape::kM;
+    static constexpr index_t NPerBlock = BlockGemmShape::kN;
+    static constexpr index_t KPerBlock = BlockGemmShape::kK;
+
+    static constexpr index_t GetVectorSizeA() { return Policy::template GetVectorSizeA<Problem>(); }
+    static constexpr index_t GetVectorSizeB() { return Policy::template GetVectorSizeB<Problem>(); }
+    static constexpr index_t GetVectorSizeC() { return Policy::template GetVectorSizeC<Problem>(); }
+
+    static constexpr bool kPadM = Problem::kPadM;
+    static constexpr bool kPadN = Problem::kPadN;
+    static constexpr bool kPadK = Problem::kPadK;
+
+    static constexpr bool DoubleSmemBuffer = Problem::DoubleSmemBuffer;
+
+    static constexpr bool HasHotLoop = Problem::HasHotLoop;
+    static constexpr auto TailNum    = Problem::TailNum;
+    static constexpr auto Scheduler  = Problem::Scheduler;
+
+    static constexpr index_t NumWarps = BlockGemmShape::NumWarps;
+
+    static constexpr index_t KTileSize = BlockGemmShape::WarpTile::at(I2{});
+
+    CK_TILE_HOST_DEVICE static constexpr index_t GetSmemSize()
+    {
+        return Policy::template GetSmemSize<Problem>();
+    }
+
+    CK_TILE_HOST_DEVICE static constexpr auto IsTransposeC()
+    {
+        return Policy::template IsTransposeC<Problem>();
+    }
+
+    template <GemmPipelineScheduler Scheduler>
+    struct PipelineImpl : public PipelineImplBase
+    {
+    };
+
+    template <>
+    struct PipelineImpl<GemmPipelineScheduler::Intrawave> : public PipelineImplBase
+    {
+        using Base = PipelineImplBase;
+
+        template <bool HasHotLoop,
+                  TailNumber TailNum,
+                  typename ADramBlockWindowTmp,
+                  typename AElementFunction,
+                  typename BDramBlockWindowTmp,
+                  typename BElementFunction>
+        CK_TILE_DEVICE auto operator()(const ADramBlockWindowTmp& a_dram_block_window_tmp,
+                                       const AElementFunction& a_element_func,
+                                       const BDramBlockWindowTmp& b_dram_block_window_tmp,
+                                       const BElementFunction& b_element_func,
+                                       index_t num_loop,
+                                       void* __restrict__ p_smem_0) const
+        {
+            static_assert(kNumWaveGroups == 2);
+
+            static_assert(
+                std::is_same_v<ADataType, remove_cvref_t<typename ADramBlockWindowTmp::DataType>> &&
+                    std::is_same_v<BDataType,
+                                   remove_cvref_t<typename BDramBlockWindowTmp::DataType>>,
+                "Data Type conflict on A and B matrix input data type.");
+
+            static_assert(
+                KPerBlock % ((NumWarps / 2) * KTileSize) == 0,
+                "Ping Pong Warps, TileSize and Block Size for K dimensions does not match.");
+
+            constexpr bool is_a_col_major =
+                std::is_same_v<ALayout, tensor_layout::gemm::ColumnMajor>;
+            constexpr bool is_b_row_major = std::is_same_v<BLayout, tensor_layout::gemm::RowMajor>;
+
+            static_assert(is_a_col_major
+                              ? (KPerBlock == ADramBlockWindowTmp{}.get_window_lengths()[I0{}] &&
+                                 MPerBlock == ADramBlockWindowTmp{}.get_window_lengths()[I1{}])
+                              : (MPerBlock == ADramBlockWindowTmp{}.get_window_lengths()[I0{}] &&
+                                 KPerBlock == ADramBlockWindowTmp{}.get_window_lengths()[I1{}]),
+                          "A block window has incorrect lengths for defined ALayout!");
+            static_assert(is_b_row_major
+                              ? (KPerBlock == BDramBlockWindowTmp{}.get_window_lengths()[I0{}] &&
+                                 NPerBlock == BDramBlockWindowTmp{}.get_window_lengths()[I1{}])
+                              : (NPerBlock == BDramBlockWindowTmp{}.get_window_lengths()[I0{}] &&
+                                 KPerBlock == BDramBlockWindowTmp{}.get_window_lengths()[I1{}]),
+                          "B block window has incorrect lengths for defined BLayout!");
+
+            index_t group_id     = __builtin_amdgcn_readfirstlane(get_warp_id() % kNumWaveGroups);
+            index_t operation_id = __builtin_amdgcn_readfirstlane(get_warp_id() % kNumWaveGroups);
+
+            // global memory structures here.
+            auto a_copy_dram_window = make_tile_window(
+                a_dram_block_window_tmp.get_bottom_tensor_view(),
+                make_tuple(number<MPerBlock>{}, number<KPerBlock>{}),
+                a_dram_block_window_tmp.get_window_origin(),
+                Policy::template MakeADramTileDistribution<Problem>());
+
+            // B DRAM tile window for load
+            auto b_copy_dram_window = make_tile_window(
+                b_dram_block_window_tmp.get_bottom_tensor_view(),
+                make_tuple(number<NPerBlock>{}, number<KPerBlock>{}),
+                b_dram_block_window_tmp.get_window_origin(),
+                Policy::template MakeBDramTileDistribution<Problem>());
+
+            // DRAM window steps.
+            using ADramTileWindowStep = typename ADramBlockWindowTmp::BottomTensorIndex;
+            using BDramTileWindowStep = typename BDramBlockWindowTmp::BottomTensorIndex;
+            constexpr ADramTileWindowStep a_dram_tile_window_step =
+                is_a_col_major ? make_array(KPerBlock, 0) : make_array(0, KPerBlock);
+            constexpr BDramTileWindowStep b_dram_tile_window_step =
+                is_b_row_major ? make_array(KPerBlock, 0) : make_array(0, KPerBlock);
+
+            constexpr auto AGemmTileDistr = decltype(make_static_tile_distribution(
+                BlockGemm::MakeABlockDistributionEncode())){};
+            constexpr auto BGemmTileDistr = decltype(make_static_tile_distribution(
+                BlockGemm::MakeBBlockDistributionEncode())){};
+
+            using AGemmTile = decltype(make_static_distributed_tensor<ADataType>(AGemmTileDistr));
+            using BGemmTile = decltype(make_static_distributed_tensor<BDataType>(BGemmTileDistr));
+            AGemmTile a_tile_0, a_tile_1; // Gemm Tiles in registers.
+            BGemmTile b_tile_0, b_tile_1;
+
+            // Register tile for A and B.
+            constexpr auto ABlockTileDistr = a_copy_dram_window.get_tile_distribution();
+            constexpr auto BBlockTileDistr = b_copy_dram_window.get_tile_distribution();
+            using ABlockTile = decltype(make_static_distributed_tensor<ADataType>(ABlockTileDistr));
+            using BBlockTile = decltype(make_static_distributed_tensor<BDataType>(BBlockTileDistr));
+            ABlockTile a_global_load_tile;
+            BBlockTile b_global_load_tile;
+
+            // Block GEMM
+            auto block_gemm     = BlockGemm();
+            auto c_block_tile_0 = block_gemm.MakeCBlockTile(); // Gemm distribution.
+            auto c_block_tile_1 = block_gemm.MakeCBlockTile();
+
+            // Not needed
+            auto&& [a_lds_block, b_lds_block] = Base::GetABLdsTensorViews(p_smem_0);
+
+            auto a_copy_lds_window = make_tile_window(
+                a_lds_block, make_tuple(number<MPerBlock>{}, number<KPerBlock>{}), {0, 0});
+            auto b_copy_lds_window = make_tile_window(
+                b_lds_block, make_tuple(number<NPerBlock>{}, number<KPerBlock>{}), {0, 0});
+
+            auto a_lds_window =
+                make_tile_window(a_lds_block,
+                                 make_tuple(number<MPerBlock>{}, number<KPerBlock>{}),
+                                 {0, 0},
+                                 AGemmTileDistr);
+            auto b_lds_window =
+                make_tile_window(b_lds_block,
+                                 make_tuple(number<NPerBlock>{}, number<KPerBlock>{}),
+                                 {0, 0},
+                                 BGemmTileDistr);
+
+            // initialize C
+            tile_elementwise_inout([](auto& c) { c = 0; }, c_block_tile_0);
+            tile_elementwise_inout([](auto& c) { c = 0; }, c_block_tile_1);
+
+            // define ping, pong steps here as lambda functions.
+            auto MemoryOpsStep = [&](auto idx) {
+                // Memory read half here.
+                Base::GlobalPrefetch(
+                    a_global_load_tile, a_copy_dram_window, a_dram_tile_window_step);
+                Base::GlobalPrefetch(
+                    b_global_load_tile, b_copy_dram_window, b_dram_tile_window_step);
+
+                if constexpr(is_a_col_major)
+                {
+                    auto a_shuffle_tmp = make_static_distributed_tensor<ADataType>(
+                        Policy::template MakeShuffledARegTileDistribution<Problem>());
+                    transpose_tile2d(a_shuffle_tmp, a_global_load_tile);
+                    Base::LocalPrefill(a_copy_lds_window, a_shuffle_tmp, a_element_func);
+                }
+                else
+                {
+                    Base::LocalPrefill(a_copy_lds_window, a_global_load_tile, a_element_func);
+                }
+
+                if constexpr(is_b_row_major)
+                {
+                    auto b_shuffle_tmp = make_static_distributed_tensor<BDataType>(
+                        Policy::template MakeShuffledBRegTileDistribution<Problem>());
+                    transpose_tile2d(b_shuffle_tmp, b_global_load_tile);
+                    Base::LocalPrefill(b_copy_lds_window, b_shuffle_tmp, b_element_func);
+                }
+                else
+                {
+                    Base::LocalPrefill(b_copy_lds_window, b_global_load_tile, b_element_func);
+                }
+
+                if(idx == 0)
+                {
+                    Base::LocalPrefetch(a_tile_0, a_lds_window);
+                    Base::LocalPrefetch(b_tile_0, b_lds_window);
+                }
+                else
+                {
+                    Base::LocalPrefetch(a_tile_1, a_lds_window);
+                    Base::LocalPrefetch(b_tile_1, b_lds_window);
+                }
+            };
+
+            auto ComputeStep = [&](auto idx) {
+                if(idx == 0)
+                {
+                    block_gemm(c_block_tile_0, a_tile_0, b_tile_0);
+                }
+                else
+                {
+                    block_gemm(c_block_tile_1, a_tile_1, b_tile_1);
+                }
+            };
+
+            if(operation_id == 0)
+            {
+                MemoryOpsStep(group_id);
+            }
+
+            // start the main loop.
+            index_t num_compute_steps = __builtin_amdgcn_readfirstlane(num_loop);
+            while(num_compute_steps > 10)
+            {
+                block_sync_lds();
+                operation_id = (operation_id + 1) % kNumWaveGroups;
+
+                if(operation_id == 0)
+                {
+                    MemoryOpsStep(group_id);
+                }
+                else
+                {
+                    ComputeStep(group_id);
+                }
+                num_compute_steps -= 1;
+            }
+
+            // Handle Tail Number here.
+            if(operation_id == 0)
+            {
+                ComputeStep(group_id);
+            }
+            block_sync_lds();
+
+            // Add both the tiles and return the result.
+            /*
+            if(group_id == 0)
+            {
+                constexpr auto s_spans = decltype(c_block_tile_0)::get_distributed_spans();
+                sweep_tile_span(s_spans[number<0>{}], [&](auto idx0) {
+                    sweep_tile_span(s_spans[number<1>{}], [&](auto idx1) {
+                        auto idx2 = make_tuple(idx0, idx1);
+                        c_block_tile_0(idx2) += c_block_tile_1(idx2);
+                    });
+                });
+            }*/
+
+            return c_block_tile_0;
+        }
+    };
+
+    template <typename ADramBlockWindowTmp,
+              typename BDramBlockWindowTmp,
+              typename AElementFunction,
+              typename BElementFunction>
+    CK_TILE_DEVICE auto operator()(const ADramBlockWindowTmp& a_dram_block_window_tmp,
+                                   const AElementFunction& a_element_func,
+                                   const BDramBlockWindowTmp& b_dram_block_window_tmp,
+                                   const BElementFunction& b_element_func,
+                                   index_t num_loop,
+                                   void* p_smem_0) const
+    {
+        return PipelineImpl<Scheduler>{}.template operator()<HasHotLoop, TailNum>(
+            a_dram_block_window_tmp,
+            a_element_func,
+            b_dram_block_window_tmp,
+            b_element_func,
+            num_loop,
+            p_smem_0);
+    }
+
+    public:
+    template <typename ADramBlockWindowTmp, typename BDramBlockWindowTmp>
+    CK_TILE_DEVICE auto operator()(const ADramBlockWindowTmp& a_dram_block_window_tmp,
+                                   const BDramBlockWindowTmp& b_dram_block_window_tmp,
+                                   const index_t num_loop,
+                                   void* __restrict__ p_smem_0) const
+    {
+        return PipelineImpl<Scheduler>{}.template operator()<HasHotLoop, TailNum>(
+            a_dram_block_window_tmp,
+            [](const ADataType& a) { return a; },
+            b_dram_block_window_tmp,
+            [](const BDataType& b) { return b; },
+            num_loop,
+            p_smem_0);
+    }
+};
+
+} // namespace ck_tile

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
@@ -143,27 +143,30 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
             index_t group_id     = __builtin_amdgcn_readfirstlane(get_warp_id() % kNumWaveGroups);
             index_t operation_id = __builtin_amdgcn_readfirstlane(get_warp_id() % kNumWaveGroups);
 
+            auto a_offset = (group_id == 0) ? multi_index<2>{0, 0}: multi_index<2>{0, KPerBlock};
+            auto b_offset = (group_id == 0) ? multi_index<2>{0, 0} : multi_index<2>{KPerBlock, 0};
+
             // global memory structures here.
             auto a_copy_dram_window =
                 make_tile_window(a_dram_block_window_tmp.get_bottom_tensor_view(),
                                  make_tuple(number<MPerBlock>{}, number<KPerBlock>{}),
-                                 a_dram_block_window_tmp.get_window_origin(),
+                                 a_dram_block_window_tmp.get_window_origin() + a_offset,
                                  Policy::template MakeADramTileDistribution<Problem>());
 
             // B DRAM tile window for load
             auto b_copy_dram_window =
                 make_tile_window(b_dram_block_window_tmp.get_bottom_tensor_view(),
                                  make_tuple(number<NPerBlock>{}, number<KPerBlock>{}),
-                                 b_dram_block_window_tmp.get_window_origin(),
+                                 b_dram_block_window_tmp.get_window_origin() + b_offset,
                                  Policy::template MakeBDramTileDistribution<Problem>());
 
             // DRAM window steps.
             using ADramTileWindowStep = typename ADramBlockWindowTmp::BottomTensorIndex;
             using BDramTileWindowStep = typename BDramBlockWindowTmp::BottomTensorIndex;
             constexpr ADramTileWindowStep a_dram_tile_window_step =
-                is_a_col_major ? make_array(KPerBlock, 0) : make_array(0, KPerBlock);
+                is_a_col_major ? make_array(KPerBlock * NumWarps, 0) : make_array(0, KPerBlock * NumWarps);
             constexpr BDramTileWindowStep b_dram_tile_window_step =
-                is_b_row_major ? make_array(KPerBlock, 0) : make_array(0, KPerBlock);
+                is_b_row_major ? make_array(KPerBlock * NumWarps, 0) : make_array(0, KPerBlock * NumWarps);
 
             constexpr auto AGemmTileDistr = decltype(make_static_tile_distribution(
                 BlockGemm::MakeABlockDistributionEncode())){};

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
@@ -298,7 +298,6 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
             block_sync_lds();
 
             // Add both the tiles and return the result.
-            /*
             if(group_id == 0)
             {
                 constexpr auto s_spans = decltype(c_block_tile_0)::get_distributed_spans();
@@ -308,7 +307,7 @@ struct GemmPipelineAgBgCrCompV5 : public BaseGemmPipelineAgBgCrCompV5<Problem>
                         c_block_tile_0(idx2) += c_block_tile_1(idx2);
                     });
                 });
-            }*/
+            }
 
             return c_block_tile_0;
         }

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_problem.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_problem.hpp
@@ -195,6 +195,7 @@ struct UniversalGemmPipelineProblem
     static constexpr auto TailNum    = TailNum_;
 
     static constexpr bool TransposeC = Traits::TransposeC;
+    static constexpr index_t kNumWaveGroups = Traits::kNumWaveGroups;
 };
 
 } // namespace ck_tile

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_problem.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_problem.hpp
@@ -194,7 +194,7 @@ struct UniversalGemmPipelineProblem
     static constexpr auto HasHotLoop = HasHotLoop_;
     static constexpr auto TailNum    = TailNum_;
 
-    static constexpr bool TransposeC = Traits::TransposeC;
+    static constexpr bool TransposeC        = Traits::TransposeC;
     static constexpr index_t kNumWaveGroups = Traits::kNumWaveGroups;
 };
 

--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -191,6 +191,9 @@ struct UniversalGemmBasePolicy
         constexpr index_t MPerBlock   = Problem::BlockGemmShape::kM;
         constexpr index_t KPerBlock   = Problem::BlockGemmShape::kK;
         constexpr index_t VecLoadSize = GetVectorSizeA<Problem>();
+        constexpr index_t kNumWaveGroups = Problem::kNumWaveGroups;
+
+        static_assert(kNumWaveGroups == 2);
 
         // Tile: MPerBlock X KPerBlock
         if constexpr(std::is_same_v<ALayout, ck_tile::tensor_layout::gemm::RowMajor>)
@@ -199,6 +202,7 @@ struct UniversalGemmBasePolicy
                                                                           MPerBlock,
                                                                           KPerBlock,
                                                                           VecLoadSize,
+                                                                          kNumWaveGroups,
                                                                           ATileAccessPattern>;
             return TileEncodingPattern::Make2DStaticTileDistribution();
         }
@@ -209,6 +213,7 @@ struct UniversalGemmBasePolicy
                                                                           KPerBlock,
                                                                           MPerBlock,
                                                                           VecLoadSize,
+                                                                          kNumWaveGroups,
                                                                           ATileAccessPattern>;
             return TileEncodingPattern::Make2DStaticTileDistribution();
         }
@@ -223,6 +228,9 @@ struct UniversalGemmBasePolicy
         constexpr index_t NPerBlock   = Problem::BlockGemmShape::kN;
         constexpr index_t KPerBlock   = Problem::BlockGemmShape::kK;
         constexpr index_t VecLoadSize = GetVectorSizeB<Problem>();
+        constexpr index_t kNumWaveGroups = Problem::kNumWaveGroups;
+
+        static_assert(kNumWaveGroups == 2);
 
         // Tile: KPerBlock X NPerBlock
         if constexpr(std::is_same_v<BLayout, ck_tile::tensor_layout::gemm::RowMajor>)
@@ -231,6 +239,7 @@ struct UniversalGemmBasePolicy
                                                                           KPerBlock,
                                                                           NPerBlock,
                                                                           VecLoadSize,
+                                                                          kNumWaveGroups,
                                                                           BTileAccessPattern>;
             return TileEncodingPattern::Make2DStaticTileDistribution();
         }
@@ -241,6 +250,7 @@ struct UniversalGemmBasePolicy
                                                                           NPerBlock,
                                                                           KPerBlock,
                                                                           VecLoadSize,
+                                                                          kNumWaveGroups,
                                                                           BTileAccessPattern>;
             return TileEncodingPattern::Make2DStaticTileDistribution();
         }
@@ -255,11 +265,15 @@ struct UniversalGemmBasePolicy
         constexpr index_t MPerBlock   = Problem::BlockGemmShape::kM;
         constexpr index_t KPerBlock   = Problem::BlockGemmShape::kK;
         constexpr index_t VecLoadSize = GetVectorSizeA<Problem>();
+        constexpr index_t kNumWaveGroups = Problem::kNumWaveGroups;
+
+        static_assert(kNumWaveGroups == 2);
 
         using TileEncodingPattern = TileDistributionEncodingPattern2D<BlockSize,
                                                                       KPerBlock,
                                                                       MPerBlock,
                                                                       VecLoadSize,
+                                                                      kNumWaveGroups,
                                                                       ATileAccessPattern>;
         return TileEncodingPattern::MakeShuffled2DStaticTileDistribution();
     }
@@ -273,11 +287,15 @@ struct UniversalGemmBasePolicy
         constexpr index_t NPerBlock   = Problem::BlockGemmShape::kN;
         constexpr index_t KPerBlock   = Problem::BlockGemmShape::kK;
         constexpr index_t VecLoadSize = GetVectorSizeB<Problem>();
+        constexpr index_t kNumWaveGroups = Problem::kNumWaveGroups;
+
+        static_assert(kNumWaveGroups == 2);
 
         using TileEncodingPattern = TileDistributionEncodingPattern2D<BlockSize,
                                                                       KPerBlock,
                                                                       NPerBlock,
                                                                       VecLoadSize,
+                                                                      kNumWaveGroups,
                                                                       BTileAccessPattern>;
         return TileEncodingPattern::MakeShuffled2DStaticTileDistribution();
     }

--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -327,12 +327,22 @@ struct UniversalGemmBasePolicy
     }
 
     template <typename Problem>
+    CK_TILE_DEVICE static constexpr index_t GetSmemSizeC()
+    {
+        constexpr index_t NPerBlock = Problem::BlockGemmShape::kN;
+        constexpr index_t MPerBlock = Problem::BlockGemmShape::kM;
+
+        return integer_least_multiple(sizeof(typename Problem::CDataType) * MPerBlock * NPerBlock * 2, 16);
+    }
+
+    template <typename Problem>
     CK_TILE_HOST_DEVICE static constexpr index_t GetSmemSize()
     {
         constexpr index_t smem_size_a = GetSmemSizeA<Problem>();
         constexpr index_t smem_size_b = GetSmemSizeB<Problem>();
+        constexpr index_t smem_size_c = GetSmemSizeC<Problem>();
 
-        return smem_size_a + smem_size_b;
+        return smem_size_a + smem_size_b + smem_size_c;
     }
 };
 

--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -187,10 +187,10 @@ struct UniversalGemmBasePolicy
     {
         using ALayout = remove_cvref_t<typename Problem::ALayout>;
 
-        constexpr index_t BlockSize   = Problem::kBlockSize;
-        constexpr index_t MPerBlock   = Problem::BlockGemmShape::kM;
-        constexpr index_t KPerBlock   = Problem::BlockGemmShape::kK;
-        constexpr index_t VecLoadSize = GetVectorSizeA<Problem>();
+        constexpr index_t BlockSize      = Problem::kBlockSize;
+        constexpr index_t MPerBlock      = Problem::BlockGemmShape::kM;
+        constexpr index_t KPerBlock      = Problem::BlockGemmShape::kK;
+        constexpr index_t VecLoadSize    = GetVectorSizeA<Problem>();
         constexpr index_t kNumWaveGroups = Problem::kNumWaveGroups;
 
         static_assert(kNumWaveGroups == 2);
@@ -224,10 +224,10 @@ struct UniversalGemmBasePolicy
     {
         using BLayout = remove_cvref_t<typename Problem::BLayout>;
 
-        constexpr index_t BlockSize   = Problem::kBlockSize;
-        constexpr index_t NPerBlock   = Problem::BlockGemmShape::kN;
-        constexpr index_t KPerBlock   = Problem::BlockGemmShape::kK;
-        constexpr index_t VecLoadSize = GetVectorSizeB<Problem>();
+        constexpr index_t BlockSize      = Problem::kBlockSize;
+        constexpr index_t NPerBlock      = Problem::BlockGemmShape::kN;
+        constexpr index_t KPerBlock      = Problem::BlockGemmShape::kK;
+        constexpr index_t VecLoadSize    = GetVectorSizeB<Problem>();
         constexpr index_t kNumWaveGroups = Problem::kNumWaveGroups;
 
         static_assert(kNumWaveGroups == 2);
@@ -261,10 +261,10 @@ struct UniversalGemmBasePolicy
     {
         using ALayout = remove_cvref_t<typename Problem::ALayout>;
         static_assert(std::is_same_v<ALayout, ck_tile::tensor_layout::gemm::ColumnMajor>);
-        constexpr index_t BlockSize   = Problem::kBlockSize;
-        constexpr index_t MPerBlock   = Problem::BlockGemmShape::kM;
-        constexpr index_t KPerBlock   = Problem::BlockGemmShape::kK;
-        constexpr index_t VecLoadSize = GetVectorSizeA<Problem>();
+        constexpr index_t BlockSize      = Problem::kBlockSize;
+        constexpr index_t MPerBlock      = Problem::BlockGemmShape::kM;
+        constexpr index_t KPerBlock      = Problem::BlockGemmShape::kK;
+        constexpr index_t VecLoadSize    = GetVectorSizeA<Problem>();
         constexpr index_t kNumWaveGroups = Problem::kNumWaveGroups;
 
         static_assert(kNumWaveGroups == 2);
@@ -283,10 +283,10 @@ struct UniversalGemmBasePolicy
     {
         using BLayout = remove_cvref_t<typename Problem::BLayout>;
         static_assert(std::is_same_v<BLayout, ck_tile::tensor_layout::gemm::RowMajor>);
-        constexpr index_t BlockSize   = Problem::kBlockSize;
-        constexpr index_t NPerBlock   = Problem::BlockGemmShape::kN;
-        constexpr index_t KPerBlock   = Problem::BlockGemmShape::kK;
-        constexpr index_t VecLoadSize = GetVectorSizeB<Problem>();
+        constexpr index_t BlockSize      = Problem::kBlockSize;
+        constexpr index_t NPerBlock      = Problem::BlockGemmShape::kN;
+        constexpr index_t KPerBlock      = Problem::BlockGemmShape::kK;
+        constexpr index_t VecLoadSize    = GetVectorSizeB<Problem>();
         constexpr index_t kNumWaveGroups = Problem::kNumWaveGroups;
 
         static_assert(kNumWaveGroups == 2);

--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -193,8 +193,6 @@ struct UniversalGemmBasePolicy
         constexpr index_t VecLoadSize    = GetVectorSizeA<Problem>();
         constexpr index_t kNumWaveGroups = Problem::kNumWaveGroups;
 
-        static_assert(kNumWaveGroups == 2);
-
         // Tile: MPerBlock X KPerBlock
         if constexpr(std::is_same_v<ALayout, ck_tile::tensor_layout::gemm::RowMajor>)
         {
@@ -229,8 +227,6 @@ struct UniversalGemmBasePolicy
         constexpr index_t KPerBlock      = Problem::BlockGemmShape::kK;
         constexpr index_t VecLoadSize    = GetVectorSizeB<Problem>();
         constexpr index_t kNumWaveGroups = Problem::kNumWaveGroups;
-
-        static_assert(kNumWaveGroups == 2);
 
         // Tile: KPerBlock X NPerBlock
         if constexpr(std::is_same_v<BLayout, ck_tile::tensor_layout::gemm::RowMajor>)
@@ -267,8 +263,6 @@ struct UniversalGemmBasePolicy
         constexpr index_t VecLoadSize    = GetVectorSizeA<Problem>();
         constexpr index_t kNumWaveGroups = Problem::kNumWaveGroups;
 
-        static_assert(kNumWaveGroups == 2);
-
         using TileEncodingPattern = TileDistributionEncodingPattern2D<BlockSize,
                                                                       KPerBlock,
                                                                       MPerBlock,
@@ -288,8 +282,6 @@ struct UniversalGemmBasePolicy
         constexpr index_t KPerBlock      = Problem::BlockGemmShape::kK;
         constexpr index_t VecLoadSize    = GetVectorSizeB<Problem>();
         constexpr index_t kNumWaveGroups = Problem::kNumWaveGroups;
-
-        static_assert(kNumWaveGroups == 2);
 
         using TileEncodingPattern = TileDistributionEncodingPattern2D<BlockSize,
                                                                       KPerBlock,

--- a/include/ck_tile/ops/gemm/pipeline/tile_gemm_traits.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/tile_gemm_traits.hpp
@@ -36,7 +36,8 @@ template <bool kPadM_,
           typename ALayout_,
           typename BLayout_,
           typename CLayout_,
-          bool TransposeC_ = false>
+          bool TransposeC_ = false, 
+          index_t kNumWaveGroups_ = 1>
 struct TileGemmUniversalTraits
 {
     static constexpr bool kPadM = kPadM_;
@@ -50,6 +51,7 @@ struct TileGemmUniversalTraits
     using CLayout = CLayout_;
 
     static constexpr bool TransposeC = TransposeC_;
+    static constexpr index_t kNumWaveGroups = kNumWaveGroups_;
 };
 
 } // namespace ck_tile

--- a/include/ck_tile/ops/gemm/pipeline/tile_gemm_traits.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/tile_gemm_traits.hpp
@@ -36,7 +36,7 @@ template <bool kPadM_,
           typename ALayout_,
           typename BLayout_,
           typename CLayout_,
-          bool TransposeC_ = false, 
+          bool TransposeC_        = false,
           index_t kNumWaveGroups_ = 1>
 struct TileGemmUniversalTraits
 {
@@ -50,7 +50,7 @@ struct TileGemmUniversalTraits
     using BLayout = BLayout_;
     using CLayout = CLayout_;
 
-    static constexpr bool TransposeC = TransposeC_;
+    static constexpr bool TransposeC        = TransposeC_;
     static constexpr index_t kNumWaveGroups = kNumWaveGroups_;
 };
 


### PR DESCRIPTION
## Proposed changes

Implementation of a ping pong scheduler for GEMM kernel. 
Ping pong scheduler splits the available warps into 2 groups. 
In each cycle one group performs memory reads and loads tiles into registers and the other group performs block-gemm operation on the data available from the previous cycle. 

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

