### PR TITLE
Add templates for fp16 and unsigned short atomic add to fix FBGEMM builds.

### DIFF
--- a/include/ck/utility/generic_memory_space_atomic.hpp
+++ b/include/ck/utility/generic_memory_space_atomic.hpp
@@ -33,6 +33,14 @@ __device__ float atomic_add<float>(float* p_dst, const float& x)
 }
 
 template <>
+__device__ _Float16 atomic_add<_Float16>(_Float16* p_dst, const _Float16& x)
+{
+    // Use atomicAdd with unsigned int
+    return static_cast<_Float16>(
+        atomicAdd(reinterpret_cast<unsigned int*>(p_dst), static_cast<unsigned int>(x)));
+}
+
+template <>
 __device__ double atomic_add<double>(double* p_dst, const double& x)
 {
     return atomicAdd(p_dst, x);

--- a/include/ck/utility/generic_memory_space_atomic.hpp
+++ b/include/ck/utility/generic_memory_space_atomic.hpp
@@ -35,17 +35,28 @@ __device__ float atomic_add<float>(float* p_dst, const float& x)
 template <>
 __device__ unsigned short atomic_add<unsigned short>(unsigned short* p_dst, const unsigned short& x)
 {
-    // Use atomicAdd with unsigned int
-    return static_cast<unsigned short>(
-        atomicAdd(reinterpret_cast<unsigned int*>(p_dst), static_cast<unsigned int>(x)));
+    unsigned short old_val, new_val;
+    do
+    {
+        old_val = *p_dst;
+        new_val = old_val + x;
+    } while(atomicCAS(p_dst, old_val, new_val) != old_val);
+    return old_val;
 }
 
 template <>
 __device__ _Float16 atomic_add<_Float16>(_Float16* p_dst, const _Float16& x)
 {
-    // Use atomicAdd with unsigned int
-    return static_cast<_Float16>(
-        atomicAdd(reinterpret_cast<unsigned int*>(p_dst), static_cast<unsigned int>(x)));
+    _Float16 old_val, new_val;
+    do
+    {
+        old_val = *p_dst;
+        new_val = old_val + x; // Proper FP16 addition
+    } while(atomicCAS(reinterpret_cast<unsigned short*>(p_dst),
+                      *reinterpret_cast<unsigned short*>(&old_val),
+                      *reinterpret_cast<unsigned short*>(&new_val)) !=
+            *reinterpret_cast<unsigned short*>(&old_val));
+    return old_val;
 }
 
 template <>

--- a/include/ck/utility/generic_memory_space_atomic.hpp
+++ b/include/ck/utility/generic_memory_space_atomic.hpp
@@ -33,6 +33,14 @@ __device__ float atomic_add<float>(float* p_dst, const float& x)
 }
 
 template <>
+__device__ unsigned short atomic_add<unsigned short>(unsigned short* p_dst, const unsigned short& x)
+{
+    // Use atomicAdd with unsigned int
+    return static_cast<unsigned short>(
+        atomicAdd(reinterpret_cast<unsigned int*>(p_dst), static_cast<unsigned int>(x)));
+}
+
+template <>
 __device__ _Float16 atomic_add<_Float16>(_Float16* p_dst, const _Float16& x)
 {
     // Use atomicAdd with unsigned int

--- a/library/include/ck/library/tensor_operation_instance/gpu/gemm_universal_preshuffle.inc
+++ b/library/include/ck/library/tensor_operation_instance/gpu/gemm_universal_preshuffle.inc
@@ -10,27 +10,11 @@ namespace instance {
 
 #if(defined(CK_ENABLE_BF16) && defined(CK_ENABLE_FP8))
 
-using GemmF8F8BF16InstanceVector =
-    std::vector<std::unique_ptr<DeviceGemmV2BPreshuffle<Row,
-                                                        Col,
-                                                        Row,
-                                                        F8,
-                                                        F8,
-                                                        BF16,
-                                                        PassThrough,
-                                                        PassThrough,
-                                                        PassThrough>>>&;
+using GemmF8F8BF16InstanceVector = std::vector<std::unique_ptr<
+    DeviceGemmV2BPreshuffle<Row, Col, Row, F8, F8, BF16, PassThrough, PassThrough, PassThrough>>>&;
 
-using GemmF8F8F16InstanceVector =
-    std::vector<std::unique_ptr<DeviceGemmV2BPreshuffle<Row,
-                                                        Col,
-                                                        Row,
-                                                        F8,
-                                                        F8,
-                                                        F16,
-                                                        PassThrough,
-                                                        PassThrough,
-                                                        PassThrough>>>&;
+using GemmF8F8F16InstanceVector = std::vector<std::unique_ptr<
+    DeviceGemmV2BPreshuffle<Row, Col, Row, F8, F8, F16, PassThrough, PassThrough, PassThrough>>>&;
 
 void add_device_gemm_xdl_universal_preshuffle_f8_f8_bf16_mk_mfma32x32_mn_instances(
     GemmF8F8BF16InstanceVector& instances);
@@ -48,7 +32,7 @@ void add_device_gemm_xdl_universal_preshuffle_f8_f8_bf16_mk_mfma_mn_p3_instances
     GemmF8F8BF16InstanceVector& instances);
 
 void add_device_gemm_xdl_universal_preshuffle_f8_f8_bf16_mk_mfma_mn_p4_instances(
-        GemmF8F8BF16InstanceVector& instances);
+    GemmF8F8BF16InstanceVector& instances);
 void add_device_gemm_xdl_universal_preshuffle_f8_f8_bf16_mk_mfma_mn_p5_instances(
     GemmF8F8BF16InstanceVector& instances);
 
@@ -84,7 +68,7 @@ void add_device_gemm_universal_preshuffle_xdl_f8_f8_f16_mk_mfma_mn_compute_defau
     GemmF8F8F16InstanceVector& instances);
 
 void add_device_gemm_universal_preshuffle_xdl_f8_f8_f16_mk_mfma_mn_p1_default_instances(
-        GemmF8F8F16InstanceVector& instances);
+    GemmF8F8F16InstanceVector& instances);
 void add_device_gemm_universal_preshuffle_xdl_f8_f8_f16_mk_mfma_mn_p2_default_instances(
     GemmF8F8F16InstanceVector& instances);
 void add_device_gemm_universal_preshuffle_xdl_f8_f8_f16_mk_mfma_mn_p3_default_instances(


### PR DESCRIPTION
## Proposed changes

These changes should fix a couple of linker errors for FBGEMM library when using CK as backend:

lld: error: undefined hidden symbol: unsigned short ck::atomic_add<unsigned short>(unsigned short*, unsigned short const&)
lld: error: undefined hidden symbol: _Float16 ck::atomic_add<_Float16>(_Float16*, _Float16 const&)

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged


