### PR TITLE
[CK_TILE] Avoid compile kernel in host pass

### DIFF
--- a/include/ck_tile/host/kernel_launch.hpp
+++ b/include/ck_tile/host/kernel_launch.hpp
@@ -4,11 +4,12 @@
 #pragma once
 
 #include "ck_tile/core/config.hpp"
-#include "ck_tile/host/stream_config.hpp"
+#include "ck_tile/core/utility/ignore.hpp"
 #include "ck_tile/host/hip_check_error.hpp"
+#include "ck_tile/host/stream_config.hpp"
 #include "ck_tile/host/timer.hpp"
-#include <hip/hip_runtime.h>
 #include <cstddef>
+#include <hip/hip_runtime.h>
 
 namespace ck_tile {
 
@@ -24,7 +25,11 @@ __launch_bounds__(MaxThreadPerBlock, MinBlockPerCu)
 #endif
     __global__ void kentry(Args... args)
 {
+#if defined(__HIP_DEVICE_COMPILE__)
     Kernel{}(args...);
+#else
+    (..., (ignore = args, 0));
+#endif
 }
 
 //


### PR DESCRIPTION
## Proposed changes

Avoid compiler kernel functions in host pass (i.e. `__HIP_DEVICE_COMPILE__` undefined), benefiting
1. speedups compilation up to 50% in theory (usually 5% - 30%, e.g.1 42s->30s , e.g.2 10m30s->9m45s)
2. Avoid unexpected static assertion error (i.e. developers no longer need to won't worry that none of gfx identifier (e.g. \_\_gfx950\_\_) is defined). Solving problem like the below example:
   ```c++
   inline __device__ void f()
   #if defined(__950__)
     static_assert(something_only_true_on_gfx950);
   #else
     static_assert(something_only_true_before_gfx950);
     // 👆failed even if GPU_TARGETS=gfx950 is set
   #endif
   ```

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

