### PR TITLE
Explicitly set the LINKER_LANGUAGE for the gemm_template_instances ta…

### DIFF
--- a/tile_engine/ops/gemm/CMakeLists.txt
+++ b/tile_engine/ops/gemm/CMakeLists.txt
@@ -36,6 +36,8 @@ add_custom_command(
 )
 
 add_library(gemm_template_instances OBJECT EXCLUDE_FROM_ALL ${GEMM_CODEGEN_CPP_FILES})
+# Explicitly set LINKER_LANGUAGE to avoid build config failures with Ninja.
+set_target_properties(gemm_template_instances PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(gemm_template_instances PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 target_sources(gemm_template_instances PRIVATE ${GEMM_CODEGEN_HPP_FILES})
 


### PR DESCRIPTION
…rget to avoid Ninja build config failure.

## Proposed changes

I noticed that the develop branch stopped configuring properly with "cmake -G Ninja" starting from commit:

[May 27th  [Tile Engine] Add benchmark for tile engine gemm](https://github.com/ROCm/composable_kernel/commit/128f5a1eab330744d10c82a799bfdd9978d4c14b)

The issue was the Ninja could not determine the LINKER_LANGUAGE for the new gemm_template_instances target automatically, so I had to explicitly specify it.

## Checklist

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [X] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [X] I have run `clang-format` on all changed files
- [X] Any dependent changes have been merged
