### PR TITLE
Report HIP occupancy-driven grid sizes in Stream-K CkProfiler output

### DIFF
--- a/include/ck/tensor_operation/gpu/device/device_base.hpp
+++ b/include/ck/tensor_operation/gpu/device/device_base.hpp
@@ -56,17 +56,10 @@ struct BaseArgument
     virtual ~BaseArgument() {}
 
     void* p_workspace_ = nullptr;
-  
-    virtual dim3 GetLaunchGridDims() const 
-    { 
-        return dim3{0, 0, 0}; 
-    }
-    
-    virtual bool HasLaunchGridDims() const 
-    { 
-        return false; 
-    }
 
+    virtual dim3 GetLaunchGridDims() const { return dim3{0, 0, 0}; }
+
+    virtual bool HasLaunchGridDims() const { return false; }
 };
 
 struct BaseInvoker

--- a/include/ck/tensor_operation/gpu/device/device_base.hpp
+++ b/include/ck/tensor_operation/gpu/device/device_base.hpp
@@ -56,6 +56,17 @@ struct BaseArgument
     virtual ~BaseArgument() {}
 
     void* p_workspace_ = nullptr;
+  
+    virtual dim3 GetLaunchGridDims() const 
+    { 
+        return dim3{0, 0, 0}; 
+    }
+    
+    virtual bool HasLaunchGridDims() const 
+    { 
+        return false; 
+    }
+
 };
 
 struct BaseInvoker

--- a/include/ck/tensor_operation/gpu/device/impl/device_gemm_xdl_cshuffle_streamk_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_gemm_xdl_cshuffle_streamk_v3.hpp
@@ -168,11 +168,30 @@ struct DeviceGemm_Xdl_CShuffle_Streamk_V3 : public DeviceGemm_Streamk_V2<ALayout
                     hip_check_error(hipGetDevice(&dev));
                     hip_check_error(hipGetDeviceProperties(&dev_prop, dev));
                     num_cu        = dev_prop.multiProcessorCount;
-                    arg.Grid_size = num_cu * occupancy;
-                    grid_dim      = arg.Grid_size;
+                    // arg.Grid_size = num_cu * occupancy;
+                    // grid_dim      = arg.Grid_size;
+                    grid_dim.x = num_cu * occupancy; // Set the x-dimension
+
+                    // TODO: Set grid_dim.y and grid_dim.z appropriately if they are not 1.
+                    // This often comes from the block_2_ctile_map.CalculateGridSize(...)
+                    // For now, assuming they might be 1 or derived from block_2_ctile_map elsewhere if needed.
+                    // If block_2_ctile_map.CalculateGridSize gives (N0, M0, k_split), then
+                    // grid_dim might be (N0, M0, k_split) or (total_blocks, 1, 1)
+                    // The current code sets grid_dim = arg.Grid_size (if positive) or occupancy-based (if negative)
+                    // which implies a 1D grid of blocks. We'll stick to that interpretation for grid_dim.x
+                    grid_dim.y = 1;
+                    grid_dim.z = 1;
                 }
                 else
-                    grid_dim = arg.Grid_size;
+                {
+                    // grid_dim = arg.Grid_size;
+                    grid_dim.x = arg.Grid_size;
+                    // TODO: As above, confirm y and z dimensions.
+                    grid_dim.y = 1;
+                    grid_dim.z = 1;
+                }
+                   
+                arg.SetLaunchGridDims(grid_dim); // Store the determined launch grid dimensions
 
                 if(stream_config.flush_cache)
                 {

--- a/include/ck/tensor_operation/gpu/device/impl/device_gemm_xdl_cshuffle_streamk_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_gemm_xdl_cshuffle_streamk_v3.hpp
@@ -777,7 +777,7 @@ struct DeviceGemm_Xdl_CShuffle_Streamk_V3 : public DeviceGemm_Streamk_V2<ALayout
             {BlockGemmPipelineVersion::v5, "v5"}};
 
         // clang-format off
-        str << "DeviceGemmXdlUniversal"
+        str << "DeviceGemmXdlStreamKUniversal"
             << "<"
             << getGemmSpecializationString(GemmSpec) << ", "
             << std::string(ALayout::name)[0]
@@ -799,7 +799,9 @@ struct DeviceGemm_Xdl_CShuffle_Streamk_V3 : public DeviceGemm_Streamk_V2<ALayout
             << "BlkGemmPipelineVersion: "
             << BlkGemmPipelineVersionToString[BlkGemmPipelineVer] << ", "
             << "BlkGemmPipelinePrefetchStages: "
-            << GridwiseGemm::BlockwiseGemmPipe::PrefetchStages;
+            << GridwiseGemm::BlockwiseGemmPipe::PrefetchStages << ", "
+            << "GridDim: "
+            << grid_dims.x << "x" << grid_dims.y << "x" << grid_dims.z;
         // clang-format on
 
         return str.str();

--- a/include/ck/tensor_operation/gpu/device/impl/device_gemm_xdl_cshuffle_streamk_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_gemm_xdl_cshuffle_streamk_v3.hpp
@@ -818,9 +818,8 @@ struct DeviceGemm_Xdl_CShuffle_Streamk_V3 : public DeviceGemm_Streamk_V2<ALayout
             << "BlkGemmPipelineVersion: "
             << BlkGemmPipelineVersionToString[BlkGemmPipelineVer] << ", "
             << "BlkGemmPipelinePrefetchStages: "
-            << GridwiseGemm::BlockwiseGemmPipe::PrefetchStages << ", "
-            << "GridDim: "
-            << grid_dims.x << "x" << grid_dims.y << "x" << grid_dims.z;
+            << GridwiseGemm::BlockwiseGemmPipe::PrefetchStages ;
+            
         // clang-format on
 
         return str.str();

--- a/include/ck/tensor_operation/gpu/device/impl/device_gemm_xdl_cshuffle_streamk_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_gemm_xdl_cshuffle_streamk_v3.hpp
@@ -169,25 +169,14 @@ struct DeviceGemm_Xdl_CShuffle_Streamk_V3 : public DeviceGemm_Streamk_V2<ALayout
                     hip_check_error(hipGetDeviceProperties(&dev_prop, dev));
                     num_cu        = dev_prop.multiProcessorCount;
                     arg.Grid_size = num_cu * occupancy;
-                    // grid_dim      = arg.Grid_size;
                     grid_dim.x = num_cu * occupancy; // Set the x-dimension
-
-                    // TODO: Set grid_dim.y and grid_dim.z appropriately if they are not 1.
-                    // This often comes from the block_2_ctile_map.CalculateGridSize(...)
-                    // For now, assuming they might be 1 or derived from block_2_ctile_map elsewhere
-                    // if needed. If block_2_ctile_map.CalculateGridSize gives (N0, M0, k_split),
-                    // then grid_dim might be (N0, M0, k_split) or (total_blocks, 1, 1) The current
-                    // code sets grid_dim = arg.Grid_size (if positive) or occupancy-based (if
-                    // negative) which implies a 1D grid of blocks. We'll stick to that
-                    // interpretation for grid_dim.x
                     grid_dim.y = 1;
                     grid_dim.z = 1;
                 }
                 else
                 {
-                    // grid_dim = arg.Grid_size;
+                 
                     grid_dim.x = arg.Grid_size;
-                    // TODO: As above, confirm y and z dimensions.
                     grid_dim.y = 1;
                     grid_dim.z = 1;
                 }

