### PR TITLE
add CShuffleM/NXdlPerWavePerShuffle in cshuffle_epilogue

### DIFF
--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -78,8 +78,8 @@ struct CShuffleEpilogue
      */
     CK_TILE_HOST_DEVICE static constexpr auto GetVectorSizeC()
     {
-        constexpr index_t MaxVectorStoreSize = 16;
-        return MaxVectorStoreSize / sizeof(ODataType);
+        constexpr index_t max_vector_store_size = 16;
+        return max_vector_store_size / sizeof(ODataType);
     }
 
     /**
@@ -90,7 +90,7 @@ struct CShuffleEpilogue
      * - NumMXdlPerWavePerShuffle: Number of XDL tiles in M dimension processed per wave
      * - NumNXdlPerWavePerShuffle: Number of XDL tiles in N dimension processed per wave
      */
-    static constexpr auto ShuffleTileTuple = [] {
+    static constexpr auto shuffle_tile_tuple = [] {
         constexpr index_t vecPerThread = kMPerXdl * kNPerXdl / get_warp_size();
         if constexpr(vecPerThread >= GetVectorSizeC())
         {
@@ -98,22 +98,25 @@ struct CShuffleEpilogue
         }
         else
         {
-            constexpr index_t maxElementsPerThread = GetVectorSizeC() / vecPerThread;
+            constexpr index_t num_xdl_shuffles = GetVectorSizeC() / vecPerThread;
             if constexpr(std::is_same_v<CLayout, tensor_layout::gemm::RowMajor>)
             {
-
-                return std::make_tuple(min(maxElementsPerThread, kMPerBlock / (kMPerXdl * kMWave)),
+                static_assert(kMPerBlock % (kMPerXdl * kMWave) == 0,
+                              "kMPerBlock must be divisible by kMPerXdl*kMWave for CShuffleEpilogue");
+                return std::make_tuple(min(num_xdl_shuffles, kMPerBlock / (kMPerXdl * kMWave)),
                                        1);
             }
             else
             {
+                static_assert(kNPerBlock % (kNPerXdl * kNWave) == 0,
+                              "kNPerBlock must be divisible by kNPerXdl*kNWave for CShuffleEpilogue");
                 return std::make_tuple(1,
-                                       min(maxElementsPerThread, kNPerBlock / (kNPerXdl * kNWave)));
+                                       min(num_xdl_shuffles, kNPerBlock / (kNPerXdl * kNWave)));
             }
         }
     }();
-    static constexpr index_t NumMXdlPerWavePerShuffle = std::get<0>(ShuffleTileTuple);
-    static constexpr index_t NumNXdlPerWavePerShuffle = std::get<1>(ShuffleTileTuple);
+    static constexpr index_t NumMXdlPerWavePerShuffle = std::get<0>(shuffle_tile_tuple);
+    static constexpr index_t NumNXdlPerWavePerShuffle = std::get<1>(shuffle_tile_tuple);
 
     static constexpr index_t kMPerIteration = kMPerXdl * kMWave * NumMXdlPerWavePerShuffle;
     static constexpr index_t kNPerIteration = kNPerXdl * kNWave * NumNXdlPerWavePerShuffle;

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -22,23 +22,25 @@ template <typename ADataType_,
           index_t kMPerXdl_,
           index_t kNPerXdl_,
           index_t kKPerXdl_,
-          bool isCTransposed_>
+          bool isCTransposed_,
+          memory_operation_enum MemoryOperation_>
 struct CShuffleEpilogueProblem
 {
-    using ADataType                        = remove_cvref_t<ADataType_>;
-    using BDataType                        = remove_cvref_t<BDataType_>;
-    using AccDataType                      = remove_cvref_t<AccDataType_>;
-    using ODataType                        = remove_cvref_t<ODataType_>;
-    using CLayout                          = remove_cvref_t<CLayout_>;
-    static constexpr index_t kBlockSize    = kBlockSize_;
-    static constexpr index_t kMPerBlock    = kM_;
-    static constexpr index_t kNPerBlock    = kN_;
-    static constexpr index_t kMWave        = kMWave_;
-    static constexpr index_t kNWave        = kNWave_;
-    static constexpr index_t kMPerXdl      = kMPerXdl_;
-    static constexpr index_t kNPerXdl      = kNPerXdl_;
-    static constexpr index_t kKPerXdl      = kKPerXdl_;
-    static constexpr index_t isCTransposed = isCTransposed_;
+    using ADataType                                        = remove_cvref_t<ADataType_>;
+    using BDataType                                        = remove_cvref_t<BDataType_>;
+    using AccDataType                                      = remove_cvref_t<AccDataType_>;
+    using ODataType                                        = remove_cvref_t<ODataType_>;
+    using CLayout                                          = remove_cvref_t<CLayout_>;
+    static constexpr index_t kBlockSize                    = kBlockSize_;
+    static constexpr index_t kMPerBlock                    = kM_;
+    static constexpr index_t kNPerBlock                    = kN_;
+    static constexpr index_t kMWave                        = kMWave_;
+    static constexpr index_t kNWave                        = kNWave_;
+    static constexpr index_t kMPerXdl                      = kMPerXdl_;
+    static constexpr index_t kNPerXdl                      = kNPerXdl_;
+    static constexpr index_t kKPerXdl                      = kKPerXdl_;
+    static constexpr index_t isCTransposed                 = isCTransposed_;
+    static constexpr memory_operation_enum MemoryOperation = MemoryOperation_;
 };
 
 template <typename Problem_, typename Policy_ = void>
@@ -81,27 +83,6 @@ struct CShuffleEpilogue
     using CWarpDstr   = typename WG::CWarpDstr;
     using CWarpTensor = typename WG::CWarpTensor;
 
-    CK_TILE_DEVICE static constexpr auto MakeLdsDistributionEncode()
-    {
-        constexpr auto block_outer_dstr_encoding =
-            tile_distribution_encoding<sequence<>,
-                                       tuple<sequence<CShuffleMXdlPerWavePerShuffle, kMWave>,
-                                             sequence<CShuffleNXdlPerWavePerShuffle, kNWave>>,
-                                       tuple<sequence<1, 2>>,
-                                       tuple<sequence<1, 1>>,
-                                       sequence<1, 2>,
-                                       sequence<0, 0>>;
-        constexpr auto block_dstr_encoding = detail::make_embed_tile_distribution_encoding(
-            block_outer_dstr_encoding, typename CWarpDstr::DstrEncode{});
-
-        return block_dstr_encoding;
-    }
-
-    static constexpr auto LdsDistributionTileDistr =
-        decltype(make_static_tile_distribution(MakeLdsDistributionEncode())){};
-
-    using LdsTile = decltype(make_static_distributed_tensor<ODataType>(LdsDistributionTileDistr));
-    LdsTile lds_tile_;
     /**
      * @brief Get the vector store size for C tensor.
      *
@@ -208,10 +189,6 @@ struct CShuffleEpilogue
                                               tile_distribution_pattern::thread_raked>;
         constexpr auto dram_tile_distribution = TileEncodingPattern::Make2DStaticTileDistribution();
 
-        constexpr auto c_warp_tile_y_lengths =
-            to_sequence(LdsTile{}.get_ys_to_d_descriptor().get_lengths());
-        constexpr auto c_warp_tile_y_index_zeros = uniform_sequence_gen_t<LdsTile::NDimY, 0>{};
-
         constexpr auto c_warp_y_lengths =
             to_sequence(CWarpDstr{}.get_ys_to_d_descriptor().get_lengths());
         constexpr auto c_warp_y_index_zeros = uniform_sequence_gen_t<CWarpDstr::NDimY, 0>{};
@@ -219,10 +196,6 @@ struct CShuffleEpilogue
         static_for<0, num_access, 1>{}([&](auto iAccess) {
             constexpr auto idx_y_start = SFC::get_index(iAccess);
 
-            constexpr auto mIter = number<idx_y_start.at(number<0>{}) /
-                                          (kMPerXdl * kMWave * CShuffleMXdlPerWavePerShuffle)>{};
-            constexpr auto nIter = number<idx_y_start.at(number<1>{}) /
-                                          (kNPerXdl * kNWave * CShuffleNXdlPerWavePerShuffle)>{};
             constexpr auto mIter = number<idx_y_start.at(number<0>{}) /
                                           (kMPerXdl * kMWave * CShuffleMXdlPerWavePerShuffle)>{};
             constexpr auto nIter = number<idx_y_start.at(number<1>{}) /
@@ -259,74 +232,6 @@ struct CShuffleEpilogue
                 move_tile_window(out_dram_window, {step.at(number<0>{}), step.at(number<1>{})});
             }
         });
-
-        // const index_t iMWarp = get_warp_id() / kNWave;
-        // const index_t iNWarp = get_warp_id() - iMWarp * kNWave;
-
-        // constexpr auto lds_block_desc = MakeLdsBlockDescriptor<Problem>();
-        // auto o_lds_block              = make_tensor_view<address_space_enum::lds>(
-        //     static_cast<ODataType*>(p_smem), lds_block_desc);
-        // auto in_lds_window =
-        //     make_tile_window(o_lds_block,
-        //                      make_tuple(number<kMPerXdl>{}, number<kNPerXdl>{}),
-        //                      {number<kMPerXdl>{} * iMWarp, number<kNPerXdl>{} * iNWarp});
-        // auto out_lds_window =
-        //     make_tile_window(o_lds_block,
-        //                      make_tuple(number<kMWave * kMPerXdl>{}, number<kNWave *
-        //                      kNPerXdl>{}), {0, 0});
-
-        // using SFC                    = space_filling_curve<sequence<kMPerBlock, kNPerBlock>,
-        //                                 sequence<0, 1>,
-        //                                 sequence<kMPerXdl * kMWave, kNPerXdl * kNWave>>;
-        // constexpr index_t num_access = SFC::get_num_of_access();
-
-        // using TileEncodingPattern =
-        //     TileDistributionEncodingPattern2D<kBlockSize,
-        //                                       kMPerIteration,
-        //                                       kNPerIteration,
-        //                                       GetVectorSizeC(),
-        //                                       tile_distribution_pattern::thread_raked>;
-        // constexpr auto dram_tile_distribution =
-        // TileEncodingPattern::Make2DStaticTileDistribution();
-
-        // constexpr auto c_warp_y_lengths =
-        //     to_sequence(CWarpDstr{}.get_ys_to_d_descriptor().get_lengths());
-        // constexpr auto c_warp_y_index_zeros = uniform_sequence_gen_t<CWarpDstr::NDimY, 0>{};
-
-        // CWarpTensor c_warp_in_tensor;
-        // static_for<0, num_access, 1>{}([&](auto iAccess) {
-        //     constexpr auto idx_y_start = SFC::get_index(iAccess);
-
-        //     constexpr auto mIter = number<idx_y_start.at(number<0>{}) / (kMPerXdl * kMWave)>{};
-        //     constexpr auto nIter = number<idx_y_start.at(number<1>{}) / (kNPerXdl * kNWave)>{};
-
-        //     c_warp_in_tensor.get_thread_buffer() = o_acc_tile.get_y_sliced_thread_data(
-        //         merge_sequences(sequence<mIter, nIter>{}, c_warp_y_index_zeros),
-        //         merge_sequences(sequence<1, 1>{}, c_warp_y_lengths));
-
-        //     const auto c_warp_in_tensor_casted = cast_tile<ODataType>(c_warp_in_tensor);
-
-        //     block_sync_lds();
-        //     store_tile(in_lds_window, c_warp_in_tensor_casted);
-        //     block_sync_lds();
-
-        //     const auto c_out_tensor =
-        //         load_tile(make_tile_window(out_lds_window, dram_tile_distribution));
-
-        //     if constexpr(MemoryOperation == memory_operation_enum::set)
-        //     {
-        //         store_tile(out_dram_window, c_out_tensor);
-        //     }
-        //     else
-        //     {
-        //         update_tile(out_dram_window, c_out_tensor);
-        //     }
-        //     if constexpr(iAccess != num_access - 1)
-        //     {
-        //         constexpr auto step = SFC::get_forward_step(iAccess);
-        //         move_tile_window(out_dram_window, {step.at(number<0>{}), step.at(number<1>{})});
-        //     }
-        // });
     }
 };
 } // namespace ck_tile

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -22,25 +22,23 @@ template <typename ADataType_,
           index_t kMPerXdl_,
           index_t kNPerXdl_,
           index_t kKPerXdl_,
-          bool isCTransposed_,
-          memory_operation_enum MemoryOperation_>
+          bool isCTransposed_>
 struct CShuffleEpilogueProblem
 {
-    using ADataType                                        = remove_cvref_t<ADataType_>;
-    using BDataType                                        = remove_cvref_t<BDataType_>;
-    using AccDataType                                      = remove_cvref_t<AccDataType_>;
-    using ODataType                                        = remove_cvref_t<ODataType_>;
-    using CLayout                                          = remove_cvref_t<CLayout_>;
-    static constexpr index_t kBlockSize                    = kBlockSize_;
-    static constexpr index_t kMPerBlock                    = kM_;
-    static constexpr index_t kNPerBlock                    = kN_;
-    static constexpr index_t kMWave                        = kMWave_;
-    static constexpr index_t kNWave                        = kNWave_;
-    static constexpr index_t kMPerXdl                      = kMPerXdl_;
-    static constexpr index_t kNPerXdl                      = kNPerXdl_;
-    static constexpr index_t kKPerXdl                      = kKPerXdl_;
-    static constexpr index_t isCTransposed                 = isCTransposed_;
-    static constexpr memory_operation_enum MemoryOperation = MemoryOperation_;
+    using ADataType                        = remove_cvref_t<ADataType_>;
+    using BDataType                        = remove_cvref_t<BDataType_>;
+    using AccDataType                      = remove_cvref_t<AccDataType_>;
+    using ODataType                        = remove_cvref_t<ODataType_>;
+    using CLayout                          = remove_cvref_t<CLayout_>;
+    static constexpr index_t kBlockSize    = kBlockSize_;
+    static constexpr index_t kMPerBlock    = kM_;
+    static constexpr index_t kNPerBlock    = kN_;
+    static constexpr index_t kMWave        = kMWave_;
+    static constexpr index_t kNWave        = kNWave_;
+    static constexpr index_t kMPerXdl      = kMPerXdl_;
+    static constexpr index_t kNPerXdl      = kNPerXdl_;
+    static constexpr index_t kKPerXdl      = kKPerXdl_;
+    static constexpr index_t isCTransposed = isCTransposed_;
 };
 
 template <typename Problem_, typename Policy_ = void>
@@ -67,7 +65,7 @@ struct CShuffleEpilogue
     static constexpr index_t isCTransposed                 = Problem::isCTransposed;
 
     static constexpr index_t CShuffleMXdlPerWavePerShuffle = 1;
-    static constexpr index_t CShuffleNXdlPerWavePerShuffle = 1;
+    static constexpr index_t CShuffleNXdlPerWavePerShuffle = 2;
 
     static constexpr index_t kMPerIteration = kMPerXdl * kMWave * CShuffleMXdlPerWavePerShuffle;
     static constexpr index_t kNPerIteration = kNPerXdl * kNWave * CShuffleNXdlPerWavePerShuffle;
@@ -83,27 +81,6 @@ struct CShuffleEpilogue
     using CWarpDstr   = typename WG::CWarpDstr;
     using CWarpTensor = typename WG::CWarpTensor;
 
-    CK_TILE_DEVICE static constexpr auto MakeLdsDistributionEncode()
-    {
-        constexpr auto block_outer_dstr_encoding =
-            tile_distribution_encoding<sequence<>,
-                                       tuple<sequence<CShuffleMXdlPerWavePerShuffle, kMWave>,
-                                             sequence<CShuffleNXdlPerWavePerShuffle, kNWave>>,
-                                       tuple<sequence<1, 2>>,
-                                       tuple<sequence<1, 1>>,
-                                       sequence<1, 2>,
-                                       sequence<0, 0>>;
-        constexpr auto block_dstr_encoding = detail::make_embed_tile_distribution_encoding(
-            block_outer_dstr_encoding, typename CWarpDstr::DstrEncode{});
-
-        return block_dstr_encoding;
-    }
-
-    static constexpr auto LdsDistributionTileDistr =
-        decltype(make_static_tile_distribution(MakeLdsDistributionEncode())){};
-
-    using LdsTile = decltype(make_static_distributed_tensor<ODataType>(LdsDistributionTileDistr));
-    LdsTile lds_tile_;
     /**
      * @brief Get the vector store size for C tensor.
      *
@@ -126,34 +103,41 @@ struct CShuffleEpilogue
         // N is contiguous dimension
         if constexpr(std::is_same_v<CLayout, tensor_layout::gemm::RowMajor>)
         {
-            static constexpr auto lds_desc_0 = make_naive_tensor_descriptor_packed(
-                make_tuple(number<CShuffleMXdlPerWavePerShuffle>{},
-                           number<KMWave>{},
-                           number<kMPerXdl>{},
-                           number<CShuffleNXdlPerWavePerShuffle>{},
-                           number<KNWave>{},
-                           number<kNPerXdl>{}));
-
-            return transform_tensor_descriptor(
-                lds_desc_0,
-                make_tuple(make_merge_transform(
-                               make_tuple(CShuffleMXdlPerWavePerShuffle, KMWave, kMPerXdl)),
-                           make_merge_transform(
-                               make_tuple(CShuffleNXdlPerWavePerShuffle, KNWave, kNPerXdl))),
-                make_tuple(sequence<0, 1, 2>{}, sequence<3, 4, 5>{}),
-                make_tuple(sequence<0>{}, sequence<1>{}));
+            return make_naive_tensor_descriptor(
+                make_tuple(number<kMWave * kMPerXdl * CShuffleMXdlPerWavePerShuffle>{},
+                           number<kNWave * kNPerXdl * CShuffleNXdlPerWavePerShuffle>{}),
+                make_tuple(number<kNWave * kNPerXdl * CShuffleNXdlPerWavePerShuffle>{},
+                           number<1>{}));
         }
         // M is contiguous dimension
         else if constexpr(std::is_same_v<CLayout, tensor_layout::gemm::ColumnMajor>)
         {
             return make_naive_tensor_descriptor(
-                make_tuple(number<kMWave * kMPerXdl>{}, number<kNWave * kNPerXdl>{}),
-                make_tuple(number<1>{}, number<kMWave * kMPerXdl>{}));
+                make_tuple(number<kMWave * kMPerXdl * CShuffleMXdlPerWavePerShuffle>{},
+                           number<kNWave * kNPerXdl * CShuffleNXdlPerWavePerShuffle>{}),
+                make_tuple(number<1>{},
+                           number<kMWave * kMPerXdl * CShuffleMXdlPerWavePerShuffle>{}));
         }
         else
         {
             static_assert(false, "Unsupported CLayout!");
         }
+    }
+
+    CK_TILE_DEVICE static constexpr auto MakeLdsDistributionEncode()
+    {
+        constexpr auto block_outer_dstr_encoding =
+            tile_distribution_encoding<sequence<>,
+                                       tuple<sequence<CShuffleMXdlPerWavePerShuffle, kMWave>,
+                                             sequence<CShuffleNXdlPerWavePerShuffle, kNWave>>,
+                                       tuple<sequence<1, 2>>,
+                                       tuple<sequence<1, 1>>,
+                                       sequence<1, 2>,
+                                       sequence<0, 0>>{};
+        constexpr auto block_dstr_encoding = detail::make_embed_tile_distribution_encoding(
+            block_outer_dstr_encoding, typename CWarpDstr::DstrEncode{});
+
+        return block_dstr_encoding;
     }
 
     CK_TILE_HOST_DEVICE static constexpr index_t GetSmemSize()
@@ -166,6 +150,11 @@ struct CShuffleEpilogue
     CK_TILE_DEVICE auto
     operator()(ODramWindow& out_dram_window, const OAccTile& o_acc_tile, void* p_smem)
     {
+        constexpr auto LdsDistributionTileDistr =
+            make_static_tile_distribution(MakeLdsDistributionEncode());
+
+        auto lds_tile_ = make_static_distributed_tensor<AccDataType>(LdsDistributionTileDistr);
+
         constexpr auto lds_block_desc = MakeLdsBlockDescriptor<Problem>();
         auto o_lds_block              = make_tensor_view<address_space_enum::lds>(
             static_cast<ODataType*>(p_smem), lds_block_desc);
@@ -175,7 +164,7 @@ struct CShuffleEpilogue
             make_tuple(number<kMWave * kMPerXdl * CShuffleMXdlPerWavePerShuffle>{},
                        number<kNWave * kNPerXdl * CShuffleNXdlPerWavePerShuffle>{}),
             {0, 0},
-            typename LdsTile::StaticTileDistribution{});
+            LdsDistributionTileDistr);
 
         auto out_lds_window = make_tile_window(
             o_lds_block,
@@ -198,15 +187,10 @@ struct CShuffleEpilogue
                                               tile_distribution_pattern::thread_raked>;
         constexpr auto dram_tile_distribution = TileEncodingPattern::Make2DStaticTileDistribution();
 
-        constexpr auto c_warp_tile_y_lengths =
-            to_sequence(LdsTile{}.get_ys_to_d_descriptor().get_lengths());
-        constexpr auto c_warp_tile_y_index_zeros = uniform_sequence_gen_t<LdsTile::NDimY, 0>{};
-
         constexpr auto c_warp_y_lengths =
             to_sequence(CWarpDstr{}.get_ys_to_d_descriptor().get_lengths());
         constexpr auto c_warp_y_index_zeros = uniform_sequence_gen_t<CWarpDstr::NDimY, 0>{};
 
-        LdsTile c_warptile_in_tensor;
         static_for<0, num_access, 1>{}([&](auto iAccess) {
             constexpr auto idx_y_start = SFC::get_index(iAccess);
 
@@ -215,31 +199,15 @@ struct CShuffleEpilogue
             constexpr auto nIter = number<idx_y_start.at(number<1>{}) /
                                           (kNPerXdl * kNWave * CShuffleNXdlPerWavePerShuffle)>{};
 
-            // c_warp_in_tensor.get_thread_buffer() = o_acc_tile.get_y_sliced_thread_data(
-            //     merge_sequences(sequence<mIter, nIter>{}, c_warp_y_index_zeros),
-            //     merge_sequences(sequence<1, 1>{}, c_warp_y_lengths));
-            static_for<0, CShuffleMXdlPerWavePerShuffle, 1>{}([&](auto iM) {
-                static_for<0, CShuffleNXdlPerWavePerShuffle, 1>{}([&](auto iN) {
-                    // c_warp_in_tensor.get_thread_buffer().at(iM, iN) =
-                    //     o_acc_tile.get_y_sliced_thread_data(
-                    //         merge_sequences(sequence<mIter, nIter>{}, c_warp_y_index_zeros),
-                    //         merge_sequences(sequence<1, 1>{}, c_warp_y_lengths));
-                    c_warptile_in_tensor.set_y_sliced_thread_data(
-                        merge_sequences(sequence<iM, iN>{}, c_warp_tile_y_index_zeros),
-                        merge_sequence(sequence<1, 1>{}, c_warp_tile_y_lengths),
-                        o_acc_tile.get_y_sliced_thread_data(
-                            merge_sequences(sequence<mIter * CShuffleMXdlPerWavePerShuffle + iM,
-                                                     nIter * CShuffleNXdlPerWavePerShuffle + iN>{},
-                                            c_warp_y_index_zeros),
-                            merge_sequences(sequence<1, 1>{}, c_warp_y_lengths)));
-                    // c_block_tensor.set_y_sliced_thread_data(
-                    //     merge_sequences(sequence<mIter, nIter>{}, c_warp_y_index_zeros),
-                    //     merge_sequences(sequence<1, 1>{}, c_warp_y_lengths),
-                    //     c_warp_tensor.get_thread_buffer());
-                });
-            });
+            lds_tile_.get_thread_buffer() = o_acc_tile.get_y_sliced_thread_data(
+                merge_sequences(sequence<mIter * CShuffleMXdlPerWavePerShuffle,
+                                         nIter * CShuffleNXdlPerWavePerShuffle>{},
+                                c_warp_y_index_zeros),
+                merge_sequences(
+                    sequence<CShuffleMXdlPerWavePerShuffle, CShuffleNXdlPerWavePerShuffle>{},
+                    c_warp_y_lengths));
 
-            const auto c_warptile_in_tensor_casted = cast_tile<ODataType>(c_warptile_in_tensor);
+            const auto c_warptile_in_tensor_casted = cast_tile<ODataType>(lds_tile_);
 
             block_sync_lds();
             store_tile(in_lds_window, c_warptile_in_tensor_casted);
@@ -262,74 +230,6 @@ struct CShuffleEpilogue
                 move_tile_window(out_dram_window, {step.at(number<0>{}), step.at(number<1>{})});
             }
         });
-
-        // const index_t iMWarp = get_warp_id() / kNWave;
-        // const index_t iNWarp = get_warp_id() - iMWarp * kNWave;
-
-        // constexpr auto lds_block_desc = MakeLdsBlockDescriptor<Problem>();
-        // auto o_lds_block              = make_tensor_view<address_space_enum::lds>(
-        //     static_cast<ODataType*>(p_smem), lds_block_desc);
-        // auto in_lds_window =
-        //     make_tile_window(o_lds_block,
-        //                      make_tuple(number<kMPerXdl>{}, number<kNPerXdl>{}),
-        //                      {number<kMPerXdl>{} * iMWarp, number<kNPerXdl>{} * iNWarp});
-        // auto out_lds_window =
-        //     make_tile_window(o_lds_block,
-        //                      make_tuple(number<kMWave * kMPerXdl>{}, number<kNWave *
-        //                      kNPerXdl>{}), {0, 0});
-
-        // using SFC                    = space_filling_curve<sequence<kMPerBlock, kNPerBlock>,
-        //                                 sequence<0, 1>,
-        //                                 sequence<kMPerXdl * kMWave, kNPerXdl * kNWave>>;
-        // constexpr index_t num_access = SFC::get_num_of_access();
-
-        // using TileEncodingPattern =
-        //     TileDistributionEncodingPattern2D<kBlockSize,
-        //                                       kMPerIteration,
-        //                                       kNPerIteration,
-        //                                       GetVectorSizeC(),
-        //                                       tile_distribution_pattern::thread_raked>;
-        // constexpr auto dram_tile_distribution =
-        // TileEncodingPattern::Make2DStaticTileDistribution();
-
-        // constexpr auto c_warp_y_lengths =
-        //     to_sequence(CWarpDstr{}.get_ys_to_d_descriptor().get_lengths());
-        // constexpr auto c_warp_y_index_zeros = uniform_sequence_gen_t<CWarpDstr::NDimY, 0>{};
-
-        // CWarpTensor c_warp_in_tensor;
-        // static_for<0, num_access, 1>{}([&](auto iAccess) {
-        //     constexpr auto idx_y_start = SFC::get_index(iAccess);
-
-        //     constexpr auto mIter = number<idx_y_start.at(number<0>{}) / (kMPerXdl * kMWave)>{};
-        //     constexpr auto nIter = number<idx_y_start.at(number<1>{}) / (kNPerXdl * kNWave)>{};
-
-        //     c_warp_in_tensor.get_thread_buffer() = o_acc_tile.get_y_sliced_thread_data(
-        //         merge_sequences(sequence<mIter, nIter>{}, c_warp_y_index_zeros),
-        //         merge_sequences(sequence<1, 1>{}, c_warp_y_lengths));
-
-        //     const auto c_warp_in_tensor_casted = cast_tile<ODataType>(c_warp_in_tensor);
-
-        //     block_sync_lds();
-        //     store_tile(in_lds_window, c_warp_in_tensor_casted);
-        //     block_sync_lds();
-
-        //     const auto c_out_tensor =
-        //         load_tile(make_tile_window(out_lds_window, dram_tile_distribution));
-
-        //     if constexpr(MemoryOperation == memory_operation_enum::set)
-        //     {
-        //         store_tile(out_dram_window, c_out_tensor);
-        //     }
-        //     else
-        //     {
-        //         update_tile(out_dram_window, c_out_tensor);
-        //     }
-        //     if constexpr(iAccess != num_access - 1)
-        //     {
-        //         constexpr auto step = SFC::get_forward_step(iAccess);
-        //         move_tile_window(out_dram_window, {step.at(number<0>{}), step.at(number<1>{})});
-        //     }
-        // });
     }
 };
 } // namespace ck_tile

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -41,12 +41,6 @@ struct CShuffleEpilogueProblem
     static constexpr index_t kKPerXdl                      = kKPerXdl_;
     static constexpr index_t isCTransposed                 = isCTransposed_;
     static constexpr memory_operation_enum MemoryOperation = MemoryOperation_;
-    // // NumMXdlPerWavePerShuffle used for in each shuffle iteration how many xdl tiles in M
-    // // dimensions per wave
-    // static constexpr index_t NumMXdlPerWavePerShuffle = 1;
-    // // NumNXdlPerWavePerShuffle used for in each shuffle iteration how many xdl tiles in N
-    // // dimensions per wave
-    // static constexpr index_t NumNXdlPerWavePerShuffle = 2;
 };
 
 template <typename Problem_, typename Policy_ = void>

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -66,11 +66,11 @@ struct CShuffleEpilogue
     static constexpr index_t kKPerXdl                      = Problem::kKPerXdl;
     static constexpr index_t isCTransposed                 = Problem::isCTransposed;
 
-    static constexpr index_t CShuffleMXdlPerWavePerShuffle = 1;
-    static constexpr index_t CShuffleNXdlPerWavePerShuffle = 2;
+    static constexpr index_t NumMXdlPerWavePerShuffle = 1;
+    static constexpr index_t NumNXdlPerWavePerShuffle = 2;
 
-    static constexpr index_t kMPerIteration = kMPerXdl * kMWave * CShuffleMXdlPerWavePerShuffle;
-    static constexpr index_t kNPerIteration = kNPerXdl * kNWave * CShuffleNXdlPerWavePerShuffle;
+    static constexpr index_t kMPerIteration = kMPerXdl * kMWave * NumMXdlPerWavePerShuffle;
+    static constexpr index_t kNPerIteration = kNPerXdl * kNWave * NumNXdlPerWavePerShuffle;
 
     using WG = WarpGemmMfmaDispatcher<ADataType,
                                       BTypeToUse,
@@ -106,19 +106,17 @@ struct CShuffleEpilogue
         if constexpr(std::is_same_v<CLayout, tensor_layout::gemm::RowMajor>)
         {
             return make_naive_tensor_descriptor(
-                make_tuple(number<kMWave * kMPerXdl * CShuffleMXdlPerWavePerShuffle>{},
-                           number<kNWave * kNPerXdl * CShuffleNXdlPerWavePerShuffle>{}),
-                make_tuple(number<kNWave * kNPerXdl * CShuffleNXdlPerWavePerShuffle>{},
-                           number<1>{}));
+                make_tuple(number<kMWave * kMPerXdl * NumMXdlPerWavePerShuffle>{},
+                           number<kNWave * kNPerXdl * NumNXdlPerWavePerShuffle>{}),
+                make_tuple(number<kNWave * kNPerXdl * NumNXdlPerWavePerShuffle>{}, number<1>{}));
         }
         // M is contiguous dimension
         else if constexpr(std::is_same_v<CLayout, tensor_layout::gemm::ColumnMajor>)
         {
             return make_naive_tensor_descriptor(
-                make_tuple(number<kMWave * kMPerXdl * CShuffleMXdlPerWavePerShuffle>{},
-                           number<kNWave * kNPerXdl * CShuffleNXdlPerWavePerShuffle>{}),
-                make_tuple(number<1>{},
-                           number<kMWave * kMPerXdl * CShuffleMXdlPerWavePerShuffle>{}));
+                make_tuple(number<kMWave * kMPerXdl * NumMXdlPerWavePerShuffle>{},
+                           number<kNWave * kNPerXdl * NumNXdlPerWavePerShuffle>{}),
+                make_tuple(number<1>{}, number<kMWave * kMPerXdl * NumMXdlPerWavePerShuffle>{}));
         }
         else
         {
@@ -130,8 +128,8 @@ struct CShuffleEpilogue
     {
         constexpr auto block_outer_dstr_encoding =
             tile_distribution_encoding<sequence<>,
-                                       tuple<sequence<CShuffleMXdlPerWavePerShuffle, kMWave>,
-                                             sequence<CShuffleNXdlPerWavePerShuffle, kNWave>>,
+                                       tuple<sequence<NumMXdlPerWavePerShuffle, kMWave>,
+                                             sequence<NumNXdlPerWavePerShuffle, kNWave>>,
                                        tuple<sequence<1, 2>>,
                                        tuple<sequence<1, 1>>,
                                        sequence<1, 2>,
@@ -144,41 +142,39 @@ struct CShuffleEpilogue
 
     CK_TILE_HOST_DEVICE static constexpr index_t GetSmemSize()
     {
-        return kMWave * kNWave * kMPerXdl * kNPerXdl * CShuffleMXdlPerWavePerShuffle *
-               CShuffleNXdlPerWavePerShuffle * sizeof(ODataType);
+        return kMWave * kNWave * kMPerXdl * kNPerXdl * NumMXdlPerWavePerShuffle *
+               NumNXdlPerWavePerShuffle * sizeof(ODataType);
     }
 
     template <typename ODramWindow, typename OAccTile>
     CK_TILE_DEVICE auto
     operator()(ODramWindow& out_dram_window, const OAccTile& o_acc_tile, void* p_smem)
     {
-        constexpr auto LdsDistributionTileDistr =
-            make_static_tile_distribution(MakeLdsDistributionEncode());
+        constexpr auto LdsTileDistr = make_static_tile_distribution(MakeLdsDistributionEncode());
 
-        auto lds_tile_ = make_static_distributed_tensor<AccDataType>(LdsDistributionTileDistr);
+        auto lds_tile = make_static_distributed_tensor<AccDataType>(LdsTileDistr);
 
         constexpr auto lds_block_desc = MakeLdsBlockDescriptor<Problem>();
         auto o_lds_block              = make_tensor_view<address_space_enum::lds>(
             static_cast<ODataType*>(p_smem), lds_block_desc);
 
-        auto in_lds_window = make_tile_window(
-            o_lds_block,
-            make_tuple(number<kMWave * kMPerXdl * CShuffleMXdlPerWavePerShuffle>{},
-                       number<kNWave * kNPerXdl * CShuffleNXdlPerWavePerShuffle>{}),
-            {0, 0},
-            LdsDistributionTileDistr);
+        auto in_lds_window =
+            make_tile_window(o_lds_block,
+                             make_tuple(number<kMWave * kMPerXdl * NumMXdlPerWavePerShuffle>{},
+                                        number<kNWave * kNPerXdl * NumNXdlPerWavePerShuffle>{}),
+                             {0, 0},
+                             LdsTileDistr);
 
-        auto out_lds_window = make_tile_window(
-            o_lds_block,
-            make_tuple(number<kMWave * kMPerXdl * CShuffleMXdlPerWavePerShuffle>{},
-                       number<kNWave * kNPerXdl * CShuffleNXdlPerWavePerShuffle>{}),
-            {0, 0});
+        auto out_lds_window =
+            make_tile_window(o_lds_block,
+                             make_tuple(number<kMWave * kMPerXdl * NumMXdlPerWavePerShuffle>{},
+                                        number<kNWave * kNPerXdl * NumNXdlPerWavePerShuffle>{}),
+                             {0, 0});
 
-        using SFC =
-            space_filling_curve<sequence<kMPerBlock, kNPerBlock>,
-                                sequence<0, 1>,
-                                sequence<kMPerXdl * kMWave * CShuffleMXdlPerWavePerShuffle,
-                                         kNPerXdl * kNWave * CShuffleNXdlPerWavePerShuffle>>;
+        using SFC                    = space_filling_curve<sequence<kMPerBlock, kNPerBlock>,
+                                        sequence<0, 1>,
+                                        sequence<kMPerXdl * kMWave * NumMXdlPerWavePerShuffle,
+                                                 kNPerXdl * kNWave * NumNXdlPerWavePerShuffle>>;
         constexpr index_t num_access = SFC::get_num_of_access();
 
         using TileEncodingPattern =
@@ -197,19 +193,18 @@ struct CShuffleEpilogue
             constexpr auto idx_y_start = SFC::get_index(iAccess);
 
             constexpr auto mIter = number<idx_y_start.at(number<0>{}) /
-                                          (kMPerXdl * kMWave * CShuffleMXdlPerWavePerShuffle)>{};
+                                          (kMPerXdl * kMWave * NumMXdlPerWavePerShuffle)>{};
             constexpr auto nIter = number<idx_y_start.at(number<1>{}) /
-                                          (kNPerXdl * kNWave * CShuffleNXdlPerWavePerShuffle)>{};
+                                          (kNPerXdl * kNWave * NumNXdlPerWavePerShuffle)>{};
 
-            lds_tile_.get_thread_buffer() = o_acc_tile.get_y_sliced_thread_data(
-                merge_sequences(sequence<mIter * CShuffleMXdlPerWavePerShuffle,
-                                         nIter * CShuffleNXdlPerWavePerShuffle>{},
-                                c_warp_y_index_zeros),
+            lds_tile.get_thread_buffer() = o_acc_tile.get_y_sliced_thread_data(
                 merge_sequences(
-                    sequence<CShuffleMXdlPerWavePerShuffle, CShuffleNXdlPerWavePerShuffle>{},
-                    c_warp_y_lengths));
+                    sequence<mIter * NumMXdlPerWavePerShuffle, nIter * NumNXdlPerWavePerShuffle>{},
+                    c_warp_y_index_zeros),
+                merge_sequences(sequence<NumMXdlPerWavePerShuffle, NumNXdlPerWavePerShuffle>{},
+                                c_warp_y_lengths));
 
-            const auto c_warptile_in_tensor_casted = cast_tile<ODataType>(lds_tile_);
+            const auto c_warptile_in_tensor_casted = cast_tile<ODataType>(lds_tile);
 
             block_sync_lds();
             store_tile(in_lds_window, c_warptile_in_tensor_casted);

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -101,17 +101,19 @@ struct CShuffleEpilogue
             constexpr index_t num_xdl_shuffles = GetVectorSizeC() / vecPerThread;
             if constexpr(std::is_same_v<CLayout, tensor_layout::gemm::RowMajor>)
             {
-                static_assert(kMPerBlock % (kMPerXdl * kMWave) == 0,
-                              "kMPerBlock must be divisible by kMPerXdl*kMWave for CShuffleEpilogue");
-                return std::make_tuple(min(num_xdl_shuffles, kMPerBlock / (kMPerXdl * kMWave)),
-                                       1);
+                static_assert((kMPerBlock % (kMPerXdl * kMWave) == 0) &&
+                                  (kMPerBlock % num_xdl_shuffles == 0),
+                              "kMPerBlock must be divisible by kMPerXdl*kMWave and "
+                              "num_xdl_shuffles for CShuffleEpilogue");
+                return std::make_tuple(min(num_xdl_shuffles, kMPerBlock / (kMPerXdl * kMWave)), 1);
             }
             else
             {
-                static_assert(kNPerBlock % (kNPerXdl * kNWave) == 0,
-                              "kNPerBlock must be divisible by kNPerXdl*kNWave for CShuffleEpilogue");
-                return std::make_tuple(1,
-                                       min(num_xdl_shuffles, kNPerBlock / (kNPerXdl * kNWave)));
+                static_assert((kNPerBlock % (kNPerXdl * kNWave) == 0) &&
+                                  (kNPerBlock % num_xdl_shuffles == 0),
+                              "kNPerBlock must be divisible by kNPerXdl*kNWave and "
+                              "num_xdl_shuffles for CShuffleEpilogue");
+                return std::make_tuple(1, min(num_xdl_shuffles, kNPerBlock / (kNPerXdl * kNWave)));
             }
         }
     }();

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -175,13 +175,94 @@ struct CShuffleEpilogue
             make_tuple(number<kMWave * kMPerXdl * CShuffleMXdlPerWavePerShuffle>{},
                        number<kNWave * kNPerXdl * CShuffleNXdlPerWavePerShuffle>{}),
             {0, 0},
-            LdsTile{});
+            typename LdsTile::StaticTileDistribution{});
 
         auto out_lds_window = make_tile_window(
             o_lds_block,
             make_tuple(number<kMWave * kMPerXdl * CShuffleMXdlPerWavePerShuffle>{},
                        number<kNWave * kNPerXdl * CShuffleNXdlPerWavePerShuffle>{}),
             {0, 0});
+
+        using SFC =
+            space_filling_curve<sequence<kMPerBlock, kNPerBlock>,
+                                sequence<0, 1>,
+                                sequence<kMPerXdl * kMWave * CShuffleMXdlPerWavePerShuffle,
+                                         kNPerXdl * kNWave * CShuffleNXdlPerWavePerShuffle>>;
+        constexpr index_t num_access = SFC::get_num_of_access();
+
+        using TileEncodingPattern =
+            TileDistributionEncodingPattern2D<kBlockSize,
+                                              kMPerIteration,
+                                              kNPerIteration,
+                                              GetVectorSizeC(),
+                                              tile_distribution_pattern::thread_raked>;
+        constexpr auto dram_tile_distribution = TileEncodingPattern::Make2DStaticTileDistribution();
+
+        constexpr auto c_warp_tile_y_lengths =
+            to_sequence(LdsTile{}.get_ys_to_d_descriptor().get_lengths());
+        constexpr auto c_warp_tile_y_index_zeros = uniform_sequence_gen_t<LdsTile::NDimY, 0>{};
+
+        constexpr auto c_warp_y_lengths =
+            to_sequence(CWarpDstr{}.get_ys_to_d_descriptor().get_lengths());
+        constexpr auto c_warp_y_index_zeros = uniform_sequence_gen_t<CWarpDstr::NDimY, 0>{};
+
+        LdsTile c_warptile_in_tensor;
+        static_for<0, num_access, 1>{}([&](auto iAccess) {
+            constexpr auto idx_y_start = SFC::get_index(iAccess);
+
+            constexpr auto mIter = number<idx_y_start.at(number<0>{}) /
+                                          (kMPerXdl * kMWave * CShuffleMXdlPerWavePerShuffle)>{};
+            constexpr auto nIter = number<idx_y_start.at(number<1>{}) /
+                                          (kNPerXdl * kNWave * CShuffleNXdlPerWavePerShuffle)>{};
+
+            // c_warp_in_tensor.get_thread_buffer() = o_acc_tile.get_y_sliced_thread_data(
+            //     merge_sequences(sequence<mIter, nIter>{}, c_warp_y_index_zeros),
+            //     merge_sequences(sequence<1, 1>{}, c_warp_y_lengths));
+            static_for<0, CShuffleMXdlPerWavePerShuffle, 1>{}([&](auto iM) {
+                static_for<0, CShuffleNXdlPerWavePerShuffle, 1>{}([&](auto iN) {
+                    // c_warp_in_tensor.get_thread_buffer().at(iM, iN) =
+                    //     o_acc_tile.get_y_sliced_thread_data(
+                    //         merge_sequences(sequence<mIter, nIter>{}, c_warp_y_index_zeros),
+                    //         merge_sequences(sequence<1, 1>{}, c_warp_y_lengths));
+                    c_warptile_in_tensor.set_y_sliced_thread_data(
+                        merge_sequences(sequence<iM, iN>{}, c_warp_tile_y_index_zeros),
+                        merge_sequence(sequence<1, 1>{}, c_warp_tile_y_lengths),
+                        o_acc_tile.get_y_sliced_thread_data(
+                            merge_sequences(sequence<mIter * CShuffleMXdlPerWavePerShuffle + iM,
+                                                     nIter * CShuffleNXdlPerWavePerShuffle + iN>{},
+                                            c_warp_y_index_zeros),
+                            merge_sequences(sequence<1, 1>{}, c_warp_y_lengths)));
+                    // c_block_tensor.set_y_sliced_thread_data(
+                    //     merge_sequences(sequence<mIter, nIter>{}, c_warp_y_index_zeros),
+                    //     merge_sequences(sequence<1, 1>{}, c_warp_y_lengths),
+                    //     c_warp_tensor.get_thread_buffer());
+                });
+            });
+
+            const auto c_warptile_in_tensor_casted = cast_tile<ODataType>(c_warptile_in_tensor);
+
+            block_sync_lds();
+            store_tile(in_lds_window, c_warptile_in_tensor_casted);
+            block_sync_lds();
+
+            const auto c_out_tensor =
+                load_tile(make_tile_window(out_lds_window, dram_tile_distribution));
+
+            if constexpr(MemoryOperation == memory_operation_enum::set)
+            {
+                store_tile(out_dram_window, c_out_tensor);
+            }
+            else
+            {
+                update_tile(out_dram_window, c_out_tensor);
+            }
+            if constexpr(iAccess != num_access - 1)
+            {
+                constexpr auto step = SFC::get_forward_step(iAccess);
+                move_tile_window(out_dram_window, {step.at(number<0>{}), step.at(number<1>{})});
+            }
+        });
+
         // const index_t iMWarp = get_warp_id() / kNWave;
         // const index_t iNWarp = get_warp_id() - iMWarp * kNWave;
 

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -41,12 +41,12 @@ struct CShuffleEpilogueProblem
     static constexpr index_t kKPerXdl                      = kKPerXdl_;
     static constexpr index_t isCTransposed                 = isCTransposed_;
     static constexpr memory_operation_enum MemoryOperation = MemoryOperation_;
-    // NumMXdlPerWavePerShuffle used for in each shuffle iteration how many xdl tiles in M
-    // dimensions per wave
-    static constexpr index_t NumMXdlPerWavePerShuffle = 1;
-    // NumNXdlPerWavePerShuffle used for in each shuffle iteration how many xdl tiles in N
-    // dimensions per wave
-    static constexpr index_t NumNXdlPerWavePerShuffle = 2;
+    // // NumMXdlPerWavePerShuffle used for in each shuffle iteration how many xdl tiles in M
+    // // dimensions per wave
+    // static constexpr index_t NumMXdlPerWavePerShuffle = 1;
+    // // NumNXdlPerWavePerShuffle used for in each shuffle iteration how many xdl tiles in N
+    // // dimensions per wave
+    // static constexpr index_t NumNXdlPerWavePerShuffle = 2;
 };
 
 template <typename Problem_, typename Policy_ = void>
@@ -71,21 +71,6 @@ struct CShuffleEpilogue
     static constexpr index_t kNPerXdl                      = Problem::kNPerXdl;
     static constexpr index_t kKPerXdl                      = Problem::kKPerXdl;
     static constexpr index_t isCTransposed                 = Problem::isCTransposed;
-    static constexpr index_t NumMXdlPerWavePerShuffle      = Problem::NumMXdlPerWavePerShuffle;
-    static constexpr index_t NumNXdlPerWavePerShuffle      = Problem::NumNXdlPerWavePerShuffle;
-    static constexpr index_t kMPerIteration = kMPerXdl * kMWave * NumMXdlPerWavePerShuffle;
-    static constexpr index_t kNPerIteration = kNPerXdl * kNWave * NumNXdlPerWavePerShuffle;
-
-    using WG = WarpGemmMfmaDispatcher<ADataType,
-                                      BTypeToUse,
-                                      AccDataType,
-                                      kMPerXdl,
-                                      kNPerXdl,
-                                      kKPerXdl,
-                                      isCTransposed>;
-
-    using CWarpDstr   = typename WG::CWarpDstr;
-    using CWarpTensor = typename WG::CWarpTensor;
 
     /**
      * @brief Get the vector store size for C tensor.
@@ -102,6 +87,53 @@ struct CShuffleEpilogue
         constexpr index_t MaxVectorStoreSize = 16;
         return MaxVectorStoreSize / sizeof(ODataType);
     }
+
+    /**
+     * @brief Shuffle tile configuration parameters
+     *
+     * @details These parameters control the number of XDL tiles processed per wave in each shuffle
+     * iteration:
+     * - NumMXdlPerWavePerShuffle: Number of XDL tiles in M dimension processed per wave
+     * - NumNXdlPerWavePerShuffle: Number of XDL tiles in N dimension processed per wave
+     */
+    static constexpr auto ShuffleTileTuple = [] {
+        constexpr index_t vecPerThread = kMPerXdl * kNPerXdl / get_warp_size();
+        if constexpr(vecPerThread >= GetVectorSizeC())
+        {
+            return std::make_tuple(1, 1);
+        }
+        else
+        {
+            constexpr index_t maxElementsPerThread = GetVectorSizeC() / vecPerThread;
+            if constexpr(std::is_same_v<CLayout, tensor_layout::gemm::RowMajor>)
+            {
+
+                return std::make_tuple(min(maxElementsPerThread, kMPerBlock / (kMPerXdl * kMWave)),
+                                       1);
+            }
+            else
+            {
+                return std::make_tuple(1,
+                                       min(maxElementsPerThread, kNPerBlock / (kNPerXdl * kNWave)));
+            }
+        }
+    }();
+    static constexpr index_t NumMXdlPerWavePerShuffle = std::get<0>(ShuffleTileTuple);
+    static constexpr index_t NumNXdlPerWavePerShuffle = std::get<1>(ShuffleTileTuple);
+
+    static constexpr index_t kMPerIteration = kMPerXdl * kMWave * NumMXdlPerWavePerShuffle;
+    static constexpr index_t kNPerIteration = kNPerXdl * kNWave * NumNXdlPerWavePerShuffle;
+
+    using WG = WarpGemmMfmaDispatcher<ADataType,
+                                      BTypeToUse,
+                                      AccDataType,
+                                      kMPerXdl,
+                                      kNPerXdl,
+                                      kKPerXdl,
+                                      isCTransposed>;
+
+    using CWarpDstr   = typename WG::CWarpDstr;
+    using CWarpTensor = typename WG::CWarpTensor;
 
     template <typename Problem>
     CK_TILE_HOST_DEVICE static constexpr auto MakeLdsBlockDescriptor()

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -41,6 +41,12 @@ struct CShuffleEpilogueProblem
     static constexpr index_t kKPerXdl                      = kKPerXdl_;
     static constexpr index_t isCTransposed                 = isCTransposed_;
     static constexpr memory_operation_enum MemoryOperation = MemoryOperation_;
+    // NumMXdlPerWavePerShuffle used for in each shuffle iteration how many xdl tiles in M
+    // dimensions per wave
+    static constexpr index_t NumMXdlPerWavePerShuffle = 1;
+    // NumNXdlPerWavePerShuffle used for in each shuffle iteration how many xdl tiles in N
+    // dimensions per wave
+    static constexpr index_t NumNXdlPerWavePerShuffle = 2;
 };
 
 template <typename Problem_, typename Policy_ = void>
