### PR TITLE
Add MIOPEN_REQ_LIBS_ONLY option for cmake to build only the libs MIOpen requires

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,6 +605,9 @@ ENDIF()
 ENDFOREACH()
 
 add_custom_target(instances DEPENDS utility;${CK_DEVICE_INSTANCES}  SOURCES ${INSTANCE_FILES})
+
+option(MIOPEN_REQ_LIBS_ONLY "Build only the MIOpen required libraries" ON)
+
 add_subdirectory(library)
 
 if(NOT GPU_ARCHS AND USER_GPU_TARGETS)
@@ -624,11 +627,13 @@ if(NOT GPU_ARCHS AND USER_GPU_TARGETS)
    endif()
 endif()
 
-rocm_package_setup_component(profiler
-    LIBRARY_NAME composablekernel
-    PACKAGE_NAME ckprofiler
-)
-add_subdirectory(profiler)
+if (NOT MIOPEN_REQ_LIBS_ONLY)
+    rocm_package_setup_component(profiler
+        LIBRARY_NAME composablekernel
+        PACKAGE_NAME ckprofiler
+    )
+    add_subdirectory(profiler)
+endif()
 
 if(CK_USE_CODEGEN AND (SUPPORTED_GPU_TARGETS MATCHES "gfx9" OR GPU_ARCHS))
   add_subdirectory(codegen)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -606,7 +606,7 @@ ENDFOREACH()
 
 add_custom_target(instances DEPENDS utility;${CK_DEVICE_INSTANCES}  SOURCES ${INSTANCE_FILES})
 
-option(MIOPEN_REQ_LIBS_ONLY "Build only the MIOpen required libraries" ON)
+option(MIOPEN_REQ_LIBS_ONLY "Build only the MIOpen required libraries" OFF)
 
 add_subdirectory(library)
 

--- a/library/src/tensor_operation_instance/gpu/CMakeLists.txt
+++ b/library/src/tensor_operation_instance/gpu/CMakeLists.txt
@@ -103,6 +103,28 @@ function(add_instance_library INSTANCE_NAME)
             list(REMOVE_ITEM ARGN "${source}")
         endif()
     endforeach()
+
+    foreach(source IN LISTS ARGN)
+        if(MIOPEN_REQ_LIBS_ONLY AND source MATCHES "_gemm_")
+            message("removing gemm instance ${source} ")
+            list(REMOVE_ITEM ARGN "${source}")
+        endif()
+
+        if(MIOPEN_REQ_LIBS_ONLY AND source MATCHES "mha")
+            message("removing mha instance ${source} ")
+            list(REMOVE_ITEM ARGN "${source}")
+        endif()
+
+        if(MIOPEN_REQ_LIBS_ONLY AND source MATCHES "contraction")
+            message("removing contraction instance ${source} ")
+            list(REMOVE_ITEM ARGN "${source}")
+        endif()
+
+        if(MIOPEN_REQ_LIBS_ONLY AND source MATCHES "reduce")
+            message("removing reduce instance ${source} ")
+            list(REMOVE_ITEM ARGN "${source}")
+        endif()
+    endforeach()
     #message("remaining instances: ${ARGN}")
     #only continue if there are some source files left on the list
     if(ARGN)
@@ -343,7 +365,7 @@ if(CK_DEVICE_OTHER_INSTANCES)
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/composable_kernel
         )
 endif()
-if(CK_DEVICE_GEMM_INSTANCES)
+if(CK_DEVICE_GEMM_INSTANCES AND NOT MIOPEN_REQ_LIBS_ONLY)
         add_library(device_gemm_operations ${CK_DEVICE_GEMM_INSTANCES})
         add_library(composablekernels::device_gemm_operations ALIAS device_gemm_operations)
         target_compile_features(device_gemm_operations PUBLIC)
@@ -389,7 +411,7 @@ if(CK_DEVICE_CONV_INSTANCES)
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/composable_kernel
         )
 endif()
-if(CK_DEVICE_MHA_INSTANCES)
+if(CK_DEVICE_MHA_INSTANCES AND NOT MIOPEN_REQ_LIBS_ONLY)
         set(gpu_list ${INST_TARGETS})
         if(gpu_list MATCHES "gfx94" OR gpu_list MATCHES "gfx90a" OR gpu_list MATCHES "gfx95")
             add_library(device_mha_operations ${CK_DEVICE_MHA_INSTANCES})