--- a/include/ck/tensor_operation/gpu/device/impl/device_gemm_xdl_cshuffle_streamk_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_gemm_xdl_cshuffle_streamk_v3.hpp
@@ -169,13 +169,13 @@ struct DeviceGemm_Xdl_CShuffle_Streamk_V3 : public DeviceGemm_Streamk_V2<ALayout
                     hip_check_error(hipGetDeviceProperties(&dev_prop, dev));
                     num_cu        = dev_prop.multiProcessorCount;
                     arg.Grid_size = num_cu * occupancy;
-                    grid_dim.x = num_cu * occupancy; // Set the x-dimension
-                    grid_dim.y = 1;
-                    grid_dim.z = 1;
+                    grid_dim.x    = num_cu * occupancy; // Set the x-dimension
+                    grid_dim.y    = 1;
+                    grid_dim.z    = 1;
                 }
                 else
                 {
-                 
+
                     grid_dim.x = arg.Grid_size;
                     grid_dim.y = 1;
                     grid_dim.z = 1;

--- a/include/ck/tensor_operation/gpu/device/impl/device_gemm_xdl_cshuffle_streamk_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_gemm_xdl_cshuffle_streamk_v3.hpp
@@ -168,17 +168,18 @@ struct DeviceGemm_Xdl_CShuffle_Streamk_V3 : public DeviceGemm_Streamk_V2<ALayout
                     hip_check_error(hipGetDevice(&dev));
                     hip_check_error(hipGetDeviceProperties(&dev_prop, dev));
                     num_cu        = dev_prop.multiProcessorCount;
-                    // arg.Grid_size = num_cu * occupancy;
+                    arg.Grid_size = num_cu * occupancy;
                     // grid_dim      = arg.Grid_size;
                     grid_dim.x = num_cu * occupancy; // Set the x-dimension
 
                     // TODO: Set grid_dim.y and grid_dim.z appropriately if they are not 1.
                     // This often comes from the block_2_ctile_map.CalculateGridSize(...)
-                    // For now, assuming they might be 1 or derived from block_2_ctile_map elsewhere if needed.
-                    // If block_2_ctile_map.CalculateGridSize gives (N0, M0, k_split), then
-                    // grid_dim might be (N0, M0, k_split) or (total_blocks, 1, 1)
-                    // The current code sets grid_dim = arg.Grid_size (if positive) or occupancy-based (if negative)
-                    // which implies a 1D grid of blocks. We'll stick to that interpretation for grid_dim.x
+                    // For now, assuming they might be 1 or derived from block_2_ctile_map elsewhere
+                    // if needed. If block_2_ctile_map.CalculateGridSize gives (N0, M0, k_split),
+                    // then grid_dim might be (N0, M0, k_split) or (total_blocks, 1, 1) The current
+                    // code sets grid_dim = arg.Grid_size (if positive) or occupancy-based (if
+                    // negative) which implies a 1D grid of blocks. We'll stick to that
+                    // interpretation for grid_dim.x
                     grid_dim.y = 1;
                     grid_dim.z = 1;
                 }
@@ -190,7 +191,7 @@ struct DeviceGemm_Xdl_CShuffle_Streamk_V3 : public DeviceGemm_Streamk_V2<ALayout
                     grid_dim.y = 1;
                     grid_dim.z = 1;
                 }
-                   
+
                 arg.SetLaunchGridDims(grid_dim); // Store the determined launch grid dimensions
 
                 if(stream_config.flush_cache)
@@ -819,7 +820,7 @@ struct DeviceGemm_Xdl_CShuffle_Streamk_V3 : public DeviceGemm_Streamk_V2<ALayout
             << BlkGemmPipelineVersionToString[BlkGemmPipelineVer] << ", "
             << "BlkGemmPipelinePrefetchStages: "
             << GridwiseGemm::BlockwiseGemmPipe::PrefetchStages ;
-            
+
         // clang-format on
 
         return str.str();

--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_streamk_v3.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_streamk_v3.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "ck/utility/common_header.hpp"
+#include "ck/utility/env.hpp"
 #include "ck/tensor_description/multi_index_transform_helper.hpp"
 #include "ck/tensor_description/tensor_descriptor.hpp"
 #include "ck/tensor_description/tensor_descriptor_helper.hpp"
@@ -139,9 +140,24 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
     static constexpr auto AK1Number = Number<AK1Value>{};
     static constexpr auto BK1Number = Number<BK1Value>{};
 
+    static constexpr auto lcm_AK1_BK1 = math::lcm(AK1Number, BK1Number);
+    static constexpr bool is_single_rate_mfma =
+        (((is_same<ComputeTypeA, half_t>::value || is_same<ComputeTypeA, bhalf_t>::value) &&
+          lcm_AK1_BK1 <= 4) ||
+         (is_same<ComputeTypeA, int8_t>::value && lcm_AK1_BK1 <= 8) ||
+         ((is_same<ComputeTypeA, f8_t>::value || is_same<ComputeTypeA, bf8_t>::value) &&
+          lcm_AK1_BK1 < 32))
+            ? true
+            : false;
+    static constexpr auto is_scale_mfma = false;
     static constexpr index_t KPack =
-        math::max(math::lcm(AK1Number, BK1Number),
-                  MfmaSelector<ComputeTypeA, MPerXdl, NPerXdl>::selected_mfma.k_per_blk);
+        math::max(lcm_AK1_BK1,
+                  MfmaSelector<ComputeTypeA,
+                               MPerXdl,
+                               NPerXdl,
+                               ComputeTypeA,
+                               is_single_rate_mfma,
+                               is_scale_mfma>::selected_mfma.k_per_blk);
 
     using ThisThreadBlock = ThisThreadBlock<BlockSize>;
     __host__ static auto CalculateMPadded(index_t M)
@@ -223,6 +239,23 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
             }
         }();
 
+        // Pad both M and K to be multiples of the block sizes
+        const auto a_grid_desc_m_k =
+            transform_tensor_descriptor(a_grid_desc_mraw_kraw,
+                                        make_tuple(make_right_pad_transform(M, MPad - M),
+                                                   make_right_pad_transform(K, KPad - K)),
+                                        make_tuple(Sequence<0>{}, Sequence<1>{}),
+                                        make_tuple(Sequence<0>{}, Sequence<1>{}));
+
+        const auto a_grid_desc_ak0_m_ak1 = transform_tensor_descriptor(
+            a_grid_desc_m_k,
+            make_tuple(make_unmerge_transform(make_tuple(AK0, AK1Value)),
+                       make_pass_through_transform(MPad)),
+            make_tuple(Sequence<1>{}, Sequence<0>{}),
+            make_tuple(Sequence<0, 2>{}, Sequence<1>{}));
+
+        return a_grid_desc_ak0_m_ak1;
+#if 0
         using GemmSpecialization = tensor_operation::device::GemmSpecialization;
 
         if constexpr(GemmSpec == GemmSpecialization::MKPadding ||
@@ -289,6 +322,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
 
             return a_grid_desc_ak0_m_ak1;
         }
+#endif
     }
 
     __device__ static auto MakeBGridDescriptor_BK0_N_BK1(
@@ -305,6 +339,23 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
             }
         }();
 
