### PR TITLE
OCP FP8 Macro restructure

### DIFF
--- a/include/ck_tile/core/config.hpp
+++ b/include/ck_tile/core/config.hpp
@@ -240,17 +240,18 @@
 #define CK_TILE_REFERENCE_MOE_SORTING_MOCK_ID 1
 #endif
 
-#ifndef __HIP_DEVICE_COMPILE__ // for host code
-#ifdef CK_TILE_USE_OCP_FP8
-#define CK_TILE_USE_OCP_FP8 1
-#else
-#define CK_TILE_USE_OCP_FP8 0
+#ifndef CK_TILE_USE_OCP_FP8
+#  if defined(__HIP_DEVICE_COMPILE__)
+#    if defined(__gfx950__) || defined(__gfx12__)
+#      define CK_TILE_USE_OCP_FP8 1
+#    else
+#      define CK_TILE_USE_OCP_FP8 0
+#    endif
+#  else
+#    define CK_TILE_USE_OCP_FP8 0
+#  endif
 #endif
-#elif defined(__gfx950__) || defined(__gfx12__) // for GPU code
-#define CK_TILE_USE_OCP_FP8 1
-#else // for GPU code
-#define CK_TILE_USE_OCP_FP8 0
-#endif
+
 
 #ifndef CK_TILE_USE_BUFFER_ADDRESSING_BUILTIN
 #if __clang_major__ == 20

--- a/include/ck_tile/core/config.hpp
+++ b/include/ck_tile/core/config.hpp
@@ -241,17 +241,16 @@
 #endif
 
 #ifndef CK_TILE_USE_OCP_FP8
-#  if defined(__HIP_DEVICE_COMPILE__)
-#    if defined(__gfx950__) || defined(__gfx12__)
-#      define CK_TILE_USE_OCP_FP8 1
-#    else
-#      define CK_TILE_USE_OCP_FP8 0
-#    endif
-#  else
-#    define CK_TILE_USE_OCP_FP8 0
-#  endif
+#if defined(__HIP_DEVICE_COMPILE__)
+#if defined(__gfx950__) || defined(__gfx12__)
+#define CK_TILE_USE_OCP_FP8 1
+#else
+#define CK_TILE_USE_OCP_FP8 0
 #endif
-
+#else
+#define CK_TILE_USE_OCP_FP8 0
+#endif
+#endif
 
 #ifndef CK_TILE_USE_BUFFER_ADDRESSING_BUILTIN
 #if __clang_major__ == 20


### PR DESCRIPTION
## Proposed changes

Currently, we will have the redefinition error on OCP FP8 when we have both two different hardware arch that use the OCP or not on CK Tile. This PR is to fix this issue.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

