### PR TITLE
Fix return value bug that drops minus sign in some cases.

### DIFF
--- a/include/ck/utility/mxfp_utils.hpp
+++ b/include/ck/utility/mxfp_utils.hpp
@@ -213,7 +213,7 @@ __host__ __device__ inline T convert_to_type(float value)
     {
         // closer to 0
         if(std::abs(value) <= std::abs(min_subnorm - value))
-            return 0 | (sign << (NumericUtils<T>::exp + NumericUtils<T>::mant));
+            return sign << (NumericUtils<T>::exp + NumericUtils<T>::mant);
         else
             return 1 | (sign << (NumericUtils<T>::exp + NumericUtils<T>::mant));
     }
@@ -249,7 +249,7 @@ __host__ __device__ inline T convert_to_type(float value)
 
     if(out_exponent == 0 && mantissa == 0)
     {
-        return 0 | (sign << (NumericUtils<T>::exp + NumericUtils<T>::mant));
+        return sign << (NumericUtils<T>::exp + NumericUtils<T>::mant);
     }
 
     mantissa &= (1UL << NumericUtils<T>::mant) - 1;

--- a/include/ck/utility/mxfp_utils.hpp
+++ b/include/ck/utility/mxfp_utils.hpp
@@ -213,7 +213,7 @@ __host__ __device__ inline T convert_to_type(float value)
     {
         // closer to 0
         if(std::abs(value) <= std::abs(min_subnorm - value))
-            return 0;
+            return 0 | (sign << (NumericUtils<T>::exp + NumericUtils<T>::mant));
         else
             return 1 | (sign << (NumericUtils<T>::exp + NumericUtils<T>::mant));
     }
@@ -249,7 +249,7 @@ __host__ __device__ inline T convert_to_type(float value)
 
     if(out_exponent == 0 && mantissa == 0)
     {
-        return 0;
+        return 0 | (sign << (NumericUtils<T>::exp + NumericUtils<T>::mant));
     }
 
     mantissa &= (1UL << NumericUtils<T>::mant) - 1;


### PR DESCRIPTION
## Proposed changes

This bug may drop minus sign for certain inputs, such as -0.0f.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

