### PR TITLE
Floating Point Exception Error fix for Streamk GEMM Kernel 

### DIFF
--- a/test/gemm_universal_streamk/test_gemm_universal_streamk_ut_cases_bf16.inc
+++ b/test/gemm_universal_streamk/test_gemm_universal_streamk_ut_cases_bf16.inc
@@ -44,34 +44,6 @@ TYPED_TEST(TestGemmUniversal_Streamk_BF16_KM_KN, SmallM)
     }
 }
 
-TYPED_TEST(TestGemmUniversal_Streamk_BF16_MK_KN, MidLargeM)
-{
-    std::vector<int> Ms{127, 255, 312, 799, 1573};
-    constexpr int N = 512;
-    constexpr int K = 320;
-
-    constexpr int StrideA = K;
-    constexpr int StrideB = N;
-    constexpr int StrideC = N;
-
-    for(int M : Ms)
-        this->Run(M, N, K, StrideA, StrideB, StrideC);
-}
-
-TYPED_TEST(TestGemmUniversal_Streamk_BF16_MK_NK, MidLargeM)
-{
-    std::vector<int> Ms{127, 255, 312, 799, 1573};
-    constexpr int N = 512;
-    constexpr int K = 320;
-
-    constexpr int StrideA = K;
-    constexpr int StrideB = K;
-    constexpr int StrideC = N;
-
-    for(int M : Ms)
-        this->Run(M, N, K, StrideA, StrideB, StrideC);
-}
-
 TYPED_TEST(TestGemmUniversal_Streamk_BF16_KM_KN, MidLargeM)
 {
     std::vector<int> Ms{127, 255, 312, 799, 1573};


### PR DESCRIPTION
## Proposed changes

This PR does fix floating point exception error for Streamk GEMM kernel with Stream-K Tile=1, which can be observed by some gfx942 machine. 

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.
- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