+        // Pad both N and K to be multiples of the block sizes
+        const auto b_grid_desc_n_k =
+            transform_tensor_descriptor(b_grid_desc_nraw_kraw,
+                                        make_tuple(make_right_pad_transform(N, NPad - N),
+                                                   make_right_pad_transform(K, KPad - K)),
+                                        make_tuple(Sequence<0>{}, Sequence<1>{}),
+                                        make_tuple(Sequence<0>{}, Sequence<1>{}));
+
+        const auto b_grid_desc_bk0_n_bk1 = transform_tensor_descriptor(
+            b_grid_desc_n_k,
+            make_tuple(make_unmerge_transform(make_tuple(BK0, BK1Value)),
+                       make_pass_through_transform(NPad)),
+            make_tuple(Sequence<1>{}, Sequence<0>{}),
+            make_tuple(Sequence<0, 2>{}, Sequence<1>{}));
+
+        return b_grid_desc_bk0_n_bk1;
+#if 0     
         using GemmSpecialization = tensor_operation::device::GemmSpecialization;
 
         if constexpr(GemmSpec == GemmSpecialization::NKPadding ||
@@ -371,6 +422,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
 
             return b_grid_desc_bk0_n_bk1;
         }
+#endif
     }
 
     template <typename ABlockDesc_AK0_M_AK1>
@@ -405,6 +457,13 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
             }
         }();
 
+        // Pad both M and N to be multiples of the block sizes
+        return transform_tensor_descriptor(c_grid_desc_mraw_nraw,
+                                           make_tuple(make_right_pad_transform(M, MPad - M),
+                                                      make_right_pad_transform(N, NPad - N)),
+                                           make_tuple(Sequence<0>{}, Sequence<1>{}),
+                                           make_tuple(Sequence<0>{}, Sequence<1>{}));
+#if 0
         using GemmSpecialization = tensor_operation::device::GemmSpecialization;
 
         if constexpr(GemmSpec == GemmSpecialization::MNPadding ||
@@ -442,6 +501,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
             // not pad M or N
             return c_grid_desc_mraw_nraw;
         }
+#endif
     }
 
     struct Problem
@@ -453,7 +513,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                          index_t StrideB_,
                          index_t StrideC_,
                          index_t Streamk_sel_,
-                         index_t Grid_size_)
+                         index_t Grid_size_,
+                         StreamKReductionStrategy reduction_strategy_)
             : M{M_},
               N{N_},
               K{K_},
@@ -462,6 +523,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
               StrideC{StrideC_},
               Streamk_sel{Streamk_sel_},
               Grid_size{Grid_size_},
+              reduction_strategy{reduction_strategy_}, // Initialize the member variable
               MPadded{CalculateMPadded(M_)},
               NPadded{CalculateNPadded(N_)},
               KRead{CalculateKRead(K_, 1)},
@@ -490,8 +552,13 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                       << "AK0:" << AK0 << ", "
                       << "BK0:" << BK0 << ", "
                       << "MBlock: " << MBlock << ", "
-                      << "NBlock: " << NBlock << ", Stream-K Selection:" << Streamk_sel
-                      << ", Grid size:" << Grid_size << "}" << std::endl;
+                      << "NBlock: " << NBlock << ", "
+                      << "Stream-K Selection:" << Streamk_sel << ", "
+                      << "Grid size:" << Grid_size << ", "
+                      << "Reduction Strategy:"
+                      << (reduction_strategy == StreamKReductionStrategy::Atomic ? "Atomic"
+                                                                                 : "Reduction")
+                      << "}" << std::endl;
         }
 
         index_t M;
@@ -502,6 +569,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
         index_t StrideC;
         index_t Streamk_sel;
         mutable index_t Grid_size;
+        StreamKReductionStrategy reduction_strategy;
         index_t MPadded;
         index_t NPadded;
         index_t KRead;
@@ -525,13 +593,26 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                           index_t StrideB_,
                           index_t StrideC_,
                           index_t Streamk_sel_,
-                          index_t Grid_size_)
-            : Problem{M_, N_, K_, StrideA_, StrideB_, StrideC_, Streamk_sel_, Grid_size_},
+                          index_t Grid_size_,
+                          StreamKReductionStrategy reduction_strategy_)
+            : Problem{M_,
+                      N_,
+                      K_,
+                      StrideA_,
+                      StrideB_,
+                      StrideC_,
+                      Streamk_sel_,
+                      Grid_size_,
+                      reduction_strategy_},
               p_a_grid{p_a_grid_},
               p_b_grid{p_b_grid_},
               p_c_grid{p_c_grid_},
-              block_2_ctile_map_streamk(
-                  M_, N_, AK0Number * CalculateKPadded(K_, 1), Grid_size_, Streamk_sel_),
+              block_2_ctile_map_streamk(M_,
+                                        N_,
+                                        AK0Number * CalculateKPadded(K_, 1),
+                                        Grid_size_,
+                                        Streamk_sel_,
+                                        reduction_strategy_),
               launch_grid_dims_{0, 0, 0} // Initialize grid dims to zero
 
         {
@@ -959,7 +1040,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
         if constexpr(!(GemmSpec == tensor_operation::device::GemmSpecialization::MPadding ||
                        GemmSpec == tensor_operation::device::GemmSpecialization::MNPadding ||
                        GemmSpec == tensor_operation::device::GemmSpecialization::MKPadding ||
-                       GemmSpec == tensor_operation::device::GemmSpecialization::MNKPadding))
+                       GemmSpec == tensor_operation::device::GemmSpecialization::MNKPadding) &&
+                     !(is_same<tensor_layout::gemm::RowMajor, ALayout>::value))
         {
             if(!(karg.M % MPerBlock == 0))
             {
@@ -976,7 +1058,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
         if constexpr(!(GemmSpec == tensor_operation::device::GemmSpecialization::NPadding ||
                        GemmSpec == tensor_operation::device::GemmSpecialization::MNPadding ||
                        GemmSpec == tensor_operation::device::GemmSpecialization::NKPadding ||
-                       GemmSpec == tensor_operation::device::GemmSpecialization::MNKPadding))
+                       GemmSpec == tensor_operation::device::GemmSpecialization::MNKPadding) &&
+                     (is_same<tensor_layout::gemm::RowMajor, BLayout>::value))
         {
             if(!(karg.N % NPerBlock == 0))
             {
@@ -1042,6 +1125,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                               << ABlockTransferSrcScalarPerVector << " )! " << __FILE__ << ":"
                               << __LINE__ << ", in function: " << __func__ << std::endl;
                 }
+
                 return false;
             }
         }
@@ -1057,6 +1141,10 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                               << BBlockTransferSrcScalarPerVector << " )! " << __FILE__ << ":"
                               << __LINE__ << ", in function: " << __func__ << std::endl;
                 }
+                std::cout << "Arg N (" << karg.N
+                          << ") value is not a multiple of BBlockTransferSrcScalarPerVector ("
+                          << BBlockTransferSrcScalarPerVector << " )! " << __FILE__ << ":"
+                          << __LINE__ << ", in function: " << __func__ << std::endl;
                 return false;
             }
         }
@@ -1071,6 +1159,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                               << BBlockTransferSrcScalarPerVector << " )! " << __FILE__ << ":"
                               << __LINE__ << ", in function: " << __func__ << std::endl;
                 }
+
                 return false;
             }
         }
@@ -1088,6 +1177,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                               << __FILE__ << ":" << __LINE__ << ", in function: " << __func__
                               << std::endl;
                 }
