### PR TITLE
Temporarily disable MX FP4 device tests

### DIFF
--- a/include/ck/ck.hpp
+++ b/include/ck/ck.hpp
@@ -245,6 +245,9 @@
 #define CK_WORKAROUND_FP32_TO_FP4_SR_CONVERSION 1
 
 // workaround: compiler issue on gfx950
+#define CK_TEMP_DISABLE_FP4_TESTS 1
+
+// workaround: compiler issue on gfx950
 #define CK_WORKAROUND_FP16_TO_FP8_CONVERSION 1
 
 // workaround: compiler issue on gfx950

--- a/test/data_type/test_mx_fp4.cpp
+++ b/test/data_type/test_mx_fp4.cpp
@@ -240,6 +240,7 @@ TEST(MXFP4, HostScaledConvert)
     EXPECT_EQ(test_size, i);
 }
 
+#if !CK_TEMP_DISABLE_FP4_TESTS
 __global__ void test_mx_fp4_device_scaled_convert(uint64_t N, float* p_test, uint64_t* p_completed)
 {
     test_mx_fp4_scaled_convert(N, p_test, p_completed);
@@ -539,3 +540,4 @@ TEST(MXFP4, DeviceF4x32ToF32x32ScaledConvert)
     EXPECT_EQ(N, completed);
     EXPECT_EQ(N, i);
 }
+#endif // CK_TEMP_DISABLE_FP4_TESTS


### PR DESCRIPTION
## Proposed changes

Disable MX FP4 device tests

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

N/A

