### PR TITLE
Add Clamp/Relu bf16/fp16 fixes

### DIFF
--- a/include/ck/tensor_operation/gpu/element/binary_element_wise_operation.hpp
+++ b/include/ck/tensor_operation/gpu/element/binary_element_wise_operation.hpp
@@ -390,9 +390,8 @@ struct AddClamp
     operator()<half_t, float, half_t>(half_t& y, const float& x0, const half_t& x1) const
     {
         const float a = x0 + x1;
-        y             = a > type_convert<half_t>(floor_)
-                            ? (a < type_convert<half_t>(ceil_) ? a : type_convert<half_t>(ceil_))
-                            : type_convert<half_t>(floor_);
+        const float b = a > floor_ ? (a < ceil_ ? a : ceil_) : floor_;
+        y             = type_convert<half_t>(b);
     };
 
     template <>
@@ -408,9 +407,8 @@ struct AddClamp
     operator()<bhalf_t, float, bhalf_t>(bhalf_t& y, const float& x0, const bhalf_t& x1) const
     {
         const float a = x0 + type_convert<float>(x1);
-        y             = a > type_convert<bhalf_t>(floor_)
-                            ? (a < type_convert<bhalf_t>(ceil_) ? a : type_convert<bhalf_t>(ceil_))
-                            : type_convert<bhalf_t>(floor_);
+        const float b = a > floor_ ? (a < ceil_ ? a : ceil_) : floor_;
+        y             = type_convert<bhalf_t>(b);
     };
 
     template <>
@@ -418,9 +416,8 @@ struct AddClamp
     operator()<bhalf_t, bhalf_t, bhalf_t>(bhalf_t& y, const bhalf_t& x0, const bhalf_t& x1) const
     {
         const float a = type_convert<float>(x0) + type_convert<float>(x1);
-        y             = a > type_convert<bhalf_t>(floor_)
-                            ? (a < type_convert<bhalf_t>(ceil_) ? a : type_convert<bhalf_t>(ceil_))
-                            : type_convert<bhalf_t>(floor_);
+        const float b = a > floor_ ? (a < ceil_ ? a : ceil_) : floor_;
+        y             = type_convert<bhalf_t>(b);
     };
 
     template <>
@@ -477,7 +474,8 @@ struct AddRelu
     operator()<half_t, float, half_t>(half_t& y, const float& x0, const half_t& x1) const
     {
         const float a = x0 + x1;
-        y             = a > type_convert<half_t>(0.0f) ? a : type_convert<half_t>(0.0f);
+        const float b = a > 0.0f ? a : 0.0f;
+        y             = type_convert<half_t>(b);
     };
 
     template <>
@@ -493,7 +491,8 @@ struct AddRelu
     operator()<bhalf_t, float, bhalf_t>(bhalf_t& y, const float& x0, const bhalf_t& x1) const
     {
         const float a = x0 + type_convert<float>(x1);
-        y             = a > type_convert<bhalf_t>(0.0f) ? a : type_convert<bhalf_t>(0.0f);
+        const float b = a > 0.0f ? a : 0.0f;
+        y             = type_convert<bhalf_t>(b);
     };
 
     template <>
@@ -501,7 +500,8 @@ struct AddRelu
     operator()<bhalf_t, bhalf_t, bhalf_t>(bhalf_t& y, const bhalf_t& x0, const bhalf_t& x1) const
     {
         const float a = type_convert<float>(x0) + type_convert<float>(x1);
-        y             = a > type_convert<bhalf_t>(0.0f) ? a : type_convert<bhalf_t>(0.0f);
+        const float b = a > 0.0f ? a : 0.0f;
+        y             = type_convert<bhalf_t>(b);
     };
 
     template <>

--- a/include/ck/tensor_operation/gpu/element/binary_element_wise_operation.hpp
+++ b/include/ck/tensor_operation/gpu/element/binary_element_wise_operation.hpp
@@ -389,7 +389,7 @@ struct AddClamp
     __host__ __device__ constexpr void
     operator()<half_t, float, half_t>(half_t& y, const float& x0, const half_t& x1) const
     {
-        const float a = x0 + x1;
+        const float a = x0 + type_convert<float>(x1);
         const float b = a > floor_ ? (a < ceil_ ? a : ceil_) : floor_;
         y             = type_convert<half_t>(b);
     };
@@ -473,7 +473,7 @@ struct AddRelu
     __host__ __device__ constexpr void
     operator()<half_t, float, half_t>(half_t& y, const float& x0, const half_t& x1) const
     {
-        const float a = x0 + x1;
+        const float a = x0 + type_convert<float>(x1);
         const float b = a > 0.0f ? a : 0.0f;
         y             = type_convert<half_t>(b);
     };

--- a/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp
+++ b/library/include/ck/library/reference_tensor_operation/cpu/reference_conv_fwd.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #pragma once
 
@@ -383,22 +383,29 @@ struct ReferenceConvFwd : public device::BaseOperator
                                      const T& x,
                                      Args... dims)
     {
+        float y_f32;
         if constexpr(NumTensor::value == 0)
         {
-            elementwise_op(y, x);
+            elementwise_op(y_f32, ck::type_convert<float>(x));
         }
         else if constexpr(NumTensor::value == 1)
         {
-            elementwise_op(y, x, elementwise_tensors[0](dims...));
+            elementwise_op(y_f32,
+                           ck::type_convert<float>(x),
+                           ck::type_convert<float>(elementwise_tensors[0](dims...)));
         }
         else if constexpr(NumTensor::value == 2)
         {
-            elementwise_op(y, x, elementwise_tensors[0](dims...), elementwise_tensors[1](dims...));
+            elementwise_op(y_f32,
+                           ck::type_convert<float>(x),
+                           ck::type_convert<float>(elementwise_tensors[0](dims...)),
+                           ck::type_convert<float>(elementwise_tensors[1](dims...)));
         }
         else
         {
             throw std::runtime_error("ElementOp not supported in reference.");
         }
+        y = ck::type_convert<T>(y_f32);
     }
 
     static constexpr bool IsValidCompilationParameter()


### PR DESCRIPTION
## Proposed changes

Fix AddRelu/AddClamp cast error. Previously cast was not applied after clamp from fp32 to fp16/bf16.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