+
                 return false;
             }
         }
@@ -1104,17 +1194,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                               << __FILE__ << ":" << __LINE__ << ", in function: " << __func__
                               << std::endl;
                 }
-                return false;
-            }
-        }
 
-        if constexpr(is_same<remove_cvref_t<CDataType>, bhalf_t>::value)
-        {
-            if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
-            {
-                std::cout << " Grid size: " << karg.Grid_size << " > 1 is not support yet"
-                          << __FILE__ << ":" << __LINE__ << ", in function: " << __func__
-                          << std::endl;
+                return false;
             }
         }
 
@@ -1220,11 +1301,13 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
 
         const auto b_grid_buf = make_dynamic_buffer<AddressSpaceEnum::Global>(
             p_b_grid, b_grid_desc_bk0_n_bk1.GetElementSpaceSize());
+
         Block2CTileMap_streamk block_2_ctile_map_streamk(problem.M,
                                                          problem.N,
                                                          AK0Number * problem.KPadded,
                                                          problem.Grid_size,
-                                                         problem.Streamk_sel);
+                                                         problem.Streamk_sel,
+                                                         problem.reduction_strategy);
         uint32_t iter_start, iter_end;
         bool is_sk_block, is_dp_block, is_reduction_block;
         index_t num_k_block_main_loop;
@@ -1239,6 +1322,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
         uint32_t* p_semaphore = reinterpret_cast<uint32_t*>(
             reinterpret_cast<char*>(p_workspace) +
             block_2_ctile_map_streamk.get_workspace_size_for_acc(sizeof(AccDataType)));
+
         for(auto block_idx = get_block_1d_id();
             block_idx < block_2_ctile_map_streamk.get_grid_dims();
             block_idx += gridDim.x)
@@ -1254,8 +1338,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
             block_2_ctile_map_streamk.get_block_itr(block_idx, iter_start, iter_end);
             num_k_block_main_loop = iter_end - iter_start;
 
-            if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
-                         StreamKReductionStrategy::Reduction)
+            if(problem.reduction_strategy == StreamKReductionStrategy::Reduction)
             {
                 is_reduction_block = static_cast<uint32_t>(block_idx) >=
                                      block_2_ctile_map_streamk.reduction_start_block_idx;
@@ -1843,8 +1926,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                         }
                         else if(is_sk_block)
                         {
-                            if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
-                                         StreamKReductionStrategy::Atomic)
+                            if(problem.reduction_strategy == StreamKReductionStrategy::Atomic)
                             {
                                 // each block copy its data from LDS to global
                                 c_shuffle_block_copy_lds_to_global
@@ -1856,8 +1938,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                                         c_grid_desc_mblock_mperblock_nblock_nperblock,
                                         c_grid_buf);
                             }
-                            else if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
-                                              StreamKReductionStrategy::Reduction)
+                            else if(problem.reduction_strategy ==
+                                    StreamKReductionStrategy::Reduction)
                             {
                                 // constexpr offset
                                 c_block_copy_lds_to_partial_acc.SetSrcSliceOrigin(
@@ -1889,8 +1971,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                         }
                     });
 
-                    if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
-                                 StreamKReductionStrategy::Reduction)
+                    if(problem.reduction_strategy == StreamKReductionStrategy::Reduction)
                     {
                         if(is_sk_block)
                         {
@@ -1905,8 +1986,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                 iter_end -= current_iter_length;
                 if(iter_end <= iter_start)
                     break;
-                if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
-                             StreamKReductionStrategy::Reduction)
+                if(problem.reduction_strategy == StreamKReductionStrategy::Reduction)
                 {
                     block_acc_offset -= MPerBlock * NPerBlock;
                 }
@@ -1961,7 +2041,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                                                          problem.N,
                                                          AK0Number * problem.KPadded,
                                                          problem.Grid_size,
-                                                         problem.Streamk_sel);
+                                                         problem.Streamk_sel,
+                                                         problem.reduction_strategy);
         for(auto block_idx = get_block_1d_id();
             block_idx < block_2_ctile_map_streamk.get_grid_dims();
             block_idx += gridDim.x)
@@ -1980,8 +2061,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                 reinterpret_cast<char*>(p_workspace) +
                 block_2_ctile_map_streamk.get_workspace_size_for_acc(sizeof(AccDataType)));
 
-            if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
-                         StreamKReductionStrategy::Reduction)
+            if(problem.reduction_strategy == StreamKReductionStrategy::Reduction)
             {
                 is_reduction_block = static_cast<uint32_t>(block_idx) >=
                                      block_2_ctile_map_streamk.reduction_start_block_idx;
@@ -2597,8 +2677,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                         }
                         else if(is_sk_block)
                         {
-                            if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
-                                         StreamKReductionStrategy::Atomic)
+                            if(problem.reduction_strategy == StreamKReductionStrategy::Atomic)
                             {
                                 // each block copy its data from LDS to global
                                 c_shuffle_block_copy_lds_to_global
@@ -2610,8 +2689,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                                         c_grid_desc_mblock_mperblock_nblock_nperblock,
                                         c_grid_buf);
                             }
-                            else if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
-                                              StreamKReductionStrategy::Reduction)
+                            else if(problem.reduction_strategy ==
+                                    StreamKReductionStrategy::Reduction)
                             {
                                 // constexpr offset
                                 c_block_copy_lds_to_partial_acc.SetSrcSliceOrigin(
@@ -2646,16 +2725,14 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                 iter_end -= current_iter_length;
                 if(iter_end <= iter_start)
                     break;
-                if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
-                             StreamKReductionStrategy::Reduction)
+                if(problem.reduction_strategy == StreamKReductionStrategy::Reduction)
                 {
                     block_acc_offset -= MPerBlock * NPerBlock;
                 }
                 // make sure next loop LDS is ready for use
                 block_sync_lds();
             }
-            if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
-                         StreamKReductionStrategy::Reduction)
+            if(problem.reduction_strategy == StreamKReductionStrategy::Reduction)
             {
                 if(is_sk_block)
                 {

--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_streamk_v3.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_streamk_v3.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "ck/utility/common_header.hpp"
-#include "ck/utility/env.hpp"
 #include "ck/tensor_description/multi_index_transform_helper.hpp"
 #include "ck/tensor_description/tensor_descriptor.hpp"
 #include "ck/tensor_description/tensor_descriptor_helper.hpp"
@@ -140,24 +139,9 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
     static constexpr auto AK1Number = Number<AK1Value>{};
     static constexpr auto BK1Number = Number<BK1Value>{};
 
-    static constexpr auto lcm_AK1_BK1 = math::lcm(AK1Number, BK1Number);
-    static constexpr bool is_single_rate_mfma =
-        (((is_same<ComputeTypeA, half_t>::value || is_same<ComputeTypeA, bhalf_t>::value) &&
-          lcm_AK1_BK1 <= 4) ||
-         (is_same<ComputeTypeA, int8_t>::value && lcm_AK1_BK1 <= 8) ||
-         ((is_same<ComputeTypeA, f8_t>::value || is_same<ComputeTypeA, bf8_t>::value) &&
-          lcm_AK1_BK1 < 32))
-            ? true
-            : false;
-    static constexpr auto is_scale_mfma = false;
     static constexpr index_t KPack =
-        math::max(lcm_AK1_BK1,
-                  MfmaSelector<ComputeTypeA,
-                               MPerXdl,
-                               NPerXdl,
-                               ComputeTypeA,
-                               is_single_rate_mfma,
-                               is_scale_mfma>::selected_mfma.k_per_blk);
+        math::max(math::lcm(AK1Number, BK1Number),
+                  MfmaSelector<ComputeTypeA, MPerXdl, NPerXdl>::selected_mfma.k_per_blk);
 
     using ThisThreadBlock = ThisThreadBlock<BlockSize>;
     __host__ static auto CalculateMPadded(index_t M)
@@ -239,23 +223,6 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
             }
         }();
 
