### PR TITLE
[CK] Support split_k in example grouped__conv_bwd_weight

### DIFF
--- a/example/20_grouped_conv_bwd_weight/common.hpp
+++ b/example/20_grouped_conv_bwd_weight/common.hpp
@@ -74,12 +74,13 @@ struct ExecutionConfig final
     bool do_verification = true;
     int init_method      = 1;
     bool time_kernel     = false;
+    int split_k          = 1;
 };
 
-#define DefaultConvParam                                                                         \
-    ck::utils::conv::ConvParam                                                                   \
-    {                                                                                            \
-        3, 4, 1, 128, 256, {3, 3, 3}, {14, 14, 14}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, { 1, 1, 1 } \
+#define DefaultConvParam                                                                       \
+    ck::utils::conv::ConvParam                                                                 \
+    {                                                                                          \
+        3, 4, 1, 128, 256, {3, 3, 3}, {14, 14, 14}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1} \
     }
 
 inline void print_help_msg()
@@ -87,6 +88,7 @@ inline void print_help_msg()
     std::cerr << "arg1: verification (0=no, 1=yes)\n"
               << "arg2: initialization (0=no init, 1=integer value, 2=decimal value)\n"
               << "arg3: time kernel (0=no, 1=yes)\n"
+              << "arg4: k split\n"
               << ck::utils::conv::get_conv_param_parser_helper_msg() << std::endl;
 }
 
@@ -96,7 +98,7 @@ inline bool parse_cmd_args(int argc,
                            ck::utils::conv::ConvParam& conv_param)
 {
     constexpr int num_execution_config_args =
-        3; // arguments for do_verification, init_method, time_kernel
+        4; // arguments for do_verification, init_method, time_kernel
     constexpr int num_conv_param_leading_args = 5; // arguments for num_dim_spatial_, G_, N_, K_, C_
 
     constexpr int threshold_to_catch_partial_args = 1 + num_execution_config_args;
@@ -113,6 +115,7 @@ inline bool parse_cmd_args(int argc,
         config.do_verification = std::stoi(argv[1]);
         config.init_method     = std::stoi(argv[2]);
         config.time_kernel     = std::stoi(argv[3]);
+        config.split_k         = std::stoi(argv[4]);
     }
     // catch both ExecutionConfig & ConvParam arguments
     else if(threshold_to_catch_all_args < argc && ((argc - threshold_to_catch_all_args) % 3 == 0))
@@ -120,10 +123,11 @@ inline bool parse_cmd_args(int argc,
         config.do_verification = std::stoi(argv[1]);
         config.init_method     = std::stoi(argv[2]);
         config.time_kernel     = std::stoi(argv[3]);
+        config.split_k         = std::stoi(argv[4]);
 
-        const ck::index_t num_dim_spatial = std::stoi(argv[4]);
+        const ck::index_t num_dim_spatial = std::stoi(argv[5]);
         conv_param                        = ck::utils::conv::parse_conv_param(
-            num_dim_spatial, threshold_to_catch_partial_args, argv);
+            num_dim_spatial, threshold_to_catch_partial_args + 1, argv);
     }
     else
     {

--- a/example/20_grouped_conv_bwd_weight/run_grouped_conv_bwd_weight_example.inc
+++ b/example/20_grouped_conv_bwd_weight/run_grouped_conv_bwd_weight_example.inc
@@ -6,7 +6,7 @@ bool run_grouped_conv_bwd_weight(const ExecutionConfig& config,
                                  const ck::utils::conv::ConvParam& conv_param)
 {
     // Dl and WMMA ops don't support split_k > 1
-    constexpr ck::index_t split_k = 1;
+    const ck::index_t split_k = config.split_k;
 
     const auto in_g_n_c_wis_desc =
         ck::utils::conv::make_input_host_tensor_descriptor_g_n_c_wis_packed<
@@ -96,15 +96,19 @@ bool run_grouped_conv_bwd_weight(const ExecutionConfig& config,
                                       OutElementOp{},
                                       split_k);
 
+    DeviceMem gemm_workspace_dev(conv.GetWorkSpaceSize(&argument));
+    conv.SetWorkSpacePointer(&argument, gemm_workspace_dev.GetDeviceBuffer());
+
     if(!conv.IsSupportedArgument(argument))
     {
+        invoker.ShowInfo(argument);
         std::cerr << "wrong! device_conv with the specified compilation parameters does "
                      "not support this Conv problem"
                   << std::endl;
         return true;
     }
 
-    invoker.Run(argument, StreamConfig{nullptr, false});
+    invoker.Run(argument, StreamConfig{nullptr, config.time_kernel});
 
     if(config.do_verification)
     {


### PR DESCRIPTION
1. Add split_k in example grouped_conv_bwd_weight
2. Correct the base argument when call parse_conv_param
3. Add SetWorkSpacePointer to match conv bwd interface change.

## Proposed changes

Please describe the motivation behind the pull request, whether it enables a new feature or fixes a bug. If there are associated pull requests or issues, please link them to the pull request.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