@@ -411,7 +433,7 @@ if(CK_DEVICE_MHA_INSTANCES)
             )
         endif()
 endif()
-if(CK_DEVICE_CONTRACTION_INSTANCES)
+if(CK_DEVICE_CONTRACTION_INSTANCES AND NOT MIOPEN_REQ_LIBS_ONLY)
         add_library(device_contraction_operations ${CK_DEVICE_CONTRACTION_INSTANCES})
         add_library(composablekernels::device_contraction_operations ALIAS device_contraction_operations)
         target_compile_features(device_contraction_operations PUBLIC)
@@ -433,7 +455,7 @@ if(CK_DEVICE_CONTRACTION_INSTANCES)
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/composable_kernel
         )
 endif()
-if(CK_DEVICE_REDUCTION_INSTANCES)
+if(CK_DEVICE_REDUCTION_INSTANCES AND NOT MIOPEN_REQ_LIBS_ONLY)
         add_library(device_reduction_operations ${CK_DEVICE_REDUCTION_INSTANCES})
         add_library(composablekernels::device_reduction_operations ALIAS device_reduction_operations)
         target_compile_features(device_reduction_operations PUBLIC)
@@ -455,14 +477,16 @@ if(CK_DEVICE_REDUCTION_INSTANCES)
         )
 endif()
 
-add_library(device_operations INTERFACE)
-target_link_libraries(device_operations INTERFACE
-    device_contraction_operations
-    device_conv_operations
-    device_gemm_operations
-    device_other_operations
-    device_reduction_operations
-    utility)
+if(NOT MIOPEN_REQ_LIBS_ONLY)
+    add_library(device_operations INTERFACE)
+    target_link_libraries(device_operations INTERFACE
+        device_contraction_operations
+        device_conv_operations
+        device_gemm_operations
+        device_other_operations
+        device_reduction_operations
+        utility)
+endif()
 
 set(DEV_OPS_INC_DIRS
     ${PROJECT_SOURCE_DIR}/include/ck/

--- a/library/src/tensor_operation_instance/gpu/CMakeLists.txt
+++ b/library/src/tensor_operation_instance/gpu/CMakeLists.txt
@@ -104,27 +104,17 @@ function(add_instance_library INSTANCE_NAME)
         endif()
     endforeach()
 
-    foreach(source IN LISTS ARGN)
-        if(MIOPEN_REQ_LIBS_ONLY AND source MATCHES "_gemm_")
-            message("removing gemm instance ${source} ")
-            list(REMOVE_ITEM ARGN "${source}")
-        endif()
-
-        if(MIOPEN_REQ_LIBS_ONLY AND source MATCHES "mha")
-            message("removing mha instance ${source} ")
-            list(REMOVE_ITEM ARGN "${source}")
-        endif()
-
-        if(MIOPEN_REQ_LIBS_ONLY AND source MATCHES "contraction")
-            message("removing contraction instance ${source} ")
-            list(REMOVE_ITEM ARGN "${source}")
-        endif()
-
-        if(MIOPEN_REQ_LIBS_ONLY AND source MATCHES "reduce")
-            message("removing reduce instance ${source} ")
-            list(REMOVE_ITEM ARGN "${source}")
-        endif()
-    endforeach()
+    if(MIOPEN_REQ_LIBS_ONLY)
+        message("Removing all sources that are not required for MIOpen")
+        foreach(source IN LISTS ARGN)
+            if(source MATCHES "gemm" OR 
+               source MATCHES "mha" OR 
+               source MATCHES "contraction" OR 
+               source MATCHES "reduce")
+                    list(REMOVE_ITEM ARGN "${source}")
+            endif()
+        endforeach()
+    endif()
     #message("remaining instances: ${ARGN}")
     #only continue if there are some source files left on the list
     if(ARGN)


### PR DESCRIPTION
## Proposed changes

We are looking to significantly reduce the build time for CK inside MIOpen in preparation to get CK enabled in MIOpen TheRock builds.  This is one of the first steps that incrementally moves us in that direction.  The docker container build we use now takes less than 2 hours, before the build would take >5 hours.  I have tested whats in this PR using a branch inside MIOpen.  

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