-        // Pad both M and K to be multiples of the block sizes
-        const auto a_grid_desc_m_k =
-            transform_tensor_descriptor(a_grid_desc_mraw_kraw,
-                                        make_tuple(make_right_pad_transform(M, MPad - M),
-                                                   make_right_pad_transform(K, KPad - K)),
-                                        make_tuple(Sequence<0>{}, Sequence<1>{}),
-                                        make_tuple(Sequence<0>{}, Sequence<1>{}));
-
-        const auto a_grid_desc_ak0_m_ak1 = transform_tensor_descriptor(
-            a_grid_desc_m_k,
-            make_tuple(make_unmerge_transform(make_tuple(AK0, AK1Value)),
-                       make_pass_through_transform(MPad)),
-            make_tuple(Sequence<1>{}, Sequence<0>{}),
-            make_tuple(Sequence<0, 2>{}, Sequence<1>{}));
-
-        return a_grid_desc_ak0_m_ak1;
-#if 0
         using GemmSpecialization = tensor_operation::device::GemmSpecialization;
 
         if constexpr(GemmSpec == GemmSpecialization::MKPadding ||
@@ -322,7 +289,6 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
 
             return a_grid_desc_ak0_m_ak1;
         }
-#endif
     }
 
     __device__ static auto MakeBGridDescriptor_BK0_N_BK1(
@@ -339,23 +305,6 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
             }
         }();
 
-        // Pad both N and K to be multiples of the block sizes
-        const auto b_grid_desc_n_k =
-            transform_tensor_descriptor(b_grid_desc_nraw_kraw,
-                                        make_tuple(make_right_pad_transform(N, NPad - N),
-                                                   make_right_pad_transform(K, KPad - K)),
-                                        make_tuple(Sequence<0>{}, Sequence<1>{}),
-                                        make_tuple(Sequence<0>{}, Sequence<1>{}));
-
-        const auto b_grid_desc_bk0_n_bk1 = transform_tensor_descriptor(
-            b_grid_desc_n_k,
-            make_tuple(make_unmerge_transform(make_tuple(BK0, BK1Value)),
-                       make_pass_through_transform(NPad)),
-            make_tuple(Sequence<1>{}, Sequence<0>{}),
-            make_tuple(Sequence<0, 2>{}, Sequence<1>{}));
-
-        return b_grid_desc_bk0_n_bk1;
-#if 0     
         using GemmSpecialization = tensor_operation::device::GemmSpecialization;
 
         if constexpr(GemmSpec == GemmSpecialization::NKPadding ||
@@ -422,7 +371,6 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
 
             return b_grid_desc_bk0_n_bk1;
         }
-#endif
     }
 
     template <typename ABlockDesc_AK0_M_AK1>
@@ -457,13 +405,6 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
             }
         }();
 
-        // Pad both M and N to be multiples of the block sizes
-        return transform_tensor_descriptor(c_grid_desc_mraw_nraw,
-                                           make_tuple(make_right_pad_transform(M, MPad - M),
-                                                      make_right_pad_transform(N, NPad - N)),
-                                           make_tuple(Sequence<0>{}, Sequence<1>{}),
-                                           make_tuple(Sequence<0>{}, Sequence<1>{}));
-#if 0
         using GemmSpecialization = tensor_operation::device::GemmSpecialization;
 
         if constexpr(GemmSpec == GemmSpecialization::MNPadding ||
@@ -501,7 +442,6 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
             // not pad M or N
             return c_grid_desc_mraw_nraw;
         }
-#endif
     }
 
     struct Problem
@@ -513,8 +453,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                          index_t StrideB_,
                          index_t StrideC_,
                          index_t Streamk_sel_,
-                         index_t Grid_size_,
-                         StreamKReductionStrategy reduction_strategy_)
+                         index_t Grid_size_)
             : M{M_},
               N{N_},
               K{K_},
@@ -523,7 +462,6 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
               StrideC{StrideC_},
               Streamk_sel{Streamk_sel_},
               Grid_size{Grid_size_},
-              reduction_strategy{reduction_strategy_}, // Initialize the member variable
               MPadded{CalculateMPadded(M_)},
               NPadded{CalculateNPadded(N_)},
               KRead{CalculateKRead(K_, 1)},
@@ -552,13 +490,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                       << "AK0:" << AK0 << ", "
                       << "BK0:" << BK0 << ", "
                       << "MBlock: " << MBlock << ", "
-                      << "NBlock: " << NBlock << ", "
-                      << "Stream-K Selection:" << Streamk_sel << ", "
-                      << "Grid size:" << Grid_size << ", "
-                      << "Reduction Strategy:"
-                      << (reduction_strategy == StreamKReductionStrategy::Atomic ? "Atomic"
-                                                                                 : "Reduction")
-                      << "}" << std::endl;
+                      << "NBlock: " << NBlock << ", Stream-K Selection:" << Streamk_sel
+                      << ", Grid size:" << Grid_size << "}" << std::endl;
         }
 
         index_t M;
@@ -569,7 +502,6 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
         index_t StrideC;
         index_t Streamk_sel;
         mutable index_t Grid_size;
-        StreamKReductionStrategy reduction_strategy;
         index_t MPadded;
         index_t NPadded;
         index_t KRead;
@@ -593,26 +525,14 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                           index_t StrideB_,
                           index_t StrideC_,
                           index_t Streamk_sel_,
-                          index_t Grid_size_,
-                          StreamKReductionStrategy reduction_strategy_)
-            : Problem{M_,
-                      N_,
-                      K_,
-                      StrideA_,
-                      StrideB_,
-                      StrideC_,
-                      Streamk_sel_,
-                      Grid_size_,
-                      reduction_strategy_},
+                          index_t Grid_size_)
+            : Problem{M_, N_, K_, StrideA_, StrideB_, StrideC_, Streamk_sel_, Grid_size_},
               p_a_grid{p_a_grid_},
               p_b_grid{p_b_grid_},
               p_c_grid{p_c_grid_},
-              block_2_ctile_map_streamk(M_,
-                                        N_,
-                                        AK0Number * CalculateKPadded(K_, 1),
-                                        Grid_size_,
-                                        Streamk_sel_,
-                                        reduction_strategy_)
+              block_2_ctile_map_streamk(
+                  M_, N_, AK0Number * CalculateKPadded(K_, 1), Grid_size_, Streamk_sel_),
+              launch_grid_dims_{0, 0, 0} // Initialize grid dims to zero
 
         {
         }
@@ -627,6 +547,18 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                                        8,
                                        4>
             block_2_ctile_map_streamk;
+
+        mutable dim3 launch_grid_dims_;
+
+        void SetLaunchGridDims(dim3 dims) const
+        {
+            launch_grid_dims_ = dims;
+        }
+
+        dim3 GetLaunchGridDims() const
+        {
+            return launch_grid_dims_;
+        }
     };
 
     struct SplitKBatchOffset
