### PR TITLE
Remove usage of 'warpSize' variable as it has been deprecated

### DIFF
--- a/include/ck/utility/get_id.hpp
+++ b/include/ck/utility/get_id.hpp
@@ -9,8 +9,13 @@ namespace ck {
 
 __host__ __device__ constexpr index_t get_warp_size()
 {
-    // warpSize is defined by HIP
-    return warpSize;
+    // this is a temporary workaround until composable_kernel stops assuming
+    // it can get the warpSize as constexpr
+#if defined(__GFX9__) || !defined(__HIP_DEVICE_COMPILE__)
+    return 64;
+#else
+    return 32;
+#endif
 }
 
 __device__ index_t get_thread_local_1d_id() { return threadIdx.x; }

--- a/include/ck/utility/get_id.hpp
+++ b/include/ck/utility/get_id.hpp
@@ -9,8 +9,6 @@ namespace ck {
 
 __host__ __device__ constexpr index_t get_warp_size()
 {
-    // this is a temporary workaround until composable_kernel stops assuming
-    // it can get the warpSize as constexpr
 #if defined(__GFX9__) || !defined(__HIP_DEVICE_COMPILE__)
     return 64;
 #else

--- a/include/ck_tile/core/arch/arch.hpp
+++ b/include/ck_tile/core/arch/arch.hpp
@@ -50,8 +50,6 @@ enum struct memory_operation_enum : std::uint16_t
 
 CK_TILE_HOST_DEVICE constexpr index_t get_warp_size()
 {
-    // this is a temporary workaround until composable_kernel stops assuming
-    // it can get the warpSize as constexpr
 #if defined(__GFX9__) || !defined(__HIP_DEVICE_COMPILE__)
     return 64;
 #else

--- a/include/ck_tile/core/arch/arch.hpp
+++ b/include/ck_tile/core/arch/arch.hpp
@@ -50,8 +50,13 @@ enum struct memory_operation_enum : std::uint16_t
 
 CK_TILE_HOST_DEVICE constexpr index_t get_warp_size()
 {
-    // warpSize is defined by HIP
-    return warpSize;
+    // this is a temporary workaround until composable_kernel stops assuming
+    // it can get the warpSize as constexpr
+#if defined(__GFX9__) || !defined(__HIP_DEVICE_COMPILE__)
+    return 64;
+#else
+    return 32;
+#endif
 }
 
 CK_TILE_DEVICE index_t get_grid_size() { return gridDim.x; }


### PR DESCRIPTION
A temporary solution until this repository changes the code so it does not assume that it can get a constexpr value as a return for get_warp_size()
