### PR TITLE
Fix compilation errors with clang20

### DIFF
--- a/include/ck_tile/core/arch/amd_buffer_addressing_builtins.hpp
+++ b/include/ck_tile/core/arch/amd_buffer_addressing_builtins.hpp
@@ -13,6 +13,7 @@
 #include "ck_tile/core/utility/type_traits.hpp"
 #include "ck_tile/core/utility/bit_cast.hpp"
 #include "ck_tile/core/utility/functional.hpp"
+#include "ck_tile/core/utility/ignore.hpp"
 
 using as3_uint32_ptr = uint32_t __attribute__((address_space(3)))*;
 
@@ -1598,7 +1599,7 @@ CK_TILE_DEVICE void amd_async_buffer_load(CK_TILE_LDS_ADDR T* smem,
     {
         llvm_amdgcn_raw_buffer_load_lds(
             src_wave_buffer_resource,
-            reinterpret_cast<as3_uint32_ptr t*>(reinterpret_cast<uintptr_t>(smem)),
+            reinterpret_cast<as3_uint32_ptr>(reinterpret_cast<uintptr_t>(smem)),
             bytes,
             src_thread_addr_offset,
             src_wave_addr_offset,


### PR DESCRIPTION
## Proposed changes

Fixing a couple of compilation errors with clang20.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x ] I have added inline documentation which enables the maintainers with understanding the motivation
- [x ] I have removed the stale documentation which is no longer relevant after this pull request
- [x ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x ] I have run `clang-format` on all changed files
- [x ] Any dependent changes have been merged