@@ -1027,8 +959,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
         if constexpr(!(GemmSpec == tensor_operation::device::GemmSpecialization::MPadding ||
                        GemmSpec == tensor_operation::device::GemmSpecialization::MNPadding ||
                        GemmSpec == tensor_operation::device::GemmSpecialization::MKPadding ||
-                       GemmSpec == tensor_operation::device::GemmSpecialization::MNKPadding) &&
-                     !(is_same<tensor_layout::gemm::RowMajor, ALayout>::value))
+                       GemmSpec == tensor_operation::device::GemmSpecialization::MNKPadding))
         {
             if(!(karg.M % MPerBlock == 0))
             {
@@ -1045,8 +976,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
         if constexpr(!(GemmSpec == tensor_operation::device::GemmSpecialization::NPadding ||
                        GemmSpec == tensor_operation::device::GemmSpecialization::MNPadding ||
                        GemmSpec == tensor_operation::device::GemmSpecialization::NKPadding ||
-                       GemmSpec == tensor_operation::device::GemmSpecialization::MNKPadding) &&
-                     (is_same<tensor_layout::gemm::RowMajor, BLayout>::value))
+                       GemmSpec == tensor_operation::device::GemmSpecialization::MNKPadding))
         {
             if(!(karg.N % NPerBlock == 0))
             {
@@ -1112,7 +1042,6 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                               << ABlockTransferSrcScalarPerVector << " )! " << __FILE__ << ":"
                               << __LINE__ << ", in function: " << __func__ << std::endl;
                 }
-
                 return false;
             }
         }
@@ -1128,10 +1057,6 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                               << BBlockTransferSrcScalarPerVector << " )! " << __FILE__ << ":"
                               << __LINE__ << ", in function: " << __func__ << std::endl;
                 }
-                std::cout << "Arg N (" << karg.N
-                          << ") value is not a multiple of BBlockTransferSrcScalarPerVector ("
-                          << BBlockTransferSrcScalarPerVector << " )! " << __FILE__ << ":"
-                          << __LINE__ << ", in function: " << __func__ << std::endl;
                 return false;
             }
         }
@@ -1146,7 +1071,6 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                               << BBlockTransferSrcScalarPerVector << " )! " << __FILE__ << ":"
                               << __LINE__ << ", in function: " << __func__ << std::endl;
                 }
-
                 return false;
             }
         }
@@ -1164,7 +1088,6 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                               << __FILE__ << ":" << __LINE__ << ", in function: " << __func__
                               << std::endl;
                 }
-
                 return false;
             }
         }
@@ -1181,8 +1104,17 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                               << __FILE__ << ":" << __LINE__ << ", in function: " << __func__
                               << std::endl;
                 }
-
                 return false;
+            }
+        }
+
+        if constexpr(is_same<remove_cvref_t<CDataType>, bhalf_t>::value)
+        {
+            if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
+            {
+                std::cout << " Grid size: " << karg.Grid_size << " > 1 is not support yet"
+                          << __FILE__ << ":" << __LINE__ << ", in function: " << __func__
+                          << std::endl;
             }
         }
 
@@ -1288,13 +1220,11 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
 
         const auto b_grid_buf = make_dynamic_buffer<AddressSpaceEnum::Global>(
             p_b_grid, b_grid_desc_bk0_n_bk1.GetElementSpaceSize());
-
         Block2CTileMap_streamk block_2_ctile_map_streamk(problem.M,
                                                          problem.N,
                                                          AK0Number * problem.KPadded,
                                                          problem.Grid_size,
-                                                         problem.Streamk_sel,
-                                                         problem.reduction_strategy);
+                                                         problem.Streamk_sel);
         uint32_t iter_start, iter_end;
         bool is_sk_block, is_dp_block, is_reduction_block;
         index_t num_k_block_main_loop;
@@ -1309,7 +1239,6 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
         uint32_t* p_semaphore = reinterpret_cast<uint32_t*>(
             reinterpret_cast<char*>(p_workspace) +
             block_2_ctile_map_streamk.get_workspace_size_for_acc(sizeof(AccDataType)));
-
         for(auto block_idx = get_block_1d_id();
             block_idx < block_2_ctile_map_streamk.get_grid_dims();
             block_idx += gridDim.x)
@@ -1325,7 +1254,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
             block_2_ctile_map_streamk.get_block_itr(block_idx, iter_start, iter_end);
             num_k_block_main_loop = iter_end - iter_start;
 
-            if(problem.reduction_strategy == StreamKReductionStrategy::Reduction)
+            if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
+                         StreamKReductionStrategy::Reduction)
             {
                 is_reduction_block = static_cast<uint32_t>(block_idx) >=
                                      block_2_ctile_map_streamk.reduction_start_block_idx;
@@ -1913,7 +1843,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                         }
                         else if(is_sk_block)
                         {
-                            if(problem.reduction_strategy == StreamKReductionStrategy::Atomic)
+                            if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
+                                         StreamKReductionStrategy::Atomic)
                             {
                                 // each block copy its data from LDS to global
                                 c_shuffle_block_copy_lds_to_global
@@ -1925,8 +1856,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                                         c_grid_desc_mblock_mperblock_nblock_nperblock,
                                         c_grid_buf);
                             }
-                            else if(problem.reduction_strategy ==
-                                    StreamKReductionStrategy::Reduction)
+                            else if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
+                                              StreamKReductionStrategy::Reduction)
                             {
                                 // constexpr offset
                                 c_block_copy_lds_to_partial_acc.SetSrcSliceOrigin(
@@ -1958,7 +1889,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                         }
                     });
 
-                    if(problem.reduction_strategy == StreamKReductionStrategy::Reduction)
+                    if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
+                                 StreamKReductionStrategy::Reduction)
                     {
                         if(is_sk_block)
                         {
@@ -1973,7 +1905,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                 iter_end -= current_iter_length;
                 if(iter_end <= iter_start)
                     break;
-                if(problem.reduction_strategy == StreamKReductionStrategy::Reduction)
+                if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
+                             StreamKReductionStrategy::Reduction)
                 {
                     block_acc_offset -= MPerBlock * NPerBlock;
                 }
@@ -2028,8 +1961,7 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                                                          problem.N,
                                                          AK0Number * problem.KPadded,
                                                          problem.Grid_size,
-                                                         problem.Streamk_sel,
-                                                         problem.reduction_strategy);
+                                                         problem.Streamk_sel);
         for(auto block_idx = get_block_1d_id();
             block_idx < block_2_ctile_map_streamk.get_grid_dims();
             block_idx += gridDim.x)
@@ -2048,7 +1980,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                 reinterpret_cast<char*>(p_workspace) +
                 block_2_ctile_map_streamk.get_workspace_size_for_acc(sizeof(AccDataType)));
 
-            if(problem.reduction_strategy == StreamKReductionStrategy::Reduction)
+            if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
+                         StreamKReductionStrategy::Reduction)
             {
                 is_reduction_block = static_cast<uint32_t>(block_idx) >=
                                      block_2_ctile_map_streamk.reduction_start_block_idx;
@@ -2664,7 +2597,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                         }
                         else if(is_sk_block)
                         {
-                            if(problem.reduction_strategy == StreamKReductionStrategy::Atomic)
+                            if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
+                                         StreamKReductionStrategy::Atomic)
                             {
                                 // each block copy its data from LDS to global
                                 c_shuffle_block_copy_lds_to_global
@@ -2676,8 +2610,8 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                                         c_grid_desc_mblock_mperblock_nblock_nperblock,
                                         c_grid_buf);
                             }
