### PR TITLE
[CK_TILE] fMHA batch_prefill block index & logits soft-capping optimizations

### DIFF
--- a/include/ck_tile/ops/fmha/block/variants.hpp
+++ b/include/ck_tile/ops/fmha/block/variants.hpp
@@ -15,14 +15,18 @@
 #define CK_TILE_ATTENTION_LOGITS_SOFT_CAP_DEFAULT CK_TILE_ATTENTION_LOGITS_SOFT_CAP_TANH
 #endif
 
+#ifndef CK_TILE_ATTENTION_USE_SOFTSIGN_ASM
+#define CK_TILE_ATTENTION_USE_SOFTSIGN_ASM 0
+#endif
+
 namespace ck_tile {
 namespace internal {
 __device__ inline float
 exp2_soft_sign_impl(float softmax_scale, float logits, float logits_soft_cap_rcp)
 {
-#if 0
-    return softmax_scale * logits * rcp<float>(1.f + abs(logits * logits_soft_cap_rcp));
-#else
+#if(defined(__gfx90a__) || defined(__gfx94__)) &&                                               \
+    (CK_TILE_ATTENTION_LOGITS_SOFT_CAP_DEFAULT == CK_TILE_ATTENTION_LOGITS_SOFT_CAP_SOFTSIGN && \
+     CK_TILE_ATTENTION_USE_SOFTSIGN_ASM)
     /// NOTICE: Make sure softmax_scale is stored in SGPR
     float result, numerator, denominator;
     asm volatile(
@@ -36,6 +40,8 @@ exp2_soft_sign_impl(float softmax_scale, float logits, float logits_soft_cap_rcp
           [logits] "v"(logits),
           [logits_soft_cap_rcp] "v"(logits_soft_cap_rcp));
     return result;
+#else
+    return softmax_scale * logits * rcp<float>(1.f + abs(logits * logits_soft_cap_rcp));
 #endif
 }
 } // namespace internal

--- a/include/ck_tile/ops/fmha/block/variants.hpp
+++ b/include/ck_tile/ops/fmha/block/variants.hpp
@@ -16,6 +16,29 @@
 #endif
 
 namespace ck_tile {
+namespace internal {
+__device__ inline float
+exp2_soft_sign_impl(float softmax_scale, float logits, float logits_soft_cap_rcp)
+{
+#if 0
+    return softmax_scale * logits * rcp<float>(1.f + abs(logits * logits_soft_cap_rcp));
+#else
+    /// NOTICE: Make sure softmax_scale is stored in SGPR
+    float result, numerator, denominator;
+    asm volatile(
+        "v_mul_f32_e32 %[denominator], %[logits], %[logits_soft_cap_rcp]\n"
+        "v_add_f32_e64 %[denominator], |%[denominator]|, 1.0\n"
+        "v_rcp_f32_e32 %[denominator], %[denominator]\n"
+        "v_mul_f32_e32 %[numerator], %[softmax_scale], %[logits]\n"
+        "v_mul_f32_e32 %[result], %[numerator], %[denominator]"
+        : [numerator] "=&v"(numerator), [denominator] "=&v"(denominator), [result] "=v"(result)
+        : [softmax_scale] "s"(softmax_scale),
+          [logits] "v"(logits),
+          [logits_soft_cap_rcp] "v"(logits_soft_cap_rcp));
+    return result;
+#endif
+}
+} // namespace internal
 
 template <typename ImplMask>
 struct StandardAttentionParams
@@ -169,8 +192,8 @@ struct LogitsSoftCap
             return params.logits_soft_cap *
                    tanh_fast<float>(type_convert<float>(logits) * params.logits_soft_cap_rcp);
 #elif CK_TILE_ATTENTION_LOGITS_SOFT_CAP_DEFAULT == CK_TILE_ATTENTION_LOGITS_SOFT_CAP_SOFTSIGN
-            return params.sm_scale * type_convert<float>(logits) *
-                   rcp<float>(1.f + abs(type_convert<float>(logits) * params.logits_soft_cap_rcp));
+            return internal::exp2_soft_sign_impl(
+                params.sm_scale, type_convert<float>(logits), params.logits_soft_cap_rcp);
 #endif
         }
         else
@@ -239,9 +262,8 @@ struct ComposedAttention
                 return params.logits_soft_cap *
                        tanh_fast<float>(type_convert<float>(logits) * params.logits_soft_cap_rcp);
 #elif CK_TILE_ATTENTION_LOGITS_SOFT_CAP_DEFAULT == CK_TILE_ATTENTION_LOGITS_SOFT_CAP_SOFTSIGN
-                return params.sm_scale * type_convert<float>(logits) *
-                       rcp<float>(1.f +
-                                  abs(type_convert<float>(logits) * params.logits_soft_cap_rcp));
+                return internal::exp2_soft_sign_impl(
+                    params.sm_scale, type_convert<float>(logits), params.logits_soft_cap_rcp);
 #endif
             }
             else

--- a/include/ck_tile/ops/fmha/kernel/fmha_batch_prefill_kernel.hpp
+++ b/include/ck_tile/ops/fmha/kernel/fmha_batch_prefill_kernel.hpp
@@ -651,8 +651,8 @@ struct FmhaBatchPrefillWithPagedKVCacheKernel
             };
 
             const auto [i_tile_m, i_tile_n] = f(i_block, num_tile_n1);
