### PR TITLE
Export codegen targets

### DIFF
--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -48,6 +48,7 @@ rocm_install_targets(
     INCLUDE include
 )
 rocm_export_targets(
+    TARGETS ck_host ck_headers
     EXPORT ck_host_targets
     NAMESPACE composable_kernel::
 )


### PR DESCRIPTION
This fixes the issue where the targets was not available for migraphx to use.