### PR TITLE
[Tile Engine] change from ninja to make

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1162,8 +1162,8 @@ pipeline {
                     agent{ label rocmnode("gfx90a") }
                     environment{
                         setup_args = "NO_CK_BUILD"
-                        execute_args = """ ../script/cmake-ck-dev.sh  ../ gfx90a -G Ninja && \
-                                           ninja benchmark_gemm && \
+                        execute_args = """ ../script/cmake-ck-dev.sh  ../ gfx90a && \
+                                           make benchmark_gemm -j && \
                                            ./bin/benchmark_gemm """
                     }
                     steps{
@@ -1180,8 +1180,8 @@ pipeline {
                     agent{ label rocmnode("gfx942") }
                     environment{
                         setup_args = "NO_CK_BUILD"
-                        execute_args = """ ../script/cmake-ck-dev.sh  ../ gfx942 -G Ninja && \
-                                           ninja benchmark_gemm && \
+                        execute_args = """ ../script/cmake-ck-dev.sh  ../ gfx942 && \
+                                           make benchmark_gemm -j && \
                                            ./bin/benchmark_gemm """
                     }
                     steps{

--- a/tile_engine/ops/gemm/README.md
+++ b/tile_engine/ops/gemm/README.md
@@ -6,7 +6,7 @@ CK Tile Engine GEMM is used to generate and run GEMM kernels with different comb
 
 User can provide kernel configuration such as tile size, warp size, padding, pipeline, scheduler and epilogue in the config file with limited values. For reference please see `./configs/user_provided_config.json`. 
 
-The Tile engine also has a default kernel configuration for providing range of configuration parameter values, which helps users who lack kernel development experience to benchmark  For reference please see in `./configs/default_config.json`
+The Tile engine also has a default kernel configuration for providing range of configuration parameter values, which helps users who lack kernel development experience to benchmark. For reference please see in `./configs/default_config.json`
 
 If user does not provide kernel configuration, the tile engine uses default kernel configuration to generate kernel instances and benchmark. 
 
@@ -15,16 +15,16 @@ If user does not provide kernel configuration, the tile engine uses default kern
 # in the root of composable kernel create build directory
 mkdir build && cd build
 # build composable kernel
-sh ../script/cmake-ck-dev.sh  ../ <arch> -G Ninja # replace <arch> with the appropriate architecture (example gfx942) or leave blank
+sh ../script/cmake-ck-dev.sh  ../ <arch> # replace <arch> with the appropriate architecture (example gfx942) or leave blank
 # generate the executable
-ninja benchmark_gemm
+make benchmark_gemm -j
 ```
 `benchmark_gemm` will be located in the `./bin/` directory.
 
 `benchmark_gemm` must be rebuilt everytime if configuration file is modified.
 
 ``` bash
-rm -rf tile_engine/ && ninja benchmark_gemm  # rebuild
+rm -rf tile_engine/ && make benchmark_gemm -j  # rebuild
 ```
 
 ## benchmark_gemm inputs


### PR DESCRIPTION
## Proposed changes

Currently, we are using the ninja to build up the tile engine. But it did not bring much compile time improvement and have the make conflict with other operators and tests. Will change the building method to make.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