-
-            return ck_tile::make_tuple(i_tile_m, i_tile_n, i_nhead, i_batch);
+            // assume that num_tile_n1 is always 1
+            return ck_tile::make_tuple(gridDim.z - 1 - i_tile_m, i_tile_n, i_nhead, i_batch);
         }
         else
         {

--- a/include/ck_tile/ops/fmha/kernel/fmha_batch_prefill_kernel.hpp
+++ b/include/ck_tile/ops/fmha/kernel/fmha_batch_prefill_kernel.hpp
@@ -651,8 +651,15 @@ struct FmhaBatchPrefillWithPagedKVCacheKernel
             };
 
             const auto [i_tile_m, i_tile_n] = f(i_block, num_tile_n1);
-            // assume that num_tile_n1 is always 1
-            return ck_tile::make_tuple(gridDim.z - 1 - i_tile_m, i_tile_n, i_nhead, i_batch);
+            if constexpr(kHasMask)
+            {
+                // assume that num_tile_n1 is always 1
+                return ck_tile::make_tuple(gridDim.z - 1 - i_tile_m, i_tile_n, i_nhead, i_batch);
+            }
+            else
+            {
+                return ck_tile::make_tuple(i_tile_m, i_tile_n, i_nhead, i_batch);
+            }
         }
         else
         {
@@ -672,7 +679,15 @@ struct FmhaBatchPrefillWithPagedKVCacheKernel
 
             const auto [i_tile_m, i_tile_n] = f(i_block, num_tile_n1);
 
-            return ck_tile::make_tuple(i_tile_m, i_tile_n, i_nhead, i_batch);
+            if constexpr(kHasMask)
+            {
+                // assume that num_tile_n1 is always 1
+                return ck_tile::make_tuple(gridDim.x - 1 - i_tile_m, i_tile_n, i_nhead, i_batch);
+            }
+            else
+            {
+                return ck_tile::make_tuple(i_tile_m, i_tile_n, i_nhead, i_batch);
+            }
         }
     }
 

--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_batch_prefill_pipeline_qr_ks_vs_async.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_batch_prefill_pipeline_qr_ks_vs_async.hpp
@@ -6,8 +6,9 @@
 #include "ck_tile/core.hpp"
 #include "ck_tile/ops/common/tensor_layout.hpp"
 #include "ck_tile/ops/fmha/block/block_attention_bias_enum.hpp"
-#include "ck_tile/ops/fmha/pipeline/block_fmha_batch_prefill_pipeline_qr_ks_vs_async_default_policy.hpp"
 #include "ck_tile/ops/fmha/block/block_dropout.hpp"
+#include "ck_tile/ops/fmha/block/variants.hpp"
+#include "ck_tile/ops/fmha/pipeline/block_fmha_batch_prefill_pipeline_qr_ks_vs_async_default_policy.hpp"
 #include "ck_tile/ops/reduce/block/block_reduce.hpp"
 
 namespace ck_tile {
@@ -497,10 +498,16 @@ struct BlockFmhaBatchPrefillPipelineQRKSVSAsync
                     }
 #else
                     static_for<0, s_acc.thread_buf_.size(), 1>{}([&](auto idx) {
+#if(defined(__gfx90a__) || defined(__gfx94__)) &&                                               \
+    (CK_TILE_ATTENTION_LOGITS_SOFT_CAP_DEFAULT == CK_TILE_ATTENTION_LOGITS_SOFT_CAP_SOFTSIGN && \
+     CK_TILE_ATTENTION_USE_SOFTSIGN_ASM)
+                        // Avoid data hazard if v_mfma is followed by inline asm consumer
+                        // instructions. In this case, compiler won't add s_nop for us
                         if constexpr((idx + 1) == s_acc.thread_buf_.size() / 2)
                         {
                             __builtin_amdgcn_sched_barrier(0);
                         }
+#endif
                         apply_logits_transform(s_acc.thread_buf_[idx]);
                     });
 #endif

--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_batch_prefill_pipeline_qr_ks_vs_async.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_batch_prefill_pipeline_qr_ks_vs_async.hpp
@@ -496,10 +496,13 @@ struct BlockFmhaBatchPrefillPipelineQRKSVSAsync
                         apply_logits_transform(s_acc.thread_buf_[i]);
                     }
 #else
-                    for(index_t i = 0; i < s_acc.thread_buf_.size(); ++i)
-                    {
-                        apply_logits_transform(s_acc.thread_buf_[i]);
-                    }
+                    static_for<0, s_acc.thread_buf_.size(), 1>{}([&](auto idx) {
+                        if constexpr((idx + 1) == s_acc.thread_buf_.size() / 2)
+                        {
+                            __builtin_amdgcn_sched_barrier(0);
+                        }
+                        apply_logits_transform(s_acc.thread_buf_[idx]);
+                    });
 #endif
                 }
                 else

--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_batch_prefill_pipeline_qr_ks_vs_async.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_batch_prefill_pipeline_qr_ks_vs_async.hpp
@@ -497,19 +497,20 @@ struct BlockFmhaBatchPrefillPipelineQRKSVSAsync
                         apply_logits_transform(s_acc.thread_buf_[i]);
                     }
 #else
-                    static_for<0, s_acc.thread_buf_.size(), 1>{}([&](auto idx) {
+                    for(index_t i = 0; i < s_acc.thread_buf_.size(); ++i)
+                    {
 #if(defined(__gfx90a__) || defined(__gfx94__)) &&                                               \
     (CK_TILE_ATTENTION_LOGITS_SOFT_CAP_DEFAULT == CK_TILE_ATTENTION_LOGITS_SOFT_CAP_SOFTSIGN && \
      CK_TILE_ATTENTION_USE_SOFTSIGN_ASM)
                         // Avoid data hazard if v_mfma is followed by inline asm consumer
                         // instructions. In this case, compiler won't add s_nop for us
-                        if constexpr((idx + 1) == s_acc.thread_buf_.size() / 2)
+                        if(i == s_acc.thread_buf_.size() / 2)
                         {
                             __builtin_amdgcn_sched_barrier(0);
                         }
 #endif
-                        apply_logits_transform(s_acc.thread_buf_[idx]);
-                    });
+                        apply_logits_transform(s_acc.thread_buf_[i]);
+                    }
 #endif
                 }
                 else


### PR DESCRIPTION
## Proposed changes

- Reverse block dispatching to speed up masking case execution
- Write soft-sign in inline asm to avoid `v_pk_mul` instructions which cannot co-exec with `v_mfma`

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

