### PR TITLE
fix(install_precommit.sh): for docker containers with ub24.04+

### DIFF
--- a/codegen/test/batched_gemm_softmax_gemm.cpp
+++ b/codegen/test/batched_gemm_softmax_gemm.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "ck/host/device_batched_gemm_softmax_gemm/problem.hpp"
 #include "ck/host/stringutils.hpp"
 #include "ck/host/utils.hpp"

--- a/codegen/test/include/test.hpp
+++ b/codegen/test/include/test.hpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 /*
  * The MIT License (MIT)
  *

--- a/example/04_gemm_add_add_fastgelu/gemm_add_add_fastgelu_xdl_fp32.cpp
+++ b/example/04_gemm_add_add_fastgelu/gemm_add_add_fastgelu_xdl_fp32.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 // Copyright (c) 2018-2023, Advanced Micro Devices, Inc. All rights reserved.
 
 #include "common.hpp"

--- a/example/24_batched_gemm/batched_gemm_xdl_bf16.cpp
+++ b/example/24_batched_gemm/batched_gemm_xdl_bf16.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include <iostream>
 #include <numeric>
 #include <initializer_list>

--- a/example/24_batched_gemm/batched_gemm_xdl_fp16.cpp
+++ b/example/24_batched_gemm/batched_gemm_xdl_fp16.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include <iostream>
 #include <numeric>
 #include <initializer_list>

--- a/example/24_batched_gemm/batched_gemm_xdl_fp16int4_b_scale_v3.cpp
+++ b/example/24_batched_gemm/batched_gemm_xdl_fp16int4_b_scale_v3.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include <cstdlib>
 #include <initializer_list>
 #include <iostream>

--- a/example/24_batched_gemm/batched_gemm_xdl_fp32.cpp
+++ b/example/24_batched_gemm/batched_gemm_xdl_fp32.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include <iostream>
 #include <numeric>
 #include <initializer_list>

--- a/example/24_batched_gemm/batched_gemm_xdl_int4.cpp
+++ b/example/24_batched_gemm/batched_gemm_xdl_int4.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include <iostream>
 #include <numeric>
 #include <initializer_list>

--- a/example/24_batched_gemm/batched_gemm_xdl_int8.cpp
+++ b/example/24_batched_gemm/batched_gemm_xdl_int8.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include <iostream>
 #include <numeric>
 #include <initializer_list>

--- a/example/ck_tile/02_layernorm2d/layernorm2d_fwd.cpp
+++ b/example/ck_tile/02_layernorm2d/layernorm2d_fwd.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "ck_tile/host.hpp"
 #include "layernorm2d_fwd.hpp"
 #include <algorithm>

--- a/example/ck_tile/05_reduce/reduce.cpp
+++ b/example/ck_tile/05_reduce/reduce.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "ck_tile/host.hpp"
 #include "reduce.hpp"
 #include <cstring>

--- a/example/ck_tile/06_permute/alternative_impl/matrix_core_swizzle.cpp
+++ b/example/ck_tile/06_permute/alternative_impl/matrix_core_swizzle.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "matrix_core_swizzle.hpp"
 #include "matrix_core_swizzle_kernel.hpp"
 

--- a/example/ck_tile/10_rmsnorm2d/example_rmsnorm2d_fwd.cpp
+++ b/example/ck_tile/10_rmsnorm2d/example_rmsnorm2d_fwd.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "ck_tile/host.hpp"
 #include "ck_tile/core.hpp"
 #include "ck_tile/host/kernel_launch.hpp"

--- a/example/ck_tile/10_rmsnorm2d/rmsnorm2d_fwd.cpp
+++ b/example/ck_tile/10_rmsnorm2d/rmsnorm2d_fwd.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "ck_tile/host.hpp"
 #include "rmsnorm2d_fwd.hpp"
 #include <cstring>

--- a/example/ck_tile/11_add_rmsnorm2d_rdquant/add_rmsnorm2d_rdquant_fwd.cpp
+++ b/example/ck_tile/11_add_rmsnorm2d_rdquant/add_rmsnorm2d_rdquant_fwd.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "ck_tile/host.hpp"
 #include "add_rmsnorm2d_rdquant_fwd.hpp"
 #include <cstring>

--- a/example/ck_tile/11_add_rmsnorm2d_rdquant/example_add_rmsnorm2d_rdquant_fwd.cpp
+++ b/example/ck_tile/11_add_rmsnorm2d_rdquant/example_add_rmsnorm2d_rdquant_fwd.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "ck_tile/host.hpp"
 #include "ck_tile/core.hpp"
 #include "ck_tile/host/kernel_launch.hpp"

--- a/example/ck_tile/12_smoothquant/example_smoothquant.cpp
+++ b/example/ck_tile/12_smoothquant/example_smoothquant.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "ck_tile/host.hpp"
 #include "ck_tile/core.hpp"
 #include "ck_tile/host/kernel_launch.hpp"

--- a/example/ck_tile/12_smoothquant/smoothquant.cpp
+++ b/example/ck_tile/12_smoothquant/smoothquant.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "ck_tile/host.hpp"
 #include "smoothquant.hpp"
 #include <cstring>

--- a/example/ck_tile/14_moe_smoothquant/moe_smoothquant.cpp
+++ b/example/ck_tile/14_moe_smoothquant/moe_smoothquant.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "ck_tile/host.hpp"
 #include "moe_smoothquant.hpp"
 #include <cstring>

--- a/example/ck_tile/15_fused_moe/main.cpp
+++ b/example/ck_tile/15_fused_moe/main.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include <algorithm>
 #include <cstring>
 #include <unordered_set>

--- a/include/ck/tensor_operation/gpu/device/device_batched_gemm_e_permute.hpp
+++ b/include/ck/tensor_operation/gpu/device/device_batched_gemm_e_permute.hpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #pragma once
 #include <iostream>
 #include <vector>

--- a/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_e_permute_xdl.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_e_permute_xdl.hpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #pragma once
 
 #include <iostream>

--- a/include/ck/tensor_operation/gpu/element/quantization_operation.hpp
+++ b/include/ck/tensor_operation/gpu/element/quantization_operation.hpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #pragma once
 
 #include "ck/utility/data_type.hpp"

--- a/include/ck/utility/workgroup_barrier.hpp
+++ b/include/ck/utility/workgroup_barrier.hpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #pragma once
 #include <hip/hip_runtime.h>
 #include <stdint.h>

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5.hpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "ck_tile/core.hpp"
 #include "ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp"
 #include "ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v5_default_policy.hpp"

--- a/profiler/include/profiler/profile_grouped_conv_fwd_outelementop_impl.hpp
+++ b/profiler/include/profiler/profile_grouped_conv_fwd_outelementop_impl.hpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #pragma once
 
 #include "ck/library/tensor_operation_instance/gpu/grouped_convolution_forward_convscale.hpp"

--- a/profiler/src/profile_grouped_conv_fwd_outelementop.cpp
+++ b/profiler/src/profile_grouped_conv_fwd_outelementop.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "profiler/profile_grouped_conv_fwd_outelementop_impl.hpp"
 

--- a/script/check_copyright_exists.py
+++ b/script/check_copyright_exists.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import sys
+from pathlib import Path
+from datetime import datetime
+
+def get_copyright_header():
+    """
+    Get the copyright header for C/C++ files.
+    Returns the header as a string with proper comment style.
+    """
+    current_year = datetime.now().year
+    
+    return f"""// SPDX-License-Identifier: MIT
+// Copyright (c) {current_year}, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+
+def insert_copyright_header(file_path):
+    """
+    Insert copyright header at the top of a file.
+    """
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        header = get_copyright_header()
+        
+        # Insert header at the beginning of the file
+        new_content = header + content
+        
+        # Write the modified content back
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+        
+        return True
+        
+    except Exception as e:
+        print(f"Error inserting header into {file_path}: {e}")
+        return False
+
+def has_copyright_header(file_path):
+    """
+    Check if a file has the proper copyright header.
+    Returns True if copyright header is found, False otherwise.
+    """
+    try:
+        with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+            # Read first few lines to check for copyright header
+            lines = []
+            for i, line in enumerate(f):
+                if i >= 10:  # Only check first 10 lines
+                    break
+                lines.append(line.strip()) # remove whitespace
+            
+        content = '\n'.join(lines) # join the lines into a single string
+        
+        # Check for SPDX-License-Identifier: MIT (the standard format used in this repo)
+        has_spdx = re.search(r'SPDX-License-Identifier:\s*MIT', content, re.IGNORECASE)
+        
+        # Check for specific AMD copyright format used in this repo
+        has_amd_copyright = re.search(r'Copyright.*Advanced Micro Devices, Inc\..*All rights reserved', content, re.IGNORECASE)
+        
+        return bool(has_spdx and has_amd_copyright)
+        
+    except Exception as e:
+        print(f"Error reading {file_path}: {e}")
+        return False
+
+def find_files_without_copyright(root_dir):
+    """
+    Scan directory recursively for files with specified extensions
+    that don't have copyright headers.
+    """
+    extensions = {'.cpp', '.hpp'}
+    files_without_copyright = []
+    
+    root_path = Path(root_dir)
+    
+    for file_path in root_path.rglob('*'): # for all files in the repo
+        if file_path.is_file() and file_path.suffix in extensions: # if the file is a file and has a valid extension
+            if not has_copyright_header(file_path): # if the file does not have a copyright header
+                files_without_copyright.append(str(file_path)) # add the file to the list of files without copyright
+    
+    return files_without_copyright
+
+def main():
+    # Parse command line arguments
+    import argparse
+    parser = argparse.ArgumentParser(description='Check and optionally fix copyright headers in C/C++ source files')
+    parser.add_argument('directory', nargs='?', default=os.getcwd(), 
+                       help='Directory to scan (default: current directory)')
+    parser.add_argument('--fix', action='store_true', 
+                       help='Automatically insert copyright headers into files that are missing them')
+    parser.add_argument('--dry-run', action='store_true',
+                       help='Show what would be fixed without making changes (use with --fix)')
+    
+    args = parser.parse_args()
+    
+    repo_dir = args.directory
+    
+    if not os.path.exists(repo_dir):
+        print(f"Error: Directory {repo_dir} does not exist")
+        sys.exit(1)
+    
+    print(f"Scanning repository: {repo_dir}")
+    print("Looking for files with extensions: .cpp, .hpp")
+    print("Checking for copyright header containing:")
+    print("  - SPDX-License-Identifier: MIT")
+    print("  - Copyright...Advanced Micro Devices, Inc...All rights reserved")
+    print()
+    
+    files_without_copyright = find_files_without_copyright(repo_dir)
+    
+    if files_without_copyright:
+        print(f"Found {len(files_without_copyright)} files without proper copyright header:")
+        print()
+        
+        if args.fix:
+            if args.dry_run:
+                print("DRY RUN - Would insert copyright headers into these files:")
+                for file_path in sorted(files_without_copyright):
+                    print(f"  {file_path}")
+            else:
+                print("Inserting copyright headers...")
+                success_count = 0
+                for file_path in sorted(files_without_copyright):
+                    if insert_copyright_header(file_path):
+                        print(f"  ✓ {file_path}")
+                        success_count += 1
+                    else:
+                        print(f"  ✗ {file_path}")
+                
+                print(f"\nSuccessfully updated {success_count} out of {len(files_without_copyright)} files")
+                
+                # Return the number of files that still need fixing
+                return len(files_without_copyright) - success_count
+        else:
+            for file_path in sorted(files_without_copyright):
+                print(file_path)
+            print(f"\nUse --fix to automatically insert copyright headers")
+    else:
+        print("All files have proper copyright headers!")
+    
+    return len(files_without_copyright)
+
+if __name__ == "__main__":
+    exit_code = main()
+    sys.exit(min(exit_code, 255))  # Limit exit code to valid range 

--- a/script/install_precommit.sh
+++ b/script/install_precommit.sh
@@ -10,11 +10,40 @@ run_and_check() {
     return $status
 }
 
+# Function to detect if running in Docker
+is_docker() {
+    # Method 1: Check for .dockerenv file (most reliable)
+    if [ -f /.dockerenv ]; then
+        return 0
+    fi
+    
+    # Method 2: Check cgroup for docker (fallback)
+    if [ -f /proc/1/cgroup ] && grep -q docker /proc/1/cgroup 2>/dev/null; then
+        return 0
+    fi
+    
+    # Method 3: Check for container environment variable
+    if [ -n "${container}" ] || [ -n "${DOCKER_CONTAINER}" ]; then
+        return 0
+    fi
+    
+    return 1
+}
+
 echo "I: Installing tools required for pre-commit checks..."
 run_and_check apt install clang-format-12
 
 echo "I: Installing pre-commit itself..."
-run_and_check pip3 install pre-commit
+
+# Check if running in Docker and handle pip installation accordingly
+if is_docker; then
+    echo "I: Docker environment detected - using --break-system-packages"
+    run_and_check pip3 install --break-system-packages pre-commit
+else
+    echo "I: Host environment detected - using standard pip install"
+    run_and_check pip3 install pre-commit
+fi
+
 run_and_check pre-commit install
 
 echo "I: Installation successful."

--- a/test/batched_gemm_softmax_gemm_permute/test_batched_gemm_device_utils.hpp
+++ b/test/batched_gemm_softmax_gemm_permute/test_batched_gemm_device_utils.hpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #pragma once
 
 #include <hip/hip_runtime.h>

--- a/test/block_swizzle_test/block_swizzle_test.cpp
+++ b/test/block_swizzle_test/block_swizzle_test.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include <stdio.h>
 #include <string>
 #include <algorithm>

--- a/test/ck_tile/gemm/test_gemm_pipeline_compv3.cpp
+++ b/test/ck_tile/gemm/test_gemm_pipeline_compv3.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "test_gemm_pipeline_kernel_types.hpp"
 #include "test_gemm_pipeline_util.hpp"
 #include "gtest/gtest.h"

--- a/test/ck_tile/gemm/test_gemm_pipeline_compv4.cpp
+++ b/test/ck_tile/gemm/test_gemm_pipeline_compv4.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "test_gemm_pipeline_kernel_types.hpp"
 #include "test_gemm_pipeline_util.hpp"
 #include "gtest/gtest.h"

--- a/test/ck_tile/gemm/test_gemm_pipeline_mem.cpp
+++ b/test/ck_tile/gemm/test_gemm_pipeline_mem.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "test_gemm_pipeline_kernel_types.hpp"
 #include "test_gemm_pipeline_util.hpp"
 #include "gtest/gtest.h"

--- a/test/ck_tile/gemm/test_gemm_pipeline_persistent.cpp
+++ b/test/ck_tile/gemm/test_gemm_pipeline_persistent.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include "test_gemm_pipeline_kernel_types.hpp"
 #include "test_gemm_pipeline_util.hpp"
 #include "gtest/gtest.h"

--- a/test/data_type/test_e8m0.cpp
+++ b/test/data_type/test_e8m0.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
 #include <gtest/gtest.h>
 #include "ck/utility/e8m0.hpp"
 #include "ck/utility/data_type.hpp"


### PR DESCRIPTION
## Proposed changes

**What:** I noticed that install_precommit.sh fails with this (https://stackoverflow.com/questions/75608323/how-do-i-solve-error-externally-managed-environment-every-time-i-use-pip-3) error if we run docker with ck_ub24.04_rocm6.4. However, it does not fail with ck_ub22.04_rocm6.4.

**Why:** Ubuntu 24.04 enforcing virtual env requirement for packages while 22.04 is not.

**Solution:**
There are several fixes suggested but the one that made the most sense to me is:
using --break-system-packages that overrides the need to create a virtual environment to install packages. 

This flag may have implications outside of a docker container but within docker it should be safer, since docker itself is a virtual container. 

Am wondering if this is a good enough solution or if should we go with something more robust. 

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

See description.

