### PR TITLE
[FIX] BWD grouped convolution weight returns incorrect results for Filter1x1Stride1Pad0 when K or C is even.

### DIFF
--- a/include/ck/ck.hpp
+++ b/include/ck/ck.hpp
@@ -222,9 +222,6 @@
 // TODO: separate index calculation into "compile-time", "global", "block", "wave", "thread"
 #define CK_HACK_MERGE_CALCULATE_IDX_DIFF_LOW_CONST_USE_AMD_GCN_READ_FIRST_LANE 0
 
-// workaround: conv crash when K, C is even
-#define CK_WORKAROUND_DISABLE_FILTER1x1STRIDE1PAD0_WHEN_K_C_IS_EVEN 1
-
 // workaround: compiler crash when compiling recursive lambda
 #define CK_WORKAROUND_SWDEV_275126 1
 

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle_v3.hpp
@@ -1222,13 +1222,6 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
         if constexpr(ConvBackwardWeightSpecialization ==
                      ConvolutionBackwardWeightSpecialization::Filter1x1Stride1Pad0)
         {
-// workaround: disable when K, C is even
-#if CK_WORKAROUND_DISABLE_FILTER1x1STRIDE1PAD0_WHEN_K_C_IS_EVEN
-            if(arg.Conv_C_ % 2 == 0 || arg.Conv_K_ % 2 == 0)
-            {
-                return false;
-            }
-#endif
             // check if it's 1x1, stride=1 pad = 0 conv
             for(int i = 0; i < NDimSpatial; i++)
             {

--- a/include/ck/tensor_operation/operator_transform/transform_conv_bwd_weight_to_gemm_v2.hpp
+++ b/include/ck/tensor_operation/operator_transform/transform_conv_bwd_weight_to_gemm_v2.hpp
@@ -174,8 +174,14 @@ struct TransformConvBwdWeightToGemmV2
     {
         const auto CStride     = Number<1>{};
         const auto KStride     = weights_strides[1];
-        const auto XStride     = weights_strides[4];
         const auto BatchStride = weights_strides[0];
+        auto XStride           = weights_strides[4];
+
+        if constexpr(ConvBackwardWeightSpecialization ==
+                     device::ConvolutionBackwardWeightSpecialization::Filter1x1Stride1Pad0)
+        {
+            XStride = GemmK1Number * K;
+        }
         // Add NumGroupsToMerge for Batch+M dimension and, 1 as a placehorder
         // for Batch+N dimension
         const auto desc = make_naive_tensor_descriptor(
@@ -270,8 +276,14 @@ struct TransformConvBwdWeightToGemmV2
     {
         const auto CStride     = Number<1>{};
         const auto KStride     = weights_strides[1];
-        const auto XStride     = weights_strides[5];
         const auto BatchStride = weights_strides[0];
+        auto XStride           = weights_strides[5];
+
+        if constexpr(ConvBackwardWeightSpecialization ==
+                     device::ConvolutionBackwardWeightSpecialization::Filter1x1Stride1Pad0)
+        {
+            XStride = GemmK1Number * K;
+        }
         // Add NumGroupsToMerge for Batch+M dimension and, 1 for placehord for Batch+N dimension
         const auto desc = make_naive_tensor_descriptor(
             make_tuple(NumGroupsToMerge, K, Z * Y * X, 1, C),

--- a/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight.cpp
+++ b/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight.cpp
@@ -176,6 +176,8 @@ TYPED_TEST_SUITE(TestGroupedConvndBwdWeight3d, KernelTypes3d);
 TYPED_TEST(TestGroupedConvndBwdWeight1d, Test1D)
 {
     this->conv_params.clear();
+    this->conv_params.push_back({1, 2, 64, 4, 4, {1}, {7}, {1}, {1}, {0}, {0}});
+    this->conv_params.push_back({1, 1, 1, 4, 4, {1}, {4}, {1}, {1}, {0}, {0}});
     this->conv_params.push_back({1, 2, 128, 128, 256, {1}, {14}, {2}, {1}, {0}, {0}});
     this->conv_params.push_back({1, 2, 32, 128, 256, {3}, {28}, {1}, {1}, {1}, {1}});
     this->conv_params.push_back({1, 2, 128, 128, 256, {1}, {3}, {1}, {1}, {0}, {0}});
@@ -188,6 +190,7 @@ TYPED_TEST(TestGroupedConvndBwdWeight1d, Test1D)
 TYPED_TEST(TestGroupedConvndBwdWeight2d, Test2D)
 {
     this->conv_params.clear();
+    this->conv_params.push_back({2, 1, 1, 4, 4, {1, 1}, {4, 4}, {1, 1}, {1, 1}, {0, 0}, {0, 0}});
     this->conv_params.push_back({2, 2, 64, 4, 4, {1, 1}, {7, 7}, {1, 1}, {1, 1}, {0, 0}, {0, 0}});
     this->conv_params.push_back(
         {2, 2, 64, 128, 256, {1, 1}, {7, 7}, {2, 2}, {1, 1}, {0, 0}, {0, 0}});
@@ -208,6 +211,10 @@ TYPED_TEST(TestGroupedConvndBwdWeight2d, Test2D)
 TYPED_TEST(TestGroupedConvndBwdWeight3d, Test3D)
 {
     this->conv_params.clear();
+    this->conv_params.push_back(
+        {3, 2, 64, 4, 4, {1, 1, 1}, {7, 7, 7}, {1, 1, 1}, {1, 1, 1}, {0, 0, 0}, {0, 0, 0}});
+    this->conv_params.push_back(
+        {3, 1, 1, 4, 4, {1, 1, 1}, {4, 4, 4}, {1, 1, 1}, {1, 1, 1}, {0, 0, 0}, {0, 0, 0}});
     this->conv_params.push_back(
         {3, 2, 16, 128, 256, {1, 1, 1}, {7, 7, 7}, {2, 2, 2}, {1, 1, 1}, {0, 0, 0}, {0, 0, 0}});
     this->conv_params.push_back(


### PR DESCRIPTION
## Proposed changes

The conv BWD with universal GEMM kernel returns incorrect results when K or C are even. This pull request includes a simple extends stride for weight N=2, N=3.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

