### PR TITLE
    improvements to timing and profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ add_compile_options(-Wno-unique-object-duplication)
 
 # Recent change in compiler makes this warning ON by default, which led to compile errors.
 add_compile_options(-Wno-nrvo)
+add_compile_options(-gline-tables-only)
 
 if(NOT DISABLE_DL_KERNELS)
     add_definitions(-DDL_KERNELS)

--- a/include/ck/host_utility/flush_cache.hpp
+++ b/include/ck/host_utility/flush_cache.hpp
@@ -4,8 +4,9 @@
 #pragma once
 
 #include <hip/hip_runtime.h>
-#include <set>
+#include <hip/hip_ext.h>
 #include <vector>
+#include <cassert>
 
 #include "ck/ck.hpp"
 #include "ck/utility/env.hpp"
@@ -223,6 +224,7 @@ inline void flush_icache()
     hip_check_error(hipGetLastError());
 }
 // if TimePrePress == false, return time does not include preprocess's time
+// XXX This is not used?
 template <bool TimePreprocess,
           typename GemmArgs,
           typename... Args,
@@ -238,13 +240,13 @@ float launch_and_time_kernel_with_preprocess(const StreamConfig& stream_config,
                                              Args... args)
 {
 #if CK_TIME_KERNEL
-#define MEDIAN 0
     if(stream_config.time_kernel_)
     {
         if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
         {
-            printf("%s: grid_dim {%u, %u, %u}, block_dim {%u, %u, %u} \n",
+            printf("%s: kernel %p, grid_dim {%u, %u, %u}, block_dim {%u, %u, %u} \n",
                    __func__,
+                   reinterpret_cast<void*>(kernel),
                    grid_dim.x,
                    grid_dim.y,
                    grid_dim.z,
@@ -254,109 +256,99 @@ float launch_and_time_kernel_with_preprocess(const StreamConfig& stream_config,
 
             printf("Warm up %d times\n", stream_config.cold_niters_);
         }
-        // warm up
-        for(int i = 0; i < stream_config.cold_niters_; ++i)
+        if(!ck::EnvIsEnabled(CK_ENV(CK_NEWTIMING)))
         {
-            kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(gemm_args, args...);
-            hip_check_error(hipGetLastError());
+            // old algorithm: warm up then time nrepeat iterations and take the mean
+            // warm up
+            for(int i = 0; i < stream_config.cold_niters_; ++i)
+            {
+                kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(gemm_args,
+                                                                                    args...);
+                hip_check_error(hipGetLastError());
+            }
         }
 
         const int nrepeat = stream_config.nrepeat_;
-        if(nrepeat == 0)
-        {
-            return 0.0;
-        }
+        assert(nrepeat > 0);
+
         if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
         {
             printf("Start running %d times...\n", nrepeat);
         }
 
-#if MEDIAN
-        std::set<float> times;
-#else
-        float total_time = 0;
-#endif
         hipEvent_t start, stop;
 
         hip_check_error(hipEventCreate(&start));
         hip_check_error(hipEventCreate(&stop));
 
         hip_check_error(hipDeviceSynchronize());
-        hip_check_error(hipEventRecord(start, stream_config.stream_id_));
-
-        for(int i = 0; i < nrepeat; ++i)
+        if(!ck::EnvIsEnabled(CK_ENV(CK_NEWTIMING)))
         {
-            if constexpr(!TimePreprocess)
+            // Time the entire loop
+            hip_check_error(hipEventRecord(start, stream_config.stream_id_));
+            for(int i = 0; i < nrepeat; ++i)
             {
                 preprocess();
+
+                kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(gemm_args,
+                                                                                    args...);
+                hip_check_error(hipGetLastError());
             }
+            hip_check_error(hipEventRecord(stop, stream_config.stream_id_));
+            hip_check_error(hipEventSynchronize(stop));
 
-            // hipEvent_t start, stop;
+            float total_time = 0;
+            hip_check_error(hipEventElapsedTime(&total_time, start, stop));
 
-            // hip_check_error(hipEventCreate(&start));
-            // hip_check_error(hipEventCreate(&stop));
-
-            // hip_check_error(hipDeviceSynchronize());
-            // hip_check_error(hipEventRecord(start, stream_config.stream_id_));
-            // calculate preprocess time
-            if constexpr(TimePreprocess)
-            {
-                preprocess();
-            }
-            // run real kernel
-            kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(gemm_args, args...);
+            // return total_time / nrepeat adjusted by supposed cost of icache clear
+            hipDeviceProp_t deviceProps;
+            hip_check_error(hipGetDeviceProperties(&deviceProps, 0));
+            // This seems pretty random
+            float preprocess_offset = deviceProps.multiProcessorCount == 80 ? 0.005 : 0.01;
+            return (total_time - preprocess_offset * nrepeat) / nrepeat;
+        }
+        // New algorithm: adaptive, no warmup, return minimum
+        // Need to print all the values for stats.
+        constexpr float maxtime = 10;   // ms
+        constexpr int minrep = 3;
+        std::vector<float> times;
+        float total_time = 0;
+        hip_check_error(hipDeviceSynchronize());
+        for (int i = 0; i < nrepeat; ++i)
+        {
+            hipExtLaunchKernelGGL(kernel,
+                                  grid_dim,
+                                  block_dim,
+                                  lds_byte,
+                                  stream_config.stream_id_,
+                                  start,
+                                  stop,
+                                  0,
+                                  gemm_args,
+                                  args...);
             hip_check_error(hipGetLastError());
-            // end real kernel
+            hip_check_error(hipEventSynchronize(stop));
 
-            //             hip_check_error(hipEventRecord(stop, stream_config.stream_id_));
-            //             hip_check_error(hipEventSynchronize(stop));
-            //             float cur_time = 0;
-            //             hip_check_error(hipEventElapsedTime(&cur_time, start, stop));
-            // #if MEDIAN
-            //             times.insert(cur_time);
-            // #else
-            //             total_time += cur_time;
-            // #endif
-
-            if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
-            {
-                // std::cout << "i: " << i << " cur_time: " << cur_time << std::endl;
-
-                printf("gemm_args.p_a_grid: %p, gemm_args.p_b_grid:%p\n",
-                       static_cast<const void*>(gemm_args.p_a_grid),
-                       static_cast<const void*>(gemm_args.p_b_grid));
-            }
+            float cur_time = 0;
+            hip_check_error(hipEventElapsedTime(&cur_time, start, stop));
+            times.push_back(cur_time);
+            total_time += cur_time;
+            if(total_time >= maxtime && i + 1 >= minrep)
+                break;
         }
-        hip_check_error(hipEventRecord(stop, stream_config.stream_id_));
-        hip_check_error(hipEventSynchronize(stop));
-        float cur_time = 0;
-        hip_check_error(hipEventElapsedTime(&cur_time, start, stop));
-#if MEDIAN
-        times.insert(cur_time);
-#else
-        total_time += cur_time;
-#endif
-
-#if MEDIAN
-        auto mid = times.begin();
-        std::advance(mid, (nrepeat - 1) / 2);
-        if(nrepeat % 2 == 1)
-        {
-            return *mid;
-        }
-        else
-        {
-            auto mid_next = mid;
-            std::advance(mid_next, 1);
-            return (*mid + *mid_next) / 2;
-        }
-#else
-        // return total_time / nrepeat;
-        hipDeviceProp_t deviceProps;
-        hip_check_error(hipGetDeviceProperties(&deviceProps, 0));
-        float preprocess_offset = deviceProps.multiProcessorCount == 80 ? 0.005 : 0.01;
-        return (total_time - preprocess_offset * nrepeat) / nrepeat;
-#endif
+        printf("%s: kernel %p, grid_dim {%u, %u, %u}, block_dim {%u, %u, %u}, ",
+               __func__,
+               reinterpret_cast<void *>(kernel),
+               grid_dim.x,
+               grid_dim.y,
+               grid_dim.z,
+               block_dim.x,
+               block_dim.y,
+               block_dim.z);
+        printf("times {");
+        for (float t: times) printf(" %.7f", t);
+        printf("}\n");
+        return total_time / times.size(); //*std::min_element(times.begin(), times.end());
     }
     else
     {

--- a/include/ck/host_utility/kernel_launch.hpp
+++ b/include/ck/host_utility/kernel_launch.hpp
@@ -4,11 +4,17 @@
 #pragma once
 #ifndef __HIPCC_RTC__
 #include <hip/hip_runtime.h>
+#include <hip/hip_ext.h>
+
+#include <vector>
+#include <cassert>
 
 #include "ck/ck.hpp"
 #include "ck/utility/env.hpp"
 #include "ck/stream_config.hpp"
 #include "ck/host_utility/hip_check_error.hpp"
+
+#include "hip_fix_ext.h"
 
 template <typename... Args, typename F>
 float launch_and_time_kernel(const StreamConfig& stream_config,
@@ -23,8 +29,9 @@ float launch_and_time_kernel(const StreamConfig& stream_config,
     {
         if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
         {
-            printf("%s: grid_dim {%u, %u, %u}, block_dim {%u, %u, %u} \n",
+            printf("%s: kernel %p, grid_dim {%u, %u, %u}, block_dim {%u, %u, %u} \n",
                    __func__,
+                   reinterpret_cast<void*>(kernel),
                    grid_dim.x,
                    grid_dim.y,
                    grid_dim.z,
@@ -34,43 +41,96 @@ float launch_and_time_kernel(const StreamConfig& stream_config,
 
             printf("Warm up %d times\n", stream_config.cold_niters_);
         }
-        // warm up
-        for(int i = 0; i < stream_config.cold_niters_; ++i)
+        if(!ck::EnvIsEnabled(CK_ENV(CK_NEWTIMING)))
         {
-            kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(args...);
-            hip_check_error(hipGetLastError());
+            // old algorithm: warm up then time nrepeat iterations and take the mean
+            // warm up
+            for(int i = 0; i < stream_config.cold_niters_; ++i)
+            {
+                kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(args...);
+                hip_check_error(hipGetLastError());
+            }
         }
 
         const int nrepeat = stream_config.nrepeat_;
+        assert(nrepeat > 0);
+
         if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
         {
             printf("Start running %d times...\n", nrepeat);
         }
+
         hipEvent_t start, stop;
 
         hip_check_error(hipEventCreate(&start));
         hip_check_error(hipEventCreate(&stop));
 
         hip_check_error(hipDeviceSynchronize());
-        hip_check_error(hipEventRecord(start, stream_config.stream_id_));
-
-        for(int i = 0; i < nrepeat; ++i)
+        if(!ck::EnvIsEnabled(CK_ENV(CK_NEWTIMING)))
         {
-            kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(args...);
-            hip_check_error(hipGetLastError());
+            hip_check_error(hipEventRecord(start, stream_config.stream_id_));
+
+            for(int i = 0; i < nrepeat; ++i)
+            {
+                kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(args...);
+                hip_check_error(hipGetLastError());
+            }
+
+            hip_check_error(hipEventRecord(stop, stream_config.stream_id_));
+            hip_check_error(hipEventSynchronize(stop));
+
+            float total_time = 0;
+
+            hip_check_error(hipEventElapsedTime(&total_time, start, stop));
+
+            hip_check_error(hipEventDestroy(start));
+            hip_check_error(hipEventDestroy(stop));
+
+            return total_time / nrepeat;
         }
-
-        hip_check_error(hipEventRecord(stop, stream_config.stream_id_));
-        hip_check_error(hipEventSynchronize(stop));
-
+        // New algorithm: adaptive, no warmup, return minimum
+        // Need to print all the values for stats.
+        constexpr float maxtime = 10;   // ms
+        constexpr int minrep = 2;
+        std::vector<float> times;
         float total_time = 0;
+        hip_check_error(hipDeviceSynchronize());
+        for (int i = 0; i < nrepeat; ++i)
+        {
+            myhipExtLaunchKernelGGL(kernel,
+                                    grid_dim,
+                                    block_dim,
+                                    lds_byte,
+                                    stream_config.stream_id_,
+                                    start,
+                                    stop,
+                                    0,
+                                    args...);
 
-        hip_check_error(hipEventElapsedTime(&total_time, start, stop));
+            hip_check_error(hipGetLastError());
+            hip_check_error(hipEventSynchronize(stop));
 
-        hip_check_error(hipEventDestroy(start));
-        hip_check_error(hipEventDestroy(stop));
+            float cur_time = 0;
+            hip_check_error(hipEventElapsedTime(&cur_time, start, stop));
+            times.push_back(cur_time);
+            total_time += cur_time;
+            if(total_time >= maxtime && i + 1 >= minrep)
+                break;
+        }
+        printf("%s: kernel %p, grid_dim {%u, %u, %u}, block_dim {%u, %u, %u}, ",
+               __func__,
+               reinterpret_cast<void *>(kernel),
+               grid_dim.x,
+               grid_dim.y,
+               grid_dim.z,
+               block_dim.x,
+               block_dim.y,
+               block_dim.z);
+        printf("times {");
+        for (float t: times) printf(" %.7f", t);
+        printf("}\n");
 
-        return total_time / nrepeat;
+        return total_time / times.size();
     }
     else
     {
@@ -101,8 +161,9 @@ float launch_and_time_kernel_with_preprocess(const StreamConfig& stream_config,
     {
         if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
         {
-            printf("%s: grid_dim {%u, %u, %u}, block_dim {%u, %u, %u} \n",
+            printf("%s: kernel %p, grid_dim {%u, %u, %u}, block_dim {%u, %u, %u} \n",
                    __func__,
+                   reinterpret_cast<void*>(kernel),
                    grid_dim.x,
                    grid_dim.y,
                    grid_dim.z,
@@ -112,12 +173,16 @@ float launch_and_time_kernel_with_preprocess(const StreamConfig& stream_config,
 
             printf("Warm up %d times\n", stream_config.cold_niters_);
         }
-        // warm up
-        preprocess();
-        for(int i = 0; i < stream_config.cold_niters_; ++i)
+        if(!ck::EnvIsEnabled(CK_ENV(CK_NEWTIMING)))
         {
-            kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(args...);
-            hip_check_error(hipGetLastError());
+            // old algorithm: warm up then time nrepeat iterations and take the mean
+            // warm up
+            preprocess();
+            for(int i = 0; i < stream_config.cold_niters_; ++i)
+            {
+                kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(args...);
+                hip_check_error(hipGetLastError());
+            }
         }
 
         const int nrepeat = stream_config.nrepeat_;
@@ -131,26 +196,74 @@ float launch_and_time_kernel_with_preprocess(const StreamConfig& stream_config,
         hip_check_error(hipEventCreate(&stop));
 
         hip_check_error(hipDeviceSynchronize());
-        hip_check_error(hipEventRecord(start, stream_config.stream_id_));
 
-        for(int i = 0; i < nrepeat; ++i)
+        if(!ck::EnvIsEnabled(CK_ENV(CK_NEWTIMING)))
+        {
+            hip_check_error(hipEventRecord(start, stream_config.stream_id_));
+
+            for(int i = 0; i < nrepeat; ++i)
+            {
+                preprocess();
+                kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(args...);
+                hip_check_error(hipGetLastError());
+            }
+
+            hip_check_error(hipEventRecord(stop, stream_config.stream_id_));
+            hip_check_error(hipEventSynchronize(stop));
+
+            float total_time = 0;
+
+            hip_check_error(hipEventElapsedTime(&total_time, start, stop));
+
+            hip_check_error(hipEventDestroy(start));
+            hip_check_error(hipEventDestroy(stop));
+
+            return total_time / nrepeat;
+        }
+        // New algorithm: adaptive, no warmup, return minimum
+        // Need to print all the values for stats.
+        constexpr float maxtime = 10;   // ms
+        constexpr int minrep = 2;
+        std::vector<float> times;
+        float total_time = 0;
+        hip_check_error(hipDeviceSynchronize());
+        for (int i = 0; i < nrepeat; ++i)
         {
             preprocess();
-            kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(args...);
+
+            hipExtLaunchKernelGGL(kernel,
+                                  grid_dim,
+                                  block_dim,
+                                  lds_byte,
+                                  stream_config.stream_id_,
+                                  start,
+                                  stop,
+                                  0,
+                                  args...);
             hip_check_error(hipGetLastError());
+            hip_check_error(hipEventSynchronize(stop));
+
+            float cur_time = 0;
+            hip_check_error(hipEventElapsedTime(&cur_time, start, stop));
+            times.push_back(cur_time);
+            total_time += cur_time;
+            if(total_time >= maxtime && i + 1 >= minrep)
+                break;
         }
+        printf("%s: kernel %p, grid_dim {%u, %u, %u}, block_dim {%u, %u, %u}, ",
+               __func__,
+               reinterpret_cast<void *>(kernel),
+               grid_dim.x,
+               grid_dim.y,
+               grid_dim.z,
+               block_dim.x,
+               block_dim.y,
+               block_dim.z);
+        printf("times {");
+        for (float t: times) printf(" %.7f", t);
+        printf("}\n");
 
-        hip_check_error(hipEventRecord(stop, stream_config.stream_id_));
-        hip_check_error(hipEventSynchronize(stop));
-
-        float total_time = 0;
-
-        hip_check_error(hipEventElapsedTime(&total_time, start, stop));
-
-        hip_check_error(hipEventDestroy(start));
-        hip_check_error(hipEventDestroy(stop));
-
-        return total_time / nrepeat;
+        return total_time / times.size();
     }
     else
     {

--- a/include/ck/utility/env.hpp
+++ b/include/ck/utility/env.hpp
@@ -188,5 +188,9 @@ void UpdateEnvVar(EnvVar, const std::string_view& val)
 // environment variable to enable logging:
 // export CK_LOGGING=ON or CK_LOGGING=1 or CK_LOGGING=ENABLED
 CK_DECLARE_ENV_VAR_BOOL(CK_LOGGING)
+// Runs to process
+CK_DECLARE_ENV_VAR_STR(CK_RUN)
+// New timing + output from launcher
+CK_DECLARE_ENV_VAR_BOOL(CK_NEWTIMING)
 
 #endif

--- a/include/hip_fix_ext.h
+++ b/include/hip_fix_ext.h
@@ -1,0 +1,124 @@
+
+template <std::size_t n,
+          typename... Tf,
+          typename... Ta,
+          typename std::enable_if<n == sizeof...(Ta)>::type* = nullptr>
+void mypArgs(const std::tuple<Ta...>&, void*)
+{
+}
+
+template <std::size_t n,
+          typename TTf,
+          typename... Tf,
+          typename... Ta,
+          typename std::enable_if<n != sizeof...(Ta)>::type* = nullptr>
+void mypArgs(const std::tuple<Ta...>& actuals, void** _vargs)
+{
+    using TTa = typename std::tuple_element<n, std::tuple<Ta...>>::type;
+    #if 0
+    // When using the kernel<<<...>>>(args...) syntax, hipcc allows references.
+    // This assertion is obsolete.
+    static_assert(!std::is_reference<TTf>{},
+                  "A __global__ function cannot have a reference as one of its "
+                  "arguments.");
+    #endif 
+#if defined(HIP_STRICT)
+    static_assert(std::is_trivially_copyable<T>{},
+                  "Only TriviallyCopyable types can be arguments to a __global__ "
+                  "function");
+#endif
+    if constexpr(std::is_same<TTa, TTf>::value || std::is_convertible<TTa, TTf>::value)
+        _vargs[n] = const_cast<void*>(reinterpret_cast<const void*>(&std::get<n>(actuals)));
+    else
+        static_assert("Incompatible types between formal and actual");
+
+    return mypArgs<n + 1, Tf...>(actuals, _vargs);
+}
+
+template <typename... Formals, typename... Actuals>
+void myvalidateArgsCountType(void (*kernel)(Formals...),
+                             std::tuple<Actuals...> actuals,
+                             void** _vars)
+{
+    (void)kernel;
+    static_assert(sizeof...(Formals) == sizeof...(Actuals), "Argument Count Mismatch");
+    mypArgs<0, Formals...>(actuals, _vars);
+}
+
+/**
+ * @brief Launches kernel from the pointer address, with arguments and shared memory on stream.
+ *
+ * @param [in] function_address pointer to the Kernel to launch.
+ * @param [in] numBlocks number of blocks.
+ * @param [in] dimBlocks dimension of a block.
+ * @param [in] args pointer to kernel arguments.
+ * @param [in] sharedMemBytes  Amount of dynamic shared memory to allocate for this kernel.
+ * HIP-Clang compiler provides support for extern shared declarations.
+ * @param [in] stream  Stream where the kernel should be dispatched.
+ * May be 0, in which case the default stream is used with associated synchronization rules.
+ * @param [in] startEvent  If non-null, specified event will be updated to track the start time of
+ * the kernel launch. The event must be created before calling this API.
+ * @param [in] stopEvent  If non-null, specified event will be updated to track the stop time of
+ * the kernel launch. The event must be created before calling this API.
+ * @param [in] flags  The value of hipExtAnyOrderLaunch, signifies if kernel can be
+ * launched in any order.
+ * @returns #hipSuccess, #hipInvalidDeviceId, #hipErrorNotInitialized, #hipErrorInvalidValue.
+ *
+ */
+extern "C" hipError_t hipExtLaunchKernel(const void* function_address,
+                                         dim3 numBlocks,
+                                         dim3 dimBlocks,
+                                         void** args,
+                                         size_t sharedMemBytes,
+                                         hipStream_t stream,
+                                         hipEvent_t startEvent,
+                                         hipEvent_t stopEvent,
+                                         int flags);
+
+/**
+ * @brief Launches kernel with dimention parameters and shared memory on stream with templated
+ * kernel and arguments.
+ *
+ * @param [in] kernel  Kernel to launch.
+ * @param [in] numBlocks  const number of blocks.
+ * @param [in] dimBlocks  const dimension of a block.
+ * @param [in] sharedMemBytes  Amount of dynamic shared memory to allocate for this kernel.
+ * HIP-Clang compiler provides support for extern shared declarations.
+ * @param [in] stream  Stream where the kernel should be dispatched.
+ * May be 0, in which case the default stream is used with associated synchronization rules.
+ * @param [in] startEvent  If non-null, specified event will be updated to track the start time of
+ * the kernel launch. The event must be created before calling this API.
+ * @param [in] stopEvent  If non-null, specified event will be updated to track the stop time of
+ * the kernel launch. The event must be created before calling this API.
+ * @param [in] flags  The value of hipExtAnyOrderLaunch, signifies if kernel can be
+ * launched in any order.
+ * @param [in] args  templated kernel arguments.
+ *
+ */
+template <typename... Args, typename F = void (*)(Args...)>
+inline void myhipExtLaunchKernelGGL(F kernel,
+                                    const dim3& numBlocks,
+                                    const dim3& dimBlocks,
+                                    std::uint32_t sharedMemBytes,
+                                    hipStream_t stream,
+                                    hipEvent_t startEvent,
+                                    hipEvent_t stopEvent,
+                                    std::uint32_t flags,
+                                    Args... args)
+{
+    constexpr size_t count = sizeof...(Args);
+    auto tup_              = std::tuple<Args...>{args...};
+    void* _Args[count];
+    myvalidateArgsCountType(kernel, tup_, _Args);
+
+    auto k = reinterpret_cast<void*>(kernel);
+    (void)hipExtLaunchKernel(k,
+                             numBlocks,
+                             dimBlocks,
+                             _Args,
+                             sharedMemBytes,
+                             stream,
+                             startEvent,
+                             stopEvent,
+                             static_cast<int>(flags));
+}

--- a/profiler/include/profiler/profile_gemm_universal_impl.hpp
+++ b/profiler/include/profiler/profile_gemm_universal_impl.hpp
@@ -21,6 +21,8 @@
 #include "ck/library/utility/literals.hpp"
 #include "ck/library/reference_tensor_operation/cpu/reference_gemm.hpp"
 
+#include "ck/utility/env.hpp"
+
 namespace ck {
 namespace profiler {
 
@@ -154,10 +156,66 @@ bool profile_gemm_universal_impl(int do_verification,
     float best_tflops     = 0;
     float best_gb_per_sec = 0;
     float best_kbatch     = 0;
+    int best_instance     = 0;
 
     // profile device GEMM instances
-    for(auto& op_ptr : op_ptrs)
+    const std::string runs = ck::EnvGetString(CK_ENV(CK_RUN));
+    auto parse_runs        = [](const std::string& runs_) -> std::vector<int> {
+        // helper functions
+        auto parse_number = [](std::stringstream& ss, int& num) -> bool {
+            if(ss.eof())
+                return false;
+            ss >> num;
+            if(ss.fail())
+                return false;
+            return true;
+        };
+        auto parse_comma = [](std::stringstream& ss, bool is_optional) -> bool {
+            if(ss.eof())
+            {
+                if(is_optional)
+                    return true;
+                return false;
+            }
+            char nextchar;
+            ss >> nextchar;
+            if(ss.fail())
+                return false;
+            if(ss.eof() && is_optional)
+                return true;
+            return nextchar == ',';
+        };
+
+        std::stringstream ss(runs_);
+        std::vector<int> result;
+        while(!ss.eof())
+        {
+            int num1;
+            if(!parse_number(ss, num1))
+                break;
+            result.push_back(num1);
+            if(!parse_comma(ss, false))
+                break;
+        }
+        return result;
+    };
+    std::vector<int> runslist = parse_runs(runs);
+
+    // if runslist.size() > 0, we want to restrict the device GEMM tests to just those
+    // values. Otherwise, we run through all of the possibilities.
+    // for now we will assume that runslist is small, so we just execute the normal
+    // loop and skip values not in the list.
+    auto include_run = [&runslist](int run_index) -> bool {
+        for(const auto& r : runslist)
+            if(r == run_index)
+                return true;
+        return runslist.size() == 0; // true if no restrictions specified
+    };
+
+    int run = 0;
+    for(size_t instance = 0; instance < op_ptrs.size(); ++instance)
     {
+        auto& op_ptr        = op_ptrs[instance];
         const int KPerBlock = op_ptr->GetKPerBlock();
 
         if(op_ptr->GetPermuteB())
@@ -246,10 +304,9 @@ bool profile_gemm_universal_impl(int do_verification,
             kbatch_list = {KBatch};
         }
 
-        for(std::size_t i = 0; i < kbatch_list.size(); i++)
+        // use the kbatch value, not its list index
+        for(auto kbatch_curr : kbatch_list)
         {
-            auto kbatch_curr = kbatch_list[i];
-
             auto argument_ptr =
                 op_ptr->MakeArgumentPointer(static_cast<ADataType*>(a_device_buf.GetDeviceBuffer()),
                                             static_cast<BDataType*>(b_device_buf.GetDeviceBuffer()),
@@ -269,6 +326,11 @@ bool profile_gemm_universal_impl(int do_verification,
 
             if(op_ptr->IsSupportedArgument(argument_ptr.get()))
             {
+                if(!include_run(run))
+                {
+                    run++;
+                    continue; // next kbatch
+                }
 
                 // re-init C to zero before profiling next kernel
                 c_device_buf.SetZero();
@@ -324,6 +386,8 @@ bool profile_gemm_universal_impl(int do_verification,
                                                                rotating_count > 1,
                                                                rotating_count});
 
+                float recip_ave_time = ave_time ? 1.0 / ave_time : 0;
+
                 std::size_t flop = std::size_t(2) * M * N * K;
 
                 static constexpr index_t BPackedSize = []() {
@@ -337,13 +401,13 @@ bool profile_gemm_universal_impl(int do_verification,
                                         sizeof(BDataType) * K * N / BPackedSize +
                                         sizeof(CDataType) * M * N;
 
-                float tflops = static_cast<float>(flop) / 1.E9 / ave_time;
+                float tflops = (static_cast<float>(flop) / 1.E9) * recip_ave_time;
 
-                float gb_per_sec = num_btype / 1.E6 / ave_time;
+                float gb_per_sec = (num_btype / 1.E6) * recip_ave_time;
 
                 std::cout << "Perf: " << std::setw(10) << ave_time << " ms, " << tflops
-                          << " TFlops, " << gb_per_sec << " GB/s, " << op_name << ", KBatch "
-                          << kbatch_curr << std::endl;
+                          << " TFlops, " << gb_per_sec << " GB/s, " << op_name
+                          << ", KBatch: " << kbatch_curr << ", Inst: " << instance << std::endl;
 
                 if(tflops > best_tflops && ave_time > 1e-10)
                 {
@@ -353,12 +417,14 @@ bool profile_gemm_universal_impl(int do_verification,
                     best_ave_time       = ave_time;
                     best_gb_per_sec     = gb_per_sec;
                     best_kbatch         = kbatch_curr;
+                    best_instance       = instance;
                 }
+                run++;
             }
             else
             {
-                std::cout << op_ptr->GetTypeString() << " does not support this problem"
-                          << std::endl;
+                std::cout << "Unsupported: " << op_ptr->GetTypeString()
+                          << ", KBatch: " << kbatch_curr << ", Inst: " << instance << std::endl;
             }
         }
     }
@@ -401,7 +467,8 @@ bool profile_gemm_universal_impl(int do_verification,
     std::cout << " M = " << M << " N = " << N << " K = " << K << " StrideA = " << StrideA
               << " StrideB = " << StrideB << " StrideC = " << StrideC << " KBatch = " << best_kbatch
               << " : " << best_ave_time << " ms, " << best_tflops << " TFlops, " << best_gb_per_sec
-              << " GB/s, " << best_op_name << std::endl;
+              << " GB/s, " << best_op_name << ", KBatch: " << best_kbatch
+              << ", Inst: " << best_instance << std::endl;
 
     if(best_op_object_name)
         std::cout << best_op_object_name.value() << std::endl;

--- a/profiler/src/profiler.cpp
+++ b/profiler/src/profiler.cpp
@@ -13,18 +13,29 @@ static void print_helper_message()
 
 int main(int argc, char* argv[])
 {
+    // This hack saves a bunch of time, but don't use it if rocprofiler is being used
+    const char *p = getenv("CK_QUICK_EXIT");
+    bool quick_exit;
+    quick_exit = p != nullptr;
+    int exit_code = 0;
     if(argc == 1)
     {
         print_helper_message();
+        quick_exit = true;
     }
     else if(const auto operation = ProfilerOperationRegistry::GetInstance().Get(argv[1]);
             operation.has_value())
     {
-        return (*operation)(argc, argv);
+        exit_code = (*operation)(argc, argv);
+        quick_exit = (exit_code != 0);
     }
     else
     {
         std::cerr << "cannot find operation: " << argv[1] << std::endl;
-        return EXIT_FAILURE;
+        exit_code = EXIT_FAILURE;
+        quick_exit = true;
     }
+    if (quick_exit)
+      std::quick_exit(exit_code);
+    return exit_code;
 }


### PR DESCRIPTION
    * Alternate timing methoed uses HIP events on kernel launch for improved accuracy. Times are saved for every launch. Alternate method is enabled with the CK_NEWTIMING environment variable.

    * Add logging for kernel launches including the kernel address and the individual launch times. Kernel address enables finding the kernel name in the symbol table and in disassembled exectables. The individual launch times allow better statistical analysis of timing variance.

    * Improved logging for gemm_universal allows more precise CI checking, analysis of the difference between instances (and batch sizes), and fine control to run only particular instances. (It would be nice to have this for all of the ckProfiler tensors and for the examples and client samples, but it would require a lot of refactoring).

    * Added -gline-tables-only to the build. This enables source line information in disassembly (and debugging) without greatly increasing object size.

## Proposed changes

Please describe the motivation behind the pull request, whether it enables a new feature or fixes a bug. If there are associated pull requests or issues, please link them to the pull request.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ x] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

