### PR TITLE
Fixes in build script for its usage with Tile Engine

### DIFF
--- a/script/cmake-ck-dev.sh
+++ b/script/cmake-ck-dev.sh
@@ -5,13 +5,16 @@ rm -rf CMakeFiles
 
 MY_PROJECT_SOURCE=$1
 
-if [ $# -ge 2 ] ; then
+if [ $# -ge 2 ] && [[ "$2" =~ ^gfx ]]; then
     GPU_TARGETS=$2
     shift 2
+    echo "GPU targets provided: $GPU_TARGETS"
     REST_ARGS=$@
 else
+    echo "No GPU targets provided, using default targets: gfx908;gfx90a;gfx942"
     GPU_TARGETS="gfx908;gfx90a;gfx942"
-    REST_ARGS=
+    shift 1
+    REST_ARGS=$@
 fi
 
 cmake                                                                                             \

--- a/script/cmake-ck-release.sh
+++ b/script/cmake-ck-release.sh
@@ -5,13 +5,16 @@ rm -rf CMakeFiles
 
 MY_PROJECT_SOURCE=$1
 
-if [ $# -ge 2 ] ; then
+if [ $# -ge 2 ] && [[ "$2" =~ ^gfx ]]; then
     GPU_TARGETS=$2
     shift 2
+    echo "GPU targets provided: $GPU_TARGETS"
     REST_ARGS=$@
 else
+    echo "No GPU targets provided, using default targets: gfx908;gfx90a;gfx942"
     GPU_TARGETS="gfx908;gfx90a;gfx942"
-    REST_ARGS=
+    shift 1
+    REST_ARGS=$@
 fi
 
 cmake                                                                                             \

--- a/tile_engine/ops/gemm/CMakeLists.txt
+++ b/tile_engine/ops/gemm/CMakeLists.txt
@@ -5,14 +5,15 @@ set(GEMM_LAYOUT "rcr" CACHE STRING "List of layout for GEMM (semicolon-separated
 function(build_gemm_for_datatype datatype layout)
     set(working_path "${CMAKE_CURRENT_BINARY_DIR}/${datatype}/${layout}")
 
-    #Comment this if-else block when using user_provided_config
+    # Comment this if-else block when using user_provided_config
     if(layout STREQUAL "rcr")
         set(json_blob "${CMAKE_CURRENT_LIST_DIR}/configs/default_config.json")
     else()
         set(json_blob "${CMAKE_CURRENT_LIST_DIR}/configs/custom_ci_config.json")
     endif()
 
-    #set(json_blob "${CMAKE_CURRENT_LIST_DIR}/configs/user_provided_config.json")
+    # uncomment this if you want to use user_provided_config.json
+    # set(json_blob "${CMAKE_CURRENT_LIST_DIR}/configs/user_provided_config.json")
     
     # Generate kernel list
     execute_process(

--- a/tile_engine/ops/gemm/gemm_instance_builder.py
+++ b/tile_engine/ops/gemm/gemm_instance_builder.py
@@ -98,19 +98,19 @@ class GemmCodeGenerator:
                         _,
                     ) in tile:
                         instance_name = f"gemm_{trait}_{tile_m}x{tile_n}x{tile_k}_{warp_m}x{warp_n}x{warp_k}.cpp"
-                        
+
                         if instance_name not in file_name:
                             file_name.add(instance_name)
                             f.write(str(w_p / instance_name) + "\n")
                             files_listed += 1
 
                 file_range_map[trait] = (start_idx, files_listed)
-        
-        file_path = w_p / 'gemm_instance_blobs_range.txt'
-        with  file_path.open('w') as f:
+
+        file_path = w_p / "gemm_instance_blobs_range.txt"
+        with file_path.open("w") as f:
             for name, ranges in file_range_map.items():
                 s, l = ranges
-                f.write(name + " " + f"{s}" + " " + f"{l}"+ "\n")
+                f.write(name + " " + f"{s}" + " " + f"{l}" + "\n")
 
     def _generate_all_traits(self):
         """Generate all possible kernel traits names."""
@@ -563,7 +563,7 @@ struct GemmKernel {{
             self.valid_trait_tile_combinations[trait].append(tile_valid_params)
 
     def _generate_instantiation_source_files(self):
-        """Generate kernel instance instantiation source files """
+        """Generate kernel instance instantiation source files"""
         tile_map = {}
         for trait, tile_valid_params in self.valid_trait_tile_combinations.items():
             for tile in tile_valid_params:
@@ -583,11 +583,13 @@ struct GemmKernel {{
                     if key not in tile_map:
                         tile_map[key] = set()
                     tile_map[key].add(value)
-       
+
         files_listed = 0
         for trait, _ in self.valid_trait_tile_combinations.items():
             for block_tile, warp_tiles in tile_map.items():
-                tile_m, tile_n, tile_k, warp_m, warp_n, warp_k = map(int, block_tile.split('x'))
+                tile_m, tile_n, tile_k, warp_m, warp_n, warp_k = map(
+                    int, block_tile.split("x")
+                )
 
                 content = f"""
 // SPDX-License-Identifier: MIT
@@ -598,8 +600,10 @@ struct GemmKernel {{
 
 """
                 for warp_tile in warp_tiles:
-                    warp_tile_m, warp_tile_n, warp_tile_k = map(int, warp_tile.split("x"))
-                    
+                    warp_tile_m, warp_tile_n, warp_tile_k = map(
+                        int, warp_tile.split("x")
+                    )
+
                     sparse = (
                         self.config.problem.datatype_map["matrix_a"] == "fp16"
                         and self.config.problem.datatype_map["matrix_b"] == "fp16"
@@ -619,15 +623,23 @@ struct GemmKernel {{
                     )
                     if sparse:
                         files_listed = files_listed + 1
-                        content = content + f"""
+                        content = (
+                            content
+                            + f"""
 template struct {trait}::GemmKernel<{tile_m}, {tile_n}, {tile_k}, {warp_m}, {warp_n}, {warp_k}, {warp_tile_m}, {warp_tile_n}, {warp_tile_k}, true>;"""
+                        )
                     files_listed = files_listed + 1
-                    content = content + f"""
+                    content = (
+                        content
+                        + f"""
 template struct {trait}::GemmKernel<{tile_m}, {tile_n}, {tile_k}, {warp_m}, {warp_n}, {warp_k}, {warp_tile_m}, {warp_tile_n}, {warp_tile_k}, false>;"""
+                    )
                 content += f"""
 """
-                (self.output_dir /
-                    f"gemm_{trait}_{tile_m}x{tile_n}x{tile_k}_{warp_m}x{warp_n}x{warp_k}.cpp").write_text(content)
+                (
+                    self.output_dir
+                    / f"gemm_{trait}_{tile_m}x{tile_n}x{tile_k}_{warp_m}x{warp_n}x{warp_k}.cpp"
+                ).write_text(content)
         print(f"Generated {files_listed} kernel instances in total.")
 
     def _generate_dispatcher_file(self):
@@ -823,13 +835,13 @@ if __name__ == "__main__":
         "-d",
         "--datatype",
         required=True,
-        help="Specify what datatype to use for the kernel generation, e.g. fp16, bf16, int8, fp8, bf8"
+        help="Specify what datatype to use for the kernel generation, e.g. fp16, bf16, int8, fp8, bf8",
     )
     parser.add_argument(
         "-ly",
         "--layout",
         required=True,
-        help="Specify what layout to use for the kernel generation, e.g. rcr, rrr"
+        help="Specify what layout to use for the kernel generation, e.g. rcr, rrr",
     )
     parser.add_argument(
         "-l",

--- a/tile_engine/ops/gemm/json_config.py
+++ b/tile_engine/ops/gemm/json_config.py
@@ -118,7 +118,9 @@ class GemmConfig:
     trait_config: TraitConfig
 
     @classmethod
-    def from_json(cls: Type["GemmConfig"], filepath: str, datatype: str, layout: str) -> "GemmConfig":
+    def from_json(
+        cls: Type["GemmConfig"], filepath: str, datatype: str, layout: str
+    ) -> "GemmConfig":
         """JSON configuration loader with validation controls"""
         config_path = Path(filepath)
 
@@ -132,41 +134,40 @@ class GemmConfig:
             a_type = datatype
             b_type = datatype
             c_type = datatype
-            if b_type == 'int4':
+            if b_type == "int4":
                 a_type = "fp16"
-            if b_type in ['bf8', 'fp8', 'int4']:
+            if b_type in ["bf8", "fp8", "int4"]:
                 c_type = "fp16"
 
             layout_parts = layout.lower()
-            assert len(layout_parts) == 3, f"Invalid layout string: {layout} (must be 3 characters like 'rcr' where r stands for row major and c stands for column major)"
-            assert layout_parts[0] in ("r", "c"), f"Invalid matrix_a layout: {layout_parts[0]} (must be 'r' for row major or or 'c' for column major)"
-            assert layout_parts[1] in ("r", "c"), f"Invalid matrix_a layout: {layout_parts[1]} (must be 'r' for row major or or 'c' for column major)"
-            assert layout_parts[2] == "r", f"Invalid matrix_c layout: {layout_parts[2]} (must be 'r' only as currently we are supporting only row major)"
+            assert len(layout_parts) == 3, (
+                f"Invalid layout string: {layout} (must be 3 characters like 'rcr' where r stands for row major and c stands for column major)"
+            )
+            assert layout_parts[0] in ("r", "c"), (
+                f"Invalid matrix_a layout: {layout_parts[0]} (must be 'r' for row major or or 'c' for column major)"
+            )
+            assert layout_parts[1] in ("r", "c"), (
+                f"Invalid matrix_a layout: {layout_parts[1]} (must be 'r' for row major or or 'c' for column major)"
+            )
+            assert layout_parts[2] == "r", (
+                f"Invalid matrix_c layout: {layout_parts[2]} (must be 'r' only as currently we are supporting only row major)"
+            )
             a_layout = layout_parts[0]
             b_layout = layout_parts[1]
             c_layout = layout_parts[2]
 
             # Parse problem config
-            #TODO: Not reading datatype information from json file.
+            # TODO: Not reading datatype information from json file.
             problem = ProblemConfig(
                 datatypes=(
-                    EnumConfigParam(
-                        values=[a_type]),
-                    EnumConfigParam(
-                        values=[b_type]),
-                    EnumConfigParam(
-                        values=[c_type])
+                    EnumConfigParam(values=[a_type]),
+                    EnumConfigParam(values=[b_type]),
+                    EnumConfigParam(values=[c_type]),
                 ),
                 layouts=(
-                    EnumConfigParam(
-                        values=[a_layout]
-                    ),
-                    EnumConfigParam(
-                        values=[b_layout]
-                    ),
-                    EnumConfigParam(
-                        values=[c_layout]
-                    ),
+                    EnumConfigParam(values=[a_layout]),
+                    EnumConfigParam(values=[b_layout]),
+                    EnumConfigParam(values=[c_layout]),
                 ),
             )
 


### PR DESCRIPTION
## Proposed changes

1. This PR fixes problem with `script/cmake-ck-dev.sh` when used with tile_engine. 
If no gpu architecture was specified, the script would set DATATYPE or DATALAYOUT values intended for tile engine as gpu architecture.

2. same with `script/cmake-ck-release.sh`
3. ruff formatting for python files and add a comment in CMakeLists.txt


## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

