### PR TITLE
[CMake] Disable newly added compiler warning -Wnrvo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,9 @@ add_compile_options(-Wno-pass-failed)
 add_compile_options(-Wno-switch-default)
 add_compile_options(-Wno-unique-object-duplication)
 
+# Recent change in compiler makes this warning ON by default, which led to compile errors.
+add_compile_options(-Wno-nrvo)
+
 if(NOT DISABLE_DL_KERNELS)
     add_definitions(-DDL_KERNELS)
     set(DL_KERNELS "ON")


### PR DESCRIPTION
## Proposed changes

Recently (last Friday) a new warning was added to Clang to warn when no copy-elision on return happens. The warning currently prevents our CK build. This disables the warning to unblock our nightly builds.

I am not a CMake expert or knowledgeable of the CK CMake setup, so please point me in the right direction for this change.
Thank you.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

I don't think any of the boxes apply.

## Discussion

While this is not a complex change in itself, it may spark discussion.
I have tested locally with two compiler builds (today and from end of April) to validate that both can build CK.
