### PR TITLE
[CK_TILE][HOTFIX] WA by adding NumWaveGroups inside BlockGemmProblem to avoid fmha_bwd compute error

### DIFF
--- a/include/ck_tile/ops/gemm/block/block_gemm_problem.hpp
+++ b/include/ck_tile/ops/gemm/block/block_gemm_problem.hpp
@@ -12,7 +12,8 @@ template <typename ADataType_,
           typename BDataType_,
           typename CDataType_,
           index_t kBlockSize_,
-          typename BlockGemmShape_>
+          typename BlockGemmShape_,
+          index_t NumWaveGroups_ = 1>
 struct BlockGemmProblem
 {
     using ADataType      = remove_cvref_t<ADataType_>;
@@ -20,7 +21,8 @@ struct BlockGemmProblem
     using CDataType      = remove_cvref_t<CDataType_>;
     using BlockGemmShape = remove_cvref_t<BlockGemmShape_>;
 
-    static constexpr index_t kBlockSize = kBlockSize_;
+    static constexpr index_t kBlockSize    = kBlockSize_;
+    static constexpr index_t NumWaveGroups = NumWaveGroups_;
 };
 
 } // namespace ck_tile


### PR DESCRIPTION
https://github.com/ROCm/composable_kernel/pull/2276 => this PR will let fmha_bwd compile error
![image](https://github.com/user-attachments/assets/ff8308e3-a2cd-4c9b-93e9-39c675b75fd1)
While the rootcause is not in fmha nor block_gemm, here add one extra membed inside BlockGemmProblem  as WA