### PR TITLE
Lwpck 3170 suggestions

### DIFF
--- a/example/ck_tile/37_elementwise/elementwise_example.cpp
+++ b/example/ck_tile/37_elementwise/elementwise_example.cpp
@@ -98,7 +98,9 @@ bool run(const ck_tile::ArgParser& arg_parser)
     // such warp operations might be needed to cover the BlockTile, or the BlockTile is
     // distributed differently.
     // The current configuration (BlockTile=2048, BlockWarps=8, WarpTile=64) implies that
-    // each warp processes 64 elements, and 8 warps process 8*64 = 512 elements concurrently.                                             
+    // each warp processes 64 elements, and 8 warps process 8*64 = 512 elements concurrently.
+    // Since 512 is not equal to 2048, it means that warptile(s) will need to iterate over multiple times over different set of elements to cover
+    // the entire BlockTile.                                      
     using WarpTile = ck_tile::sequence<64>;
     
     // Vector: Defines the number of elements processed by a single thread in one operation.
@@ -112,7 +114,7 @@ bool run(const ck_tile::ArgParser& arg_parser)
 
     // ElementWiseTraits bundles these tiling parameters.
     // It calculates derived properties like threads per warp, repeats, and total block size.
-    using Shape   = ck_tile::ElementWiseTraits<BlockWarps, BlockTile, WarpTile, Vector>;
+    using Shape   = ck_tile::ElementWiseShape<BlockWarps, BlockTile, WarpTile, Vector>;
 
     // ElementWisePipelineProblem encapsulates all necessary information for the elementwise kernel:
     // - Data types (input, compute, output).

--- a/example/ck_tile/37_elementwise/elementwise_example_unary.cpp
+++ b/example/ck_tile/37_elementwise/elementwise_example_unary.cpp
@@ -60,10 +60,10 @@ bool run(const ck_tile::ArgParser& arg_parser)
     using BlockWarps = ck_tile::sequence<8>; // How many concurrent warps are in a block (Each warp
                                             // will cover some part of blockTile)
     using WarpTile = ck_tile::sequence<64>; // How many elements are covered by a warp
-    using Vector   = ck_tile::sequence<1>; // How many elements are covered by a thread (Each thread
+    using Vector   = ck_tile::sequence<1>; // How many elements are covered by a thread (Each thread will cover some part of WarpTile)
 
 
-    using Shape   = ck_tile::ElementWiseTraits<BlockWarps, BlockTile, WarpTile, Vector>;
+    using Shape   = ck_tile::ElementWiseShape<BlockWarps, BlockTile, WarpTile, Vector>;
     using Problem = ck_tile::ElementWisePipelineProblem<XDataType,
                                                         XDataType, // ComputeDataType is same as XDataType in the unary case
                                                         YDataType,

--- a/include/ck_tile/ops/elementwise.hpp
+++ b/include/ck_tile/ops/elementwise.hpp
@@ -7,7 +7,7 @@
 #include "ck_tile/ops/elementwise/pipeline/elementwise_operators.hpp"
 #include "ck_tile/ops/elementwise/pipeline/elementwise_pipeline_default_policy.hpp"
 #include "ck_tile/ops/elementwise/pipeline/elementwise_pipeline_problem.hpp"
-#include "ck_tile/ops/elementwise/pipeline/elementwise_traits.hpp"
+#include "ck_tile/ops/elementwise/pipeline/elementwise_shape.hpp"
 #include "ck_tile/ops/elementwise/unary_element_wise_operation.hpp"
 #include "ck_tile/ops/common/generic_2d_block_shape.hpp"
 #include "ck_tile/ops/common/tensor_layout.hpp"

--- a/include/ck_tile/ops/elementwise/pipeline/elementwise_shape.hpp
+++ b/include/ck_tile/ops/elementwise/pipeline/elementwise_shape.hpp
@@ -8,7 +8,7 @@
 namespace ck_tile {
 
 template <typename BlockWarps, typename BlockTile, typename WarpTile, typename Vector>
-struct ElementWiseTraits
+struct ElementWiseShape
 {
     static constexpr index_t kBlockM = BlockTile::at(number<0>{});
 


### PR DESCRIPTION
## Proposed changes

Hi team, I saw the PR draft and had some minor suggestions. 
- added a comment to highlight that all concurrent warptiles need not cover entire BlockTile
- renamed ElementWiseTraits struct and .hpp to ElementWiseShape, this is the convention that we follow in gemm examples as well.
- completed a half-written comment about what a vector is


## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