@@ -65,10 +71,8 @@ struct CShuffleEpilogue
     static constexpr index_t kNPerXdl                      = Problem::kNPerXdl;
     static constexpr index_t kKPerXdl                      = Problem::kKPerXdl;
     static constexpr index_t isCTransposed                 = Problem::isCTransposed;
-
-    static constexpr index_t NumMXdlPerWavePerShuffle = 1;
-    static constexpr index_t NumNXdlPerWavePerShuffle = 2;
-
+    static constexpr index_t NumMXdlPerWavePerShuffle      = Problem::NumMXdlPerWavePerShuffle;
+    static constexpr index_t NumNXdlPerWavePerShuffle      = Problem::NumNXdlPerWavePerShuffle;
     static constexpr index_t kMPerIteration = kMPerXdl * kMWave * NumMXdlPerWavePerShuffle;
     static constexpr index_t kNPerIteration = kNPerXdl * kNWave * NumNXdlPerWavePerShuffle;
 
@@ -189,6 +193,7 @@ struct CShuffleEpilogue
             to_sequence(CWarpDstr{}.get_ys_to_d_descriptor().get_lengths());
         constexpr auto c_warp_y_index_zeros = uniform_sequence_gen_t<CWarpDstr::NDimY, 0>{};
 
+        block_sync_lds();
         static_for<0, num_access, 1>{}([&](auto iAccess) {
             constexpr auto idx_y_start = SFC::get_index(iAccess);
 
@@ -206,7 +211,6 @@ struct CShuffleEpilogue
 
             const auto c_warptile_in_tensor_casted = cast_tile<ODataType>(lds_tile);
 
-            block_sync_lds();
             store_tile(in_lds_window, c_warptile_in_tensor_casted);
             block_sync_lds();
 

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -65,8 +65,12 @@ struct CShuffleEpilogue
     static constexpr index_t kNPerXdl                      = Problem::kNPerXdl;
     static constexpr index_t kKPerXdl                      = Problem::kKPerXdl;
     static constexpr index_t isCTransposed                 = Problem::isCTransposed;
-    static constexpr index_t kMPerIteration                = kMPerXdl * kMWave;
-    static constexpr index_t kNPerIteration                = kNPerXdl * kNWave;
+
+    static constexpr index_t CShuffleMXdlPerWavePerShuffle = 1;
+    static constexpr index_t CShuffleNXdlPerWavePerShuffle = 1;
+
+    static constexpr index_t kMPerIteration = kMPerXdl * kMWave * CShuffleMXdlPerWavePerShuffle;
+    static constexpr index_t kNPerIteration = kNPerXdl * kNWave * CShuffleNXdlPerWavePerShuffle;
 
     using WG = WarpGemmMfmaDispatcher<ADataType,
                                       BTypeToUse,
@@ -79,6 +83,27 @@ struct CShuffleEpilogue
     using CWarpDstr   = typename WG::CWarpDstr;
     using CWarpTensor = typename WG::CWarpTensor;
 
+    CK_TILE_DEVICE static constexpr auto MakeLdsDistributionEncode()
+    {
+        constexpr auto block_outer_dstr_encoding =
+            tile_distribution_encoding<sequence<>,
+                                       tuple<sequence<CShuffleMXdlPerWavePerShuffle, kMWave>,
+                                             sequence<CShuffleNXdlPerWavePerShuffle, kNWave>>,
+                                       tuple<sequence<1, 2>>,
+                                       tuple<sequence<1, 1>>,
+                                       sequence<1, 2>,
+                                       sequence<0, 0>>;
+        constexpr auto block_dstr_encoding = detail::make_embed_tile_distribution_encoding(
+            block_outer_dstr_encoding, typename CWarpDstr::DstrEncode{});
+
+        return block_dstr_encoding;
+    }
+
+    static constexpr auto LdsDistributionTileDistr =
+        decltype(make_static_tile_distribution(MakeLdsDistributionEncode())){};
+
+    using LdsTile = decltype(make_static_distributed_tensor<ODataType>(LdsDistributionTileDistr));
+    LdsTile lds_tile_;
     /**
      * @brief Get the vector store size for C tensor.
      *
@@ -101,9 +126,22 @@ struct CShuffleEpilogue
         // N is contiguous dimension
         if constexpr(std::is_same_v<CLayout, tensor_layout::gemm::RowMajor>)
         {
-            return make_naive_tensor_descriptor(
-                make_tuple(number<kMWave * kMPerXdl>{}, number<kNWave * kNPerXdl>{}),
-                make_tuple(number<kNWave * kNPerXdl>{}, number<1>{}));
+            static constexpr auto lds_desc_0 = make_naive_tensor_descriptor_packed(
+                make_tuple(number<CShuffleMXdlPerWavePerShuffle>{},
+                           number<KMWave>{},
+                           number<kMPerXdl>{},
+                           number<CShuffleNXdlPerWavePerShuffle>{},
+                           number<KNWave>{},
+                           number<kNPerXdl>{}));
+
+            return transform_tensor_descriptor(
+                lds_desc_0,
+                make_tuple(make_merge_transform(
+                               make_tuple(CShuffleMXdlPerWavePerShuffle, KMWave, kMPerXdl)),
+                           make_merge_transform(
+                               make_tuple(CShuffleNXdlPerWavePerShuffle, KNWave, kNPerXdl))),
+                make_tuple(sequence<0, 1, 2>{}, sequence<3, 4, 5>{}),
+                make_tuple(sequence<0>{}, sequence<1>{}));
         }
         // M is contiguous dimension
         else if constexpr(std::is_same_v<CLayout, tensor_layout::gemm::ColumnMajor>)
@@ -120,80 +158,97 @@ struct CShuffleEpilogue
 
     CK_TILE_HOST_DEVICE static constexpr index_t GetSmemSize()
     {
-        return kMWave * kNWave * kMPerXdl * kNPerXdl * sizeof(ODataType);
+        return kMWave * kNWave * kMPerXdl * kNPerXdl * CShuffleMXdlPerWavePerShuffle *
+               CShuffleNXdlPerWavePerShuffle * sizeof(ODataType);
     }
 
     template <typename ODramWindow, typename OAccTile>
     CK_TILE_DEVICE auto
     operator()(ODramWindow& out_dram_window, const OAccTile& o_acc_tile, void* p_smem)
     {
-
-        const index_t iMWarp = get_warp_id() / kNWave;
-        const index_t iNWarp = get_warp_id() - iMWarp * kNWave;
-
         constexpr auto lds_block_desc = MakeLdsBlockDescriptor<Problem>();
         auto o_lds_block              = make_tensor_view<address_space_enum::lds>(
             static_cast<ODataType*>(p_smem), lds_block_desc);
-        auto in_lds_window =
-            make_tile_window(o_lds_block,
-                             make_tuple(number<kMPerXdl>{}, number<kNPerXdl>{}),
-                             {number<kMPerXdl>{} * iMWarp, number<kNPerXdl>{} * iNWarp});
-        auto out_lds_window =
-            make_tile_window(o_lds_block,
-                             make_tuple(number<kMWave * kMPerXdl>{}, number<kNWave * kNPerXdl>{}),
-                             {0, 0});
 
-        using SFC                    = space_filling_curve<sequence<kMPerBlock, kNPerBlock>,
-                                        sequence<0, 1>,
-                                        sequence<kMPerXdl * kMWave, kNPerXdl * kNWave>>;
-        constexpr index_t num_access = SFC::get_num_of_access();
+        auto in_lds_window = make_tile_window(
+            o_lds_block,
+            make_tuple(number<kMWave * kMPerXdl * CShuffleMXdlPerWavePerShuffle>{},
+                       number<kNWave * kNPerXdl * CShuffleNXdlPerWavePerShuffle>{}),
+            {0, 0},
+            LdsTile{});
 
-        using TileEncodingPattern =
-            TileDistributionEncodingPattern2D<kBlockSize,
-                                              kMPerIteration,
-                                              kNPerIteration,
-                                              GetVectorSizeC(),
-                                              tile_distribution_pattern::thread_raked>;
-        constexpr auto dram_tile_distribution = TileEncodingPattern::Make2DStaticTileDistribution();
+        auto out_lds_window = make_tile_window(
+            o_lds_block,
+            make_tuple(number<kMWave * kMPerXdl * CShuffleMXdlPerWavePerShuffle>{},
+                       number<kNWave * kNPerXdl * CShuffleNXdlPerWavePerShuffle>{}),
+            {0, 0});
+        // const index_t iMWarp = get_warp_id() / kNWave;
+        // const index_t iNWarp = get_warp_id() - iMWarp * kNWave;
 
-        constexpr auto c_warp_y_lengths =
-            to_sequence(CWarpDstr{}.get_ys_to_d_descriptor().get_lengths());
-        constexpr auto c_warp_y_index_zeros = uniform_sequence_gen_t<CWarpDstr::NDimY, 0>{};
+        // constexpr auto lds_block_desc = MakeLdsBlockDescriptor<Problem>();
+        // auto o_lds_block              = make_tensor_view<address_space_enum::lds>(
+        //     static_cast<ODataType*>(p_smem), lds_block_desc);
+        // auto in_lds_window =
+        //     make_tile_window(o_lds_block,
+        //                      make_tuple(number<kMPerXdl>{}, number<kNPerXdl>{}),
+        //                      {number<kMPerXdl>{} * iMWarp, number<kNPerXdl>{} * iNWarp});
+        // auto out_lds_window =
+        //     make_tile_window(o_lds_block,
+        //                      make_tuple(number<kMWave * kMPerXdl>{}, number<kNWave *
+        //                      kNPerXdl>{}), {0, 0});
 
-        CWarpTensor c_warp_in_tensor;
-        static_for<0, num_access, 1>{}([&](auto iAccess) {
-            constexpr auto idx_y_start = SFC::get_index(iAccess);
+        // using SFC                    = space_filling_curve<sequence<kMPerBlock, kNPerBlock>,
+        //                                 sequence<0, 1>,
+        //                                 sequence<kMPerXdl * kMWave, kNPerXdl * kNWave>>;
+        // constexpr index_t num_access = SFC::get_num_of_access();
 
-            constexpr auto mIter = number<idx_y_start.at(number<0>{}) / (kMPerXdl * kMWave)>{};
-            constexpr auto nIter = number<idx_y_start.at(number<1>{}) / (kNPerXdl * kNWave)>{};
+        // using TileEncodingPattern =
+        //     TileDistributionEncodingPattern2D<kBlockSize,
+        //                                       kMPerIteration,
+        //                                       kNPerIteration,
+        //                                       GetVectorSizeC(),
+        //                                       tile_distribution_pattern::thread_raked>;
+        // constexpr auto dram_tile_distribution =
+        // TileEncodingPattern::Make2DStaticTileDistribution();
 
-            c_warp_in_tensor.get_thread_buffer() = o_acc_tile.get_y_sliced_thread_data(
-                merge_sequences(sequence<mIter, nIter>{}, c_warp_y_index_zeros),
-                merge_sequences(sequence<1, 1>{}, c_warp_y_lengths));
+        // constexpr auto c_warp_y_lengths =
+        //     to_sequence(CWarpDstr{}.get_ys_to_d_descriptor().get_lengths());
+        // constexpr auto c_warp_y_index_zeros = uniform_sequence_gen_t<CWarpDstr::NDimY, 0>{};
 
-            const auto c_warp_in_tensor_casted = cast_tile<ODataType>(c_warp_in_tensor);
+        // CWarpTensor c_warp_in_tensor;
+        // static_for<0, num_access, 1>{}([&](auto iAccess) {
+        //     constexpr auto idx_y_start = SFC::get_index(iAccess);
 
-            block_sync_lds();
-            store_tile(in_lds_window, c_warp_in_tensor_casted);
-            block_sync_lds();
+        //     constexpr auto mIter = number<idx_y_start.at(number<0>{}) / (kMPerXdl * kMWave)>{};
+        //     constexpr auto nIter = number<idx_y_start.at(number<1>{}) / (kNPerXdl * kNWave)>{};
 
-            const auto c_out_tensor =
-                load_tile(make_tile_window(out_lds_window, dram_tile_distribution));
+        //     c_warp_in_tensor.get_thread_buffer() = o_acc_tile.get_y_sliced_thread_data(
+        //         merge_sequences(sequence<mIter, nIter>{}, c_warp_y_index_zeros),
+        //         merge_sequences(sequence<1, 1>{}, c_warp_y_lengths));
 
-            if constexpr(MemoryOperation == memory_operation_enum::set)
-            {
-                store_tile(out_dram_window, c_out_tensor);
-            }
-            else
-            {
-                update_tile(out_dram_window, c_out_tensor);
-            }
-            if constexpr(iAccess != num_access - 1)
-            {
-                constexpr auto step = SFC::get_forward_step(iAccess);
-                move_tile_window(out_dram_window, {step.at(number<0>{}), step.at(number<1>{})});
-            }
-        });
+        //     const auto c_warp_in_tensor_casted = cast_tile<ODataType>(c_warp_in_tensor);
+
+        //     block_sync_lds();
+        //     store_tile(in_lds_window, c_warp_in_tensor_casted);
+        //     block_sync_lds();
+
+        //     const auto c_out_tensor =
+        //         load_tile(make_tile_window(out_lds_window, dram_tile_distribution));
+
+        //     if constexpr(MemoryOperation == memory_operation_enum::set)
+        //     {
+        //         store_tile(out_dram_window, c_out_tensor);
+        //     }
+        //     else
+        //     {
+        //         update_tile(out_dram_window, c_out_tensor);
+        //     }
+        //     if constexpr(iAccess != num_access - 1)
+        //     {
+        //         constexpr auto step = SFC::get_forward_step(iAccess);
+        //         move_tile_window(out_dram_window, {step.at(number<0>{}), step.at(number<1>{})});
+        //     }
+        // });
     }
 };
 } // namespace ck_tile


### PR DESCRIPTION
## Proposed changes

add CShuffleM/NXdlPerWavePerShuffle's support in cshuffle_epilogue, which can improve performance when GEMM K's dimension is small, and will not drop performance when K's dimension becomes larger

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

