### PR TITLE
Fix ignored args in kernel_batched_gemm_wmma_cshuffle_v3()

### DIFF
--- a/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_wmma_cshuffle_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_wmma_cshuffle_v3.hpp
@@ -76,7 +76,6 @@ __global__ void
 #endif
 #else
     ignore = karg;
-    ignore = batch;
     ignore = compute_ptr_offset_of_batch;
 #endif
 }


### PR DESCRIPTION
## Proposed changes

Recently PR [#2319](https://github.com/ROCm/composable_kernel/pull/2319) (implement batched gemm wmma) was merged but introduced a build error when building for multiple architectures at the same time. In this case, device_batched_gemm_wmma_cshuffle_v3.hpp might be built but without gfx11/gfx12 macros active, meaning the kernel_batched_gemm_wmma_cshuffle_v3() arguments have to be ignored. An old argument was ignored which no longer exists, which led to a build error.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

