### PR TITLE
Add separate mask checking for scope [aligned_physical_seqlen_k_start, physical_seqlen_k_end)

### DIFF
--- a/include/ck_tile/ops/fmha/kernel/fmha_fwd_pagedkv_kernel.hpp
+++ b/include/ck_tile/ops/fmha/kernel/fmha_fwd_pagedkv_kernel.hpp
@@ -1122,7 +1122,8 @@ struct FmhaFwdPagedKVKernel
                     const index_t num_blocks =
                         integer_divide_ceil(kv_l2p_offset + kargs.seqlen_k, kargs.page_block_size);
 
-                    const long_index_t fixed_offset = i_nhead_ * kargs.nhead_stride_k;
+                    const long_index_t fixed_offset =
+                        static_cast<long_index_t>(i_nhead_) * kargs.nhead_stride_k;
 
                     return make_page_block_navigator<const KDataType, 0>(
                         kargs.k_ptr,
@@ -1152,7 +1153,8 @@ struct FmhaFwdPagedKVKernel
                     const index_t num_blocks =
                         integer_divide_ceil(kv_l2p_offset + kargs.seqlen_k, kargs.page_block_size);
 
-                    const long_index_t fixed_offset = i_nhead_ * kargs.nhead_stride_v;
+                    const long_index_t fixed_offset =
+                        static_cast<long_index_t>(i_nhead_) * kargs.nhead_stride_v;
 
                     return make_page_block_navigator<const VDataType, 1>(
                         kargs.v_ptr,


### PR DESCRIPTION
In the case where `PagedKV` is enabled, and `IsGappy` used, the columns in scope of `[aligned_physical_seqlen_k_start, physical_seqlen_k_end)` should be checked for masking


This fixing can be verified by xformers  branch `ck_tile/kvcache_prefill` (enabling support of `is_gappy` in `grouped_infer_pagedkv` path)

`#> pytest tests/test_mem_eff_attention.py::test_forward -k "not triton"`


