### PR TITLE
[CK_TILE] MUST USE INLINE FOR ANY NON TEMPLATE FUNCTION IN HEADER

### DIFF
--- a/include/ck_tile/host/check_err.hpp
+++ b/include/ck_tile/host/check_err.hpp
@@ -46,7 +46,7 @@ using I32 = int32_t;
  * @return Relative error threshold based on data type characteristics
  */
 template <typename ComputeDataType, typename OutDataType, typename AccDataType = ComputeDataType>
-double get_relative_threshold(const int number_of_accumulations = 1)
+CK_TILE_HOST double get_relative_threshold(const int number_of_accumulations = 1)
 {
 
     static_assert(
@@ -106,7 +106,7 @@ double get_relative_threshold(const int number_of_accumulations = 1)
  * @return Absolute error threshold based on data type characteristics and maximum value
  */
 template <typename ComputeDataType, typename OutDataType, typename AccDataType = ComputeDataType>
-double get_absolute_threshold(const double max_possible_num, const int number_of_accumulations = 1)
+CK_TILE_HOST double get_absolute_threshold(const double max_possible_num, const int number_of_accumulations = 1)
 {
 
     static_assert(
@@ -194,7 +194,7 @@ std::ostream& operator<<(std::ostream& os, const std::vector<T>& v)
  * @return True if sizes mismatch, false otherwise
  */
 template <typename Range, typename RefRange>
-bool check_size_mismatch(const Range& out,
+CK_TILE_HOST bool check_size_mismatch(const Range& out,
                          const RefRange& ref,
                          const std::string& msg = "Error: Incorrect results!")
 {
@@ -216,7 +216,7 @@ bool check_size_mismatch(const Range& out,
  * @param max_err Maximum error value encountered
  * @param total_size Total number of elements compared
  */
-void report_error_stats(int err_count, double max_err, std::size_t total_size)
+CK_TILE_HOST void report_error_stats(int err_count, double max_err, std::size_t total_size)
 {
     const float error_percent =
         static_cast<float>(err_count) / static_cast<float>(total_size) * 100.f;


### PR DESCRIPTION
introduced in https://github.com/ROCm/composable_kernel/pull/2284 Now any ck-tile example will result in duplicated symbol error, like below:
```
/opt/rocm/lib/libamdhip64.so.6.3.60301 --hip-link --offload-arch=gfx942 /opt/rocm-6.3.1/lib/llvm/lib/clang/18/lib/linux/libclang_rt.builtins-x86_64.a
ld.lld: error: duplicate symbol: ck_tile::report_error_stats(int, double, unsigned long)
>>> defined at moe_sorting.cpp
>>>            CMakeFiles/tile_example_moe_sorting.dir/moe_sorting.cpp.o:(ck_tile::report_error_stats(int, double, unsigned long))
>>> defined at moe_sorting_api.cpp
>>>            CMakeFiles/tile_example_moe_sorting.dir/moe_sorting_api.cpp.o:(.text+0x0)
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
failed to execute:/opt/rocm/lib/llvm/bin/clang++ --driver-mode=g++ --hip-link  -std=c++17 -O3 -ftemplate-backtrace-limit=0 -fPIE -Wno-gnu-line-marker -O3 -DNDEBUG -Xlinker --dependency-file=CMakeFiles/tile_example_moe_sorting.dir/link.d CMakeFiles/tile_example_moe_sorting.dir/moe_sorting.cpp.o CMakeFiles/tile_example_moe_sorting.dir/moe_sorting_api.cpp.o -o "../../../bin/tile_example_moe_sorting" /opt/rocm/lib/libamdhip64.so.6.3.60301 --hip-link /opt/rocm-6.3.1/lib/llvm/lib/clang/
```

CK, as a header only library, must make sure we use `inline` for every function in header, especially for any non-template function. Otherwise will result in duplicated symbol if we include such function in multiple source file