-                            else if(problem.reduction_strategy ==
-                                    StreamKReductionStrategy::Reduction)
+                            else if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
+                                              StreamKReductionStrategy::Reduction)
                             {
                                 // constexpr offset
                                 c_block_copy_lds_to_partial_acc.SetSrcSliceOrigin(
@@ -2712,14 +2646,16 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
                 iter_end -= current_iter_length;
                 if(iter_end <= iter_start)
                     break;
-                if(problem.reduction_strategy == StreamKReductionStrategy::Reduction)
+                if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
+                             StreamKReductionStrategy::Reduction)
                 {
                     block_acc_offset -= MPerBlock * NPerBlock;
                 }
                 // make sure next loop LDS is ready for use
                 block_sync_lds();
             }
-            if(problem.reduction_strategy == StreamKReductionStrategy::Reduction)
+            if constexpr(Block2CTileMap_streamk::ReductionStrategy ==
+                         StreamKReductionStrategy::Reduction)
             {
                 if(is_sk_block)
                 {

--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_streamk_v3.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_streamk_v3.hpp
@@ -631,19 +631,10 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
 
         mutable dim3 launch_grid_dims_;
 
-        void SetLaunchGridDims(dim3 dims) const
-        {
-            launch_grid_dims_ = dims;
-        }
+        void SetLaunchGridDims(dim3 dims) const { launch_grid_dims_ = dims; }
 
-        dim3 GetLaunchGridDims() const override
-        {
-            return launch_grid_dims_;
-        }
-        bool HasLaunchGridDims() const override
-        {
-            return launch_grid_dims_.x > 0;
-        }
+        dim3 GetLaunchGridDims() const override { return launch_grid_dims_; }
+        bool HasLaunchGridDims() const override { return launch_grid_dims_.x > 0; }
     };
 
     struct SplitKBatchOffset

--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_streamk_v3.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_streamk_v3.hpp
@@ -636,9 +636,13 @@ struct GridwiseGemm_xdl_cshuffle_streamk_v3
             launch_grid_dims_ = dims;
         }
 
-        dim3 GetLaunchGridDims() const
+        dim3 GetLaunchGridDims() const override
         {
             return launch_grid_dims_;
+        }
+        bool HasLaunchGridDims() const override
+        {
+            return launch_grid_dims_.x > 0;
         }
     };
 

--- a/profiler/include/profiler/profile_gemm_universal_streamk_impl.hpp
+++ b/profiler/include/profiler/profile_gemm_universal_streamk_impl.hpp
@@ -250,8 +250,19 @@ bool profile_gemm_universal_streamk_impl(int do_verification,
 
                     float gb_per_sec = num_btype / 1.E6 / ave_time;
 
-                    const auto actual_launch_grid_dims = argument_ptr->GetLaunchGridDims();
-                    
+                    // const auto actual_launch_grid_dims = argument_ptr->GetLaunchGridDims();
+                    const auto* typed_argument_ptr = dynamic_cast<const GridwiseGemm_xdl_cshuffle_streamk_v3<...>::Argument*>(argument_ptr);
+                    if (typed_argument_ptr)
+                    {
+                        const auto actual_launch_grid_dims = typed_argument_ptr->GetLaunchGridDims();
+                        std::cout << "Actual Grid Dimensions: " << actual_launch_grid_dims.x << "x"
+                                << actual_launch_grid_dims.y << "x" << actual_launch_grid_dims.z << std::endl;
+                    }
+                    else
+                    {
+                        std::cerr << "Error: Failed to cast argument_ptr to the correct type." << std::endl;
+                    }
+
                     std::cout << "Perf: " << std::setw(10) << ave_time << " ms, " << tflops
                               << " TFlops, " << gb_per_sec << " GB/s, " << op_name << ", Grid_size "
                               << actual_launch_grid_dims.x // Use the x-dimension of the actual launch grid

--- a/profiler/include/profiler/profile_gemm_universal_streamk_impl.hpp
+++ b/profiler/include/profiler/profile_gemm_universal_streamk_impl.hpp
@@ -250,10 +250,18 @@ bool profile_gemm_universal_streamk_impl(int do_verification,
 
                     float gb_per_sec = num_btype / 1.E6 / ave_time;
 
+                    const auto actual_launch_grid_dims = argument_ptr->GetLaunchGridDims();
+                    
                     std::cout << "Perf: " << std::setw(10) << ave_time << " ms, " << tflops
                               << " TFlops, " << gb_per_sec << " GB/s, " << op_name << ", Grid_size "
-                              << grid_size_curr << ", streamk selection strategy"
+                              << actual_launch_grid_dims.x // Use the x-dimension of the actual launch grid
+                              << ", streamk selection strategy "
                               << streamk_sel_curr << std::endl;
+
+                    // std::cout << "Perf: " << std::setw(10) << ave_time << " ms, " << tflops
+                    //           << " TFlops, " << gb_per_sec << " GB/s, " << op_name << ", Grid_size "
+                    //           << grid_size_curr << ", streamk selection strategy"
+                    //           << streamk_sel_curr << std::endl;
 
 #if defined CK_ENABLE_FP8
                     // set softer tolerances for fp8

--- a/profiler/include/profiler/profile_gemm_universal_streamk_impl.hpp
+++ b/profiler/include/profiler/profile_gemm_universal_streamk_impl.hpp
@@ -251,14 +251,16 @@ bool profile_gemm_universal_streamk_impl(int do_verification,
                     float gb_per_sec = num_btype / 1.E6 / ave_time;
 
                     // // const auto actual_launch_grid_dims = argument_ptr->GetLaunchGridDims();
-                    // const auto* typed_argument_ptr = dynamic_cast<const GridwiseGemm_xdl_cshuffle_streamk_v3<...>::Argument*>(argument_ptr)
+                    // const auto* typed_argument_ptr = dynamic_cast<const
+                    // GridwiseGemm_xdl_cshuffle_streamk_v3<...>::Argument*>(argument_ptr)
 
                     // Get actual launch grid dims from argument
                     dim3 actual_launch_grid_dims = argument_ptr->GetLaunchGridDims();
 
                     std::cout << "Perf: " << std::setw(10) << ave_time << " ms, " << tflops
-                              << " TFlops, " << gb_per_sec << " GB/s, " << op_name << ", Grid_size ";
-                    
+                              << " TFlops, " << gb_per_sec << " GB/s, " << op_name
+                              << ", Grid_size ";
+
                     if(argument_ptr->HasLaunchGridDims() && actual_launch_grid_dims.x > 0)
                     {
                         std::cout << actual_launch_grid_dims.x;
@@ -267,30 +269,8 @@ bool profile_gemm_universal_streamk_impl(int do_verification,
                     {
                         std::cout << grid_size_curr;
                     }
-                    
+
                     std::cout << ", streamk selection strategy " << streamk_sel_curr << std::endl;
-
-                    // if (typed_argument_ptr)
-                    // {
-                    //     const auto actual_launch_grid_dims = typed_argument_ptr->GetLaunchGridDims();
-                    //     std::cout << "Actual Grid Dimensions: " << actual_launch_grid_dims.x << "x"
-                    //             << actual_launch_grid_dims.y << "x" << actual_launch_grid_dims.z << std::endl;
-                    // }
-                    // else
-                    // {
-                    //     std::cerr << "Error: Failed to cast argument_ptr to the correct type." << std::endl;
-                    // }
-
-                    // std::cout << "Perf: " << std::setw(10) << ave_time << " ms, " << tflops
-                    //           << " TFlops, " << gb_per_sec << " GB/s, " << op_name << ", Grid_size "
-                    //           << actual_launch_grid_dims.x // Use the x-dimension of the actual launch grid
-                    //           << ", streamk selection strategy "
-                    //           << streamk_sel_curr << std::endl;
-
-                    // std::cout << "Perf: " << std::setw(10) << ave_time << " ms, " << tflops
-                    //           << " TFlops, " << gb_per_sec << " GB/s, " << op_name << ", Grid_size "
-                    //           << grid_size_curr << ", streamk selection strategy"
-                    //           << streamk_sel_curr << std::endl;
 
 #if defined CK_ENABLE_FP8
                     // set softer tolerances for fp8
@@ -313,11 +293,22 @@ bool profile_gemm_universal_streamk_impl(int do_verification,
 
                     if(tflops > best_tflops)
                     {
-                        best_op_name     = op_name;
-                        best_tflops      = tflops;
-                        best_ave_time    = ave_time;
-                        best_gb_per_sec  = gb_per_sec;
-                        best_grid_size   = grid_size_curr;
+                        best_op_name    = op_name;
+                        best_tflops     = tflops;
+                        best_ave_time   = ave_time;
+                        best_gb_per_sec = gb_per_sec;
+
+                        best_grid_size = grid_size_curr;
+
+                        if(argument_ptr->HasLaunchGridDims() && actual_launch_grid_dims.x > 0)
+                        {
+                            best_grid_size = actual_launch_grid_dims.x;
+                        }
+                        else
+                        {
+                            best_grid_size = grid_size_curr;
+                        }
+
                         best_streamk_sel = streamk_sel_curr;
                     }
                 }

--- a/profiler/include/profiler/profile_gemm_universal_streamk_impl.hpp
+++ b/profiler/include/profiler/profile_gemm_universal_streamk_impl.hpp
@@ -250,24 +250,42 @@ bool profile_gemm_universal_streamk_impl(int do_verification,
 
                     float gb_per_sec = num_btype / 1.E6 / ave_time;
 
-                    // const auto actual_launch_grid_dims = argument_ptr->GetLaunchGridDims();
-                    const auto* typed_argument_ptr = dynamic_cast<const GridwiseGemm_xdl_cshuffle_streamk_v3<...>::Argument*>(argument_ptr);
-                    if (typed_argument_ptr)
+                    // // const auto actual_launch_grid_dims = argument_ptr->GetLaunchGridDims();
+                    // const auto* typed_argument_ptr = dynamic_cast<const GridwiseGemm_xdl_cshuffle_streamk_v3<...>::Argument*>(argument_ptr)
+
+                    // Get actual launch grid dims from argument
+                    dim3 actual_launch_grid_dims = argument_ptr->GetLaunchGridDims();
+
+                    std::cout << "Perf: " << std::setw(10) << ave_time << " ms, " << tflops
+                              << " TFlops, " << gb_per_sec << " GB/s, " << op_name << ", Grid_size ";
+                    
+                    if(argument_ptr->HasLaunchGridDims() && actual_launch_grid_dims.x > 0)
                     {
-                        const auto actual_launch_grid_dims = typed_argument_ptr->GetLaunchGridDims();
-                        std::cout << "Actual Grid Dimensions: " << actual_launch_grid_dims.x << "x"
-                                << actual_launch_grid_dims.y << "x" << actual_launch_grid_dims.z << std::endl;
+                        std::cout << actual_launch_grid_dims.x;
                     }
                     else
                     {
-                        std::cerr << "Error: Failed to cast argument_ptr to the correct type." << std::endl;
+                        std::cout << grid_size_curr;
                     }
+                    
+                    std::cout << ", streamk selection strategy " << streamk_sel_curr << std::endl;
 
-                    std::cout << "Perf: " << std::setw(10) << ave_time << " ms, " << tflops
-                              << " TFlops, " << gb_per_sec << " GB/s, " << op_name << ", Grid_size "
-                              << actual_launch_grid_dims.x // Use the x-dimension of the actual launch grid
-                              << ", streamk selection strategy "
-                              << streamk_sel_curr << std::endl;
+                    // if (typed_argument_ptr)
+                    // {
+                    //     const auto actual_launch_grid_dims = typed_argument_ptr->GetLaunchGridDims();
+                    //     std::cout << "Actual Grid Dimensions: " << actual_launch_grid_dims.x << "x"
+                    //             << actual_launch_grid_dims.y << "x" << actual_launch_grid_dims.z << std::endl;
+                    // }
+                    // else
+                    // {
+                    //     std::cerr << "Error: Failed to cast argument_ptr to the correct type." << std::endl;
+                    // }
+
+                    // std::cout << "Perf: " << std::setw(10) << ave_time << " ms, " << tflops
+                    //           << " TFlops, " << gb_per_sec << " GB/s, " << op_name << ", Grid_size "
+                    //           << actual_launch_grid_dims.x // Use the x-dimension of the actual launch grid
+                    //           << ", streamk selection strategy "
+                    //           << streamk_sel_curr << std::endl;
 
                     // std::cout << "Perf: " << std::setw(10) << ave_time << " ms, " << tflops
                     //           << " TFlops, " << gb_per_sec << " GB/s, " << op_name << ", Grid_size "

--- a/profiler/include/profiler/profile_gemm_universal_streamk_impl.hpp
+++ b/profiler/include/profiler/profile_gemm_universal_streamk_impl.hpp
@@ -250,10 +250,7 @@ bool profile_gemm_universal_streamk_impl(int do_verification,
 
                     float gb_per_sec = num_btype / 1.E6 / ave_time;
 
-                    // // const auto actual_launch_grid_dims = argument_ptr->GetLaunchGridDims();
-                    // const auto* typed_argument_ptr = dynamic_cast<const
-                    // GridwiseGemm_xdl_cshuffle_streamk_v3<...>::Argument*>(argument_ptr)
-
+                 
                     // Get actual launch grid dims from argument
                     dim3 actual_launch_grid_dims = argument_ptr->GetLaunchGridDims();
 

--- a/profiler/include/profiler/profile_gemm_universal_streamk_impl.hpp
+++ b/profiler/include/profiler/profile_gemm_universal_streamk_impl.hpp
@@ -250,7 +250,6 @@ bool profile_gemm_universal_streamk_impl(int do_verification,
 
                     float gb_per_sec = num_btype / 1.E6 / ave_time;
 
-                 
                     // Get actual launch grid dims from argument
                     dim3 actual_launch_grid_dims = argument_ptr->GetLaunchGridDims();
 


### PR DESCRIPTION
## Proposed changes

This update introduces grid dimension tracking for Stream-K profiling in the CK Profiler. The grid dimensions, determined by hipOccupancyMaxActiveBlocksPerMultiprocessor are now explicitly tracked and stored during kernel execution. This enhancement improves debugging, profiling, and runtime analysis for Stream-K operations.



## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.


- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered







