### PR TITLE
Automatic deduction of split-K value for grouped convolution

### DIFF
--- a/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_multiple_d_xdl_cshuffle_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_multiple_d_xdl_cshuffle_v3.hpp
@@ -364,11 +364,11 @@ struct DeviceBatchedGemmMultiD_Xdl_CShuffle_V3
                 hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
                     &max_occupancy,
                     kernel_batched_gemm_xdl_cshuffle_v3_multi_d_2lds<
-                                GridwiseGemm,
-                                Argument,
-                                true,
-                                InMemoryDataOperationEnum::AtomicAdd,
-                                minimum_occupancy>,
+                        GridwiseGemm,
+                        Argument,
+                        true,
+                        InMemoryDataOperationEnum::AtomicAdd,
+                        minimum_occupancy>,
                     BlockSize,
                     dynamic_smem_size));
             }
@@ -377,11 +377,11 @@ struct DeviceBatchedGemmMultiD_Xdl_CShuffle_V3
                 hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
                     &max_occupancy,
                     kernel_batched_gemm_xdl_cshuffle_v3_multi_d<
-                                    GridwiseGemm,
-                                    Argument,
-                                    true,
-                                    InMemoryDataOperationEnum::AtomicAdd,
-                                    minimum_occupancy>,
+                        GridwiseGemm,
+                        Argument,
+                        true,
+                        InMemoryDataOperationEnum::AtomicAdd,
+                        minimum_occupancy>,
                     BlockSize,
                     dynamic_smem_size));
             }

--- a/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_multiple_d_xdl_cshuffle_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_multiple_d_xdl_cshuffle_v3.hpp
@@ -337,6 +337,60 @@ struct DeviceBatchedGemmMultiD_Xdl_CShuffle_V3
         }
     };
 
+    struct ActiveWorkgroupsPerCU
+    {
+        ActiveWorkgroupsPerCU()
+        {
+            constexpr int dynamic_smem_size = 0;
+            int max_occupancy               = 0;
+
+            constexpr index_t minimum_occupancy = []() {
+                if constexpr(BlkGemmPipeSched == BlockGemmPipelineScheduler::Interwave)
+                {
+                    return 2;
+                }
+                else if constexpr(BlkGemmPipelineVer == BlockGemmPipelineVersion::v3)
+                {
+                    return (MPerBlock * NPerBlock / BlockSize <= 128) ? 2 : 1;
+                }
+                else
+                {
+                    return 1;
+                }
+            }();
+
+            if constexpr(BlkGemmPipelineVer == BlockGemmPipelineVersion::v4)
+            {
+                hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+                    &max_occupancy,
+                    kernel_batched_gemm_xdl_cshuffle_v3_multi_d_2lds<
+                                GridwiseGemm,
+                                Argument,
+                                true,
+                                InMemoryDataOperationEnum::AtomicAdd,
+                                minimum_occupancy>,
+                    BlockSize,
+                    dynamic_smem_size));
+            }
+            else
+            {
+                hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+                    &max_occupancy,
+                    kernel_batched_gemm_xdl_cshuffle_v3_multi_d<
+                                    GridwiseGemm,
+                                    Argument,
+                                    true,
+                                    InMemoryDataOperationEnum::AtomicAdd,
+                                    minimum_occupancy>,
+                    BlockSize,
+                    dynamic_smem_size));
+            }
+
+            max_occupancy_ = std::max(1, max_occupancy);
+        }
+        int max_occupancy_;
+    };
+
     // Invoker
     struct Invoker : public BaseInvoker
     {
@@ -1043,6 +1097,12 @@ struct DeviceBatchedGemmMultiD_Xdl_CShuffle_V3
         // clang-format on
 
         return str.str();
+    }
+
+    static ck::index_t GetMaxOccupancy()
+    {
+        static ActiveWorkgroupsPerCU active_workgroups_per_cu;
+        return active_workgroups_per_cu.max_occupancy_;
     }
 };
 

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_explicit_xdl.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_explicit_xdl.hpp
@@ -144,7 +144,7 @@ struct DeviceGroupedConvBwdWeight_Explicit_Xdl
                       end(e_g_k_c_xs_lengths),
                       begin(filter_spatial_lengths_));
 
-            if (split_k < 0)
+            if(split_k < 0)
             {
                 const auto max_occupancy = DeviceGemmV3Op::GetMaxOccupancy();
                 index_t gdx, gdy, gdz;
@@ -153,7 +153,8 @@ struct DeviceGroupedConvBwdWeight_Explicit_Xdl
                 const index_t grid_size = gdx * gdy * gdz;
                 split_k_ = get_best_occupancy_k_batch_value(max_occupancy, grid_size);
             }
-            else {
+            else
+            {
                 split_k_ = split_k;
             }
 

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_explicit_xdl.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_explicit_xdl.hpp
@@ -306,6 +306,9 @@ struct DeviceGroupedConvBwdWeight_Explicit_Xdl
         if (arg.split_k_ < 0)
         {
             // TODO: Add split-K autodeduction. 
+            // This will probably require adding interface to the GEMM operation for 
+            // querying the optimal split-K value, as we cannot easily access the actual GEMM kernel 
+            // from here.
             return false;
         }
 

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_explicit_xdl.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_explicit_xdl.hpp
@@ -13,6 +13,8 @@
 #include "ck/tensor_operation/gpu/device/impl/device_grouped_conv_utils.hpp"
 #include "ck/tensor_operation/gpu/grid/gridwise_elementwise_2d.hpp"
 #include <ck/tensor_operation/gpu/grid/block_to_ctile_map.hpp>
+#include "ck/tensor_operation/gpu/device/impl/split_k_utils.hpp"
+#include "ck/tensor_operation/gpu/device/impl/split_k_arg.hpp"
 
 namespace ck {
 namespace tensor_operation {
@@ -118,8 +120,7 @@ struct DeviceGroupedConvBwdWeight_Explicit_Xdl
               conv_filter_strides_{conv_filter_strides},
               input_left_pads_{input_left_pads},
               input_right_pads_{input_right_pads},
-              p_wei_grid_{p_wei_grid},
-              split_k_{split_k}
+              p_wei_grid_{p_wei_grid}
         {
             constexpr index_t spatial_offset = 3;
             const index_t DoHoWo = std::accumulate(begin(a_g_n_k_wos_lengths) + spatial_offset,
@@ -142,6 +143,19 @@ struct DeviceGroupedConvBwdWeight_Explicit_Xdl
             std::copy(begin(e_g_k_c_xs_lengths) + spatial_offset,
                       end(e_g_k_c_xs_lengths),
                       begin(filter_spatial_lengths_));
+
+            if (split_k < 0)
+            {
+                const auto max_occupancy = DeviceGemmV3Op::GetMaxOccupancy();
+                index_t gdx, gdy, gdz;
+                std::tie(gdx, gdy, gdz) =
+                    DeviceGemmV3Op::GridwiseGemm::CalculateGridSize(M, N, BatchSize);
+                const index_t grid_size = gdx * gdy * gdz;
+                split_k_ = get_best_occupancy_k_batch_value(max_occupancy, grid_size);
+            }
+            else {
+                split_k_ = split_k;
+            }
 
             if constexpr(IsTwoStageNeeded)
             {
@@ -237,7 +251,7 @@ struct DeviceGroupedConvBwdWeight_Explicit_Xdl
         bool is_filter_data_packed;
         CElementwiseGridDesc elementwise_desc_;
         Block2TileMapElementwise elementwise_block_2_ctile_map_;
-        const ck::index_t split_k_;
+        ck::index_t split_k_;
     };
 
     // Invoker
@@ -303,15 +317,6 @@ struct DeviceGroupedConvBwdWeight_Explicit_Xdl
 
     static bool IsSupportedArgument(const Argument& arg)
     {
-        if(arg.split_k_ < 0)
-        {
-            // TODO: Add split-K autodeduction.
-            // This will probably require adding interface to the GEMM operation for
-            // querying the optimal split-K value, as we cannot easily access the actual GEMM kernel
-            // from here.
-            return false;
-        }
-
         if constexpr(NDimSpatial == 2)
         {
             if constexpr(!is_NHWGC_GKYXC_NHWGK<InLayout, WeiLayout, OutLayout>())

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_explicit_xdl.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_explicit_xdl.hpp
@@ -303,11 +303,11 @@ struct DeviceGroupedConvBwdWeight_Explicit_Xdl
 
     static bool IsSupportedArgument(const Argument& arg)
     {
-        if (arg.split_k_ < 0)
+        if(arg.split_k_ < 0)
         {
-            // TODO: Add split-K autodeduction. 
-            // This will probably require adding interface to the GEMM operation for 
-            // querying the optimal split-K value, as we cannot easily access the actual GEMM kernel 
+            // TODO: Add split-K autodeduction.
+            // This will probably require adding interface to the GEMM operation for
+            // querying the optimal split-K value, as we cannot easily access the actual GEMM kernel
             // from here.
             return false;
         }

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_explicit_xdl.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_explicit_xdl.hpp
@@ -118,7 +118,8 @@ struct DeviceGroupedConvBwdWeight_Explicit_Xdl
               conv_filter_strides_{conv_filter_strides},
               input_left_pads_{input_left_pads},
               input_right_pads_{input_right_pads},
-              p_wei_grid_{p_wei_grid}
+              p_wei_grid_{p_wei_grid},
+              split_k_{split_k}
         {
             constexpr index_t spatial_offset = 3;
             const index_t DoHoWo = std::accumulate(begin(a_g_n_k_wos_lengths) + spatial_offset,
@@ -176,7 +177,7 @@ struct DeviceGroupedConvBwdWeight_Explicit_Xdl
                                                   out_element_op,
                                                   in_element_op,
                                                   wei_element_op,
-                                                  split_k};
+                                                  split_k_};
             }
             else
             {
@@ -199,7 +200,7 @@ struct DeviceGroupedConvBwdWeight_Explicit_Xdl
                                                   out_element_op,
                                                   in_element_op,
                                                   wei_element_op,
-                                                  split_k};
+                                                  split_k_};
             }
         }
 
@@ -236,6 +237,7 @@ struct DeviceGroupedConvBwdWeight_Explicit_Xdl
         bool is_filter_data_packed;
         CElementwiseGridDesc elementwise_desc_;
         Block2TileMapElementwise elementwise_block_2_ctile_map_;
+        const ck::index_t split_k_;
     };
 
     // Invoker
@@ -301,6 +303,12 @@ struct DeviceGroupedConvBwdWeight_Explicit_Xdl
 
     static bool IsSupportedArgument(const Argument& arg)
     {
+        if (arg.split_k_ < 0)
+        {
+            // TODO: Add split-K autodeduction. 
+            return false;
+        }
+
         if constexpr(NDimSpatial == 2)
         {
             if constexpr(!is_NHWGC_GKYXC_NHWGK<InLayout, WeiLayout, OutLayout>())

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_multiple_d_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_multiple_d_xdl_cshuffle.hpp
@@ -19,6 +19,8 @@
 #include "ck/tensor_operation/gpu/grid/gridwise_gemm_xdlops_bwd_weight.hpp"
 #include <ck/tensor_operation/gpu/grid/block_to_ctile_map.hpp>
 #include "ck/tensor_operation/gpu/device/impl/device_grouped_conv_utils.hpp"
+#include "ck/tensor_operation/gpu/device/impl/split_k_utils.hpp"
+#include "ck/tensor_operation/gpu/device/impl/split_k_arg.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
 #include "ck/host_utility/device_prop.hpp"
@@ -543,7 +545,36 @@ struct DeviceGroupedConvBwdWeightMultipleD_Xdl_CShuffle
     using Block2CTileMap =
         decltype(GridwiseGemm::MakeCBlockClusterAdaptor(CGridDesc_M_N{}, 1, 1, 1));
 
-    struct Argument : public BaseArgument
+    struct MaximumActiveBlocksPerMultiprocessor
+    {
+        MaximumActiveBlocksPerMultiprocessor()
+        {
+            constexpr int dynamic_smem_size = 0;  
+            int max_occupancy = 0;
+            hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+                                &max_occupancy,
+                                kernel_batched_gemm_xdlops_bwd_weight<
+                                    GridwiseGemm,
+                                    ADataType,
+                                    BDataType,
+                                    AccDataType,
+                                    OutElementwiseOperation,
+                                    InElementwiseOperation,
+                                    element_wise::PassThrough,
+                                    remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
+                                    remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
+                                    remove_reference_t<DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
+                                    remove_reference_t<DeviceOp::Block2CTileMap>,
+                                    ComputePtrOffsetOfStridedBatch<I1, I1, NumDTensor>,
+                                    true>,
+                                BlockSize,
+                                dynamic_smem_size));
+            value_ = std::max(1, max_occupancy);
+        }
+        int value_;
+    };
+
+    struct Argument : public BaseArgument, public ArgumentSplitK
     {
         Argument(
             const InDataType* p_in_grid,
@@ -592,9 +623,10 @@ struct DeviceGroupedConvBwdWeightMultipleD_Xdl_CShuffle
               output_spatial_lengths_{},
               conv_filter_strides_{conv_filter_strides},
               input_left_pads_{input_left_pads},
-              input_right_pads_{input_right_pads},
-              k_batch_{split_k}
+              input_right_pads_{input_right_pads}
         {
+            static MaximumActiveBlocksPerMultiprocessor max_occupancy;
+
             c_space_size_bytes =
                 ck::accumulate_n<long_index_t>(
                     e_g_k_c_xs_lengths.begin(), NDimSpatial + I3, 1, std::multiplies<>()) *
@@ -610,6 +642,39 @@ struct DeviceGroupedConvBwdWeightMultipleD_Xdl_CShuffle
             std::copy(begin(a_g_n_k_wos_lengths) + spatial_offset,
                       end(a_g_n_k_wos_lengths),
                       begin(output_spatial_lengths_));
+
+            if (split_k < 0)
+            {
+                constexpr int k_batch_initial = 1;
+                const auto descs_initial =
+                        conv_to_gemm_transformer
+                            .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
+                                Conv_N_,
+                                Conv_K_,
+                                Conv_C_,
+                                input_spatial_lengths_,
+                                filter_spatial_lengths_,
+                                output_spatial_lengths_,
+                                b_g_n_c_wis_strides,
+                                e_g_k_c_xs_strides,
+                                a_g_n_k_wos_strides,
+                                conv_filter_strides,
+                                conv_filter_dilations,
+                                input_left_pads,
+                                input_right_pads,
+                                k_batch_initial);
+
+                const auto& ce_grid_desc_m_n = descs_initial[I2];
+                const auto& block_2_ctile_map =
+                    GridwiseGemm::MakeCBlockClusterAdaptor(ce_grid_desc_m_n, M01, N01, k_batch_initial);
+
+                const auto grid_size = block_2_ctile_map.CalculateGridSize(ce_grid_desc_m_n) * Conv_G_;
+                k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size);
+            }
+            else
+            {
+                k_batch_ = split_k;
+            }
 
             const auto descs =
                 conv_to_gemm_transformer
@@ -713,7 +778,6 @@ struct DeviceGroupedConvBwdWeightMultipleD_Xdl_CShuffle
         const std::array<ck::index_t, NDimSpatial>& conv_filter_strides_;
         const std::array<ck::index_t, NDimSpatial>& input_left_pads_;
         const std::array<ck::index_t, NDimSpatial>& input_right_pads_;
-        const index_t k_batch_;
         long_index_t c_space_size_bytes;
     };
 

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_multiple_d_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_multiple_d_xdl_cshuffle.hpp
@@ -549,26 +549,26 @@ struct DeviceGroupedConvBwdWeightMultipleD_Xdl_CShuffle
     {
         MaximumActiveBlocksPerMultiprocessor()
         {
-            constexpr int dynamic_smem_size = 0;  
-            int max_occupancy = 0;
+            constexpr int dynamic_smem_size = 0;
+            int max_occupancy               = 0;
             hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
-                                &max_occupancy,
-                                kernel_batched_gemm_xdlops_bwd_weight<
-                                    GridwiseGemm,
-                                    ADataType,
-                                    BDataType,
-                                    AccDataType,
-                                    OutElementwiseOperation,
-                                    InElementwiseOperation,
-                                    element_wise::PassThrough,
-                                    remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
-                                    remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
-                                    remove_reference_t<DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
-                                    remove_reference_t<DeviceOp::Block2CTileMap>,
-                                    ComputePtrOffsetOfStridedBatch<I1, I1, NumDTensor>,
-                                    true>,
-                                BlockSize,
-                                dynamic_smem_size));
+                &max_occupancy,
+                kernel_batched_gemm_xdlops_bwd_weight<
+                    GridwiseGemm,
+                    ADataType,
+                    BDataType,
+                    AccDataType,
+                    OutElementwiseOperation,
+                    InElementwiseOperation,
+                    element_wise::PassThrough,
+                    remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
+                    remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
+                    remove_reference_t<DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
+                    remove_reference_t<DeviceOp::Block2CTileMap>,
+                    ComputePtrOffsetOfStridedBatch<I1, I1, NumDTensor>,
+                    true>,
+                BlockSize,
+                dynamic_smem_size));
             value_ = std::max(1, max_occupancy);
         }
         int value_;
@@ -643,32 +643,33 @@ struct DeviceGroupedConvBwdWeightMultipleD_Xdl_CShuffle
                       end(a_g_n_k_wos_lengths),
                       begin(output_spatial_lengths_));
 
-            if (split_k < 0)
+            if(split_k < 0)
             {
                 constexpr int k_batch_initial = 1;
                 const auto descs_initial =
-                        conv_to_gemm_transformer
-                            .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
-                                Conv_N_,
-                                Conv_K_,
-                                Conv_C_,
-                                input_spatial_lengths_,
-                                filter_spatial_lengths_,
-                                output_spatial_lengths_,
-                                b_g_n_c_wis_strides,
-                                e_g_k_c_xs_strides,
-                                a_g_n_k_wos_strides,
-                                conv_filter_strides,
-                                conv_filter_dilations,
-                                input_left_pads,
-                                input_right_pads,
-                                k_batch_initial);
+                    conv_to_gemm_transformer
+                        .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
+                            Conv_N_,
+                            Conv_K_,
+                            Conv_C_,
+                            input_spatial_lengths_,
+                            filter_spatial_lengths_,
+                            output_spatial_lengths_,
+                            b_g_n_c_wis_strides,
+                            e_g_k_c_xs_strides,
+                            a_g_n_k_wos_strides,
+                            conv_filter_strides,
+                            conv_filter_dilations,
+                            input_left_pads,
+                            input_right_pads,
+                            k_batch_initial);
 
-                const auto& ce_grid_desc_m_n = descs_initial[I2];
-                const auto& block_2_ctile_map =
-                    GridwiseGemm::MakeCBlockClusterAdaptor(ce_grid_desc_m_n, M01, N01, k_batch_initial);
+                const auto& ce_grid_desc_m_n  = descs_initial[I2];
+                const auto& block_2_ctile_map = GridwiseGemm::MakeCBlockClusterAdaptor(
+                    ce_grid_desc_m_n, M01, N01, k_batch_initial);
 
-                const auto grid_size = block_2_ctile_map.CalculateGridSize(ce_grid_desc_m_n) * Conv_G_;
+                const auto grid_size =
+                    block_2_ctile_map.CalculateGridSize(ce_grid_desc_m_n) * Conv_G_;
                 k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size);
             }
             else

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_multiple_d_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_multiple_d_xdl_cshuffle.hpp
@@ -645,31 +645,12 @@ struct DeviceGroupedConvBwdWeightMultipleD_Xdl_CShuffle
 
             if(split_k < 0)
             {
-                constexpr int k_batch_initial = 1;
-                const auto descs_initial =
-                    conv_to_gemm_transformer
-                        .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
-                            Conv_N_,
-                            Conv_K_,
-                            Conv_C_,
-                            input_spatial_lengths_,
-                            filter_spatial_lengths_,
-                            output_spatial_lengths_,
-                            b_g_n_c_wis_strides,
-                            e_g_k_c_xs_strides,
-                            a_g_n_k_wos_strides,
-                            conv_filter_strides,
-                            conv_filter_dilations,
-                            input_left_pads,
-                            input_right_pads,
-                            k_batch_initial);
-
-                const auto& ce_grid_desc_m_n  = descs_initial[I2];
-                const auto& block_2_ctile_map = GridwiseGemm::MakeCBlockClusterAdaptor(
-                    ce_grid_desc_m_n, M01, N01, k_batch_initial);
+                ck::index_t gemmM, gemmN;
+                std::tie(gemmM, gemmN, std::ignore) =
+                    get_bwd_weight_gemm_sizes<NDimSpatial>(a_g_n_k_wos_lengths, e_g_k_c_xs_lengths);
 
                 const auto grid_size =
-                    block_2_ctile_map.CalculateGridSize(ce_grid_desc_m_n) * Conv_G_;
+                    calculate_mn_grid_size<MPerBlock, NPerBlock>(gemmM, gemmN) * Conv_G_;
                 k_batch_ = get_best_occupancy_k_batch_value(active_workgroups_per_cu.max_occupancy_,
                                                             grid_size);
             }

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_multiple_d_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_multiple_d_xdl_cshuffle.hpp
@@ -545,9 +545,9 @@ struct DeviceGroupedConvBwdWeightMultipleD_Xdl_CShuffle
     using Block2CTileMap =
         decltype(GridwiseGemm::MakeCBlockClusterAdaptor(CGridDesc_M_N{}, 1, 1, 1));
 
-    struct MaximumActiveBlocksPerMultiprocessor
+    struct ActiveWorkgroupsPerCU
     {
-        MaximumActiveBlocksPerMultiprocessor()
+        ActiveWorkgroupsPerCU()
         {
             constexpr int dynamic_smem_size = 0;
             int max_occupancy               = 0;
@@ -569,9 +569,9 @@ struct DeviceGroupedConvBwdWeightMultipleD_Xdl_CShuffle
                     true>,
                 BlockSize,
                 dynamic_smem_size));
-            value_ = std::max(1, max_occupancy);
+            max_occupancy_ = std::max(1, max_occupancy);
         }
-        int value_;
+        int max_occupancy_;
     };
 
     struct Argument : public BaseArgument, public ArgumentSplitK
@@ -625,7 +625,7 @@ struct DeviceGroupedConvBwdWeightMultipleD_Xdl_CShuffle
               input_left_pads_{input_left_pads},
               input_right_pads_{input_right_pads}
         {
-            static MaximumActiveBlocksPerMultiprocessor max_occupancy;
+            static ActiveWorkgroupsPerCU active_workgroups_per_cu;
 
             c_space_size_bytes =
                 ck::accumulate_n<long_index_t>(
@@ -670,7 +670,8 @@ struct DeviceGroupedConvBwdWeightMultipleD_Xdl_CShuffle
 
                 const auto grid_size =
                     block_2_ctile_map.CalculateGridSize(ce_grid_desc_m_n) * Conv_G_;
-                k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size);
+                k_batch_ = get_best_occupancy_k_batch_value(active_workgroups_per_cu.max_occupancy_,
+                                                            grid_size);
             }
             else
             {

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_xdl_cshuffle.hpp
@@ -629,41 +629,17 @@ struct DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle
 
             if(split_k < 0)
             {
-                constexpr int k_batch_initial = 1;
-                const auto descs_initial =
-                    conv_to_gemm_transformer_v2
-                        .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
-                            Conv_N_,
-                            Conv_K_,
-                            Conv_C_,
-                            input_spatial_lengths_,
-                            filter_spatial_lengths_,
-                            output_spatial_lengths_,
-                            b_g_n_c_wis_strides,
-                            e_g_k_c_xs_strides,
-                            a_g_n_k_wos_strides,
-                            conv_filter_strides,
-                            conv_filter_dilations,
-                            input_left_pads,
-                            input_right_pads,
-                            k_batch_initial);
+                ck::index_t gemmM, gemmN, gemmK;
+                std::tie(gemmM, gemmN, gemmK) =
+                    get_bwd_weight_gemm_sizes<NDimSpatial>(a_g_n_k_wos_lengths, e_g_k_c_xs_lengths);
 
-                const auto& a_grid_desc_kbatch_k0_m_k1 = descs_initial[I0];
-                const auto& b_grid_desc_kbatch_k0_n_k1 = descs_initial[I1];
-                const auto gemmM                       = a_grid_desc_kbatch_k0_m_k1.GetLength(I1);
-                const auto gemmN                       = b_grid_desc_kbatch_k0_n_k1.GetLength(I1);
-
-                const auto grid_size =
-                    GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN) * Conv_G_ /
-                    NumGroupsToMerge;
+                const auto grid_size = calculate_mn_grid_size<MPerBlock, NPerBlock>(gemmM, gemmN) *
+                                       Conv_G_ / NumGroupsToMerge;
                 k_batch_ = get_best_occupancy_k_batch_value(active_workgroups_per_cu.max_occupancy_,
                                                             grid_size);
 
                 // Ensure that k_batch_ does not exceed the maximum value
-                // for the GEMM pipeline
-                ck::index_t gemmK;
-                std::tie(std::ignore, std::ignore, gemmK) =
-                    get_bwd_weight_gemm_sizes<NDimSpatial>(a_g_n_k_wos_lengths, e_g_k_c_xs_lengths);
+                // for the GEMM pipeline.
                 const auto k_batch_max = static_cast<index_t>((gemmK - 1) / KPerBlock);
                 k_batch_               = std::min(k_batch_, k_batch_max);
 

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_xdl_cshuffle.hpp
@@ -655,8 +655,8 @@ struct DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle
                 const auto gemmM = a_grid_desc_kbatch_k0_m_k1.GetLength(I1);
                 const auto gemmN = b_grid_desc_kbatch_k0_n_k1.GetLength(I1);
 
-                const auto grid_size_mn = GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN);
-                k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size_mn, Conv_G_);
+                const auto grid_size = GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN) * Conv_G_;
+                k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size);
 
                 // Ensure that k_batch_ does not exceed the maximum value
                 // for the GEMM pipeline

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_xdl_cshuffle.hpp
@@ -506,9 +506,9 @@ struct DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle
         decltype(GridwiseGemm::MakeCGridDescriptor_MBlock_MPerBlock_NBlock_NPerBlock(
             CGridDesc_M_N{}, 1, 1));
 
-    struct MaximumActiveBlocksPerMultiprocessor
+    struct ActiveWorkgroupsPerCU
     {
-        MaximumActiveBlocksPerMultiprocessor()
+        ActiveWorkgroupsPerCU()
         {
             constexpr int dynamic_smem_size = 0;
             constexpr index_t minimum_occupancy =
@@ -549,9 +549,9 @@ struct DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle
                     BlockSize,
                     dynamic_smem_size));
             }
-            value_ = std::max(1, max_occupancy);
+            max_occupancy_ = std::max(1, max_occupancy);
         }
-        int value_;
+        int max_occupancy_;
     };
 
     struct Argument : public BaseArgument, public ArgumentSplitK
@@ -599,7 +599,7 @@ struct DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle
               input_left_pads_{input_left_pads},
               input_right_pads_{input_right_pads}
         {
-            static MaximumActiveBlocksPerMultiprocessor max_occupancy;
+            static ActiveWorkgroupsPerCU active_workgroups_per_cu;
 
             c_space_size_bytes =
                 ck::accumulate_n<long_index_t>(
@@ -656,7 +656,8 @@ struct DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle
                 const auto grid_size =
                     GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN) * Conv_G_ /
                     NumGroupsToMerge;
-                k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size);
+                k_batch_ = get_best_occupancy_k_batch_value(active_workgroups_per_cu.max_occupancy_,
+                                                            grid_size);
 
                 // Ensure that k_batch_ does not exceed the maximum value
                 // for the GEMM pipeline

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_xdl_cshuffle.hpp
@@ -22,6 +22,8 @@
 #include "ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_conv_v3.hpp"
 #include <ck/tensor_operation/gpu/grid/block_to_ctile_map.hpp>
 #include "ck/tensor_operation/gpu/device/impl/device_grouped_conv_utils.hpp"
+#include "ck/tensor_operation/gpu/device/impl/split_k_utils.hpp"
+#include "ck/tensor_operation/gpu/device/impl/split_k_arg.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
 #include "ck/host_utility/device_prop.hpp"
@@ -504,7 +506,57 @@ struct DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle
         decltype(GridwiseGemm::MakeCGridDescriptor_MBlock_MPerBlock_NBlock_NPerBlock(
             CGridDesc_M_N{}, 1, 1));
 
-    struct Argument : public BaseArgument
+    struct MaximumActiveBlocksPerMultiprocessor
+    {
+        MaximumActiveBlocksPerMultiprocessor()
+        {
+            constexpr int dynamic_smem_size = 0;
+            constexpr index_t minimum_occupancy =
+                BlkGemmPipeSched == BlockGemmPipelineScheduler::Intrawave ? 1 : 2;            
+            int max_occupancy = 0;
+
+            if constexpr(BlkGemmPipelineVer == BlockGemmPipelineVersion::v4)
+            {
+                hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+                                    &max_occupancy,
+                                    kernel_grouped_conv_bwd_weight_xdl_cshuffle_v3_2lds<
+                                        GridwiseGemm,
+                                        remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
+                                        remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
+                                        remove_reference_t<
+                                            DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
+                                        ComputePtrOffsetOfStridedBatch<I1, I1, I0>,
+                                        NumGroupsToMerge,
+                                        true,
+                                        InMemoryDataOperationEnum::AtomicAdd,
+                                        minimum_occupancy>,
+                                    BlockSize,
+                                    dynamic_smem_size));
+            }
+            else 
+            {
+                hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+                                    &max_occupancy,
+                                    kernel_grouped_conv_bwd_weight_xdl_cshuffle_v3<
+                                            GridwiseGemm,
+                                            remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
+                                            remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
+                                            remove_reference_t<
+                                                DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
+                                            ComputePtrOffsetOfStridedBatch<I1, I1, I0>,
+                                            NumGroupsToMerge,
+                                            true,
+                                            InMemoryDataOperationEnum::AtomicAdd,
+                                            minimum_occupancy>,
+                                    BlockSize,
+                                    dynamic_smem_size));
+            }
+            value_ = std::max(1, max_occupancy);
+        }
+        int value_;
+    };
+
+    struct Argument : public BaseArgument, public ArgumentSplitK
     {
         Argument(const InDataType* p_in_grid,
                  WeiDataType* p_wei_grid,
@@ -547,9 +599,10 @@ struct DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle
               output_spatial_lengths_{},
               conv_filter_strides_{conv_filter_strides},
               input_left_pads_{input_left_pads},
-              input_right_pads_{input_right_pads},
-              k_batch_{split_k}
+              input_right_pads_{input_right_pads}
         {
+            static MaximumActiveBlocksPerMultiprocessor max_occupancy;
+
             c_space_size_bytes =
                 ck::accumulate_n<long_index_t>(
                     e_g_k_c_xs_lengths.begin(), NDimSpatial + I3, 1, std::multiplies<>()) *
@@ -575,6 +628,56 @@ struct DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle
             std::array<index_t, NDimSpatial + 3> e_g_k_c_xs_strides_transposed =
                 conv_ngchw_to_nhwgc_transformer.TransposeWeiStrides(e_g_k_c_xs_lengths,
                                                                     e_g_k_c_xs_strides);
+
+            if (split_k < 0)
+            {
+                constexpr int k_batch_initial = 1;
+                const auto descs_initial =
+                        conv_to_gemm_transformer_v2
+                            .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
+                                Conv_N_,
+                                Conv_K_,
+                                Conv_C_,
+                                input_spatial_lengths_,
+                                filter_spatial_lengths_,
+                                output_spatial_lengths_,
+                                b_g_n_c_wis_strides,
+                                e_g_k_c_xs_strides,
+                                a_g_n_k_wos_strides,
+                                conv_filter_strides,
+                                conv_filter_dilations,
+                                input_left_pads,
+                                input_right_pads,
+                                k_batch_initial);
+
+                const auto& a_grid_desc_kbatch_k0_m_k1 = descs_initial[I0];
+                const auto& b_grid_desc_kbatch_k0_n_k1 = descs_initial[I1];
+                const auto gemmM = a_grid_desc_kbatch_k0_m_k1.GetLength(I1);
+                const auto gemmN = b_grid_desc_kbatch_k0_n_k1.GetLength(I1);
+
+                const auto grid_size_mn = GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN);
+                k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size_mn, Conv_G_);
+
+                // Ensure that k_batch_ does not exceed the maximum value
+                // for the GEMM pipeline
+                ck::index_t gemmK;
+                std::tie(std::ignore, std::ignore, gemmK) = 
+                    get_bwd_weight_gemm_sizes<NDimSpatial>(a_g_n_k_wos_lengths, e_g_k_c_xs_lengths);
+                const auto k_batch_max = static_cast<index_t>((gemmK - 1) / KPerBlock);
+                k_batch_ = std::min(k_batch_, k_batch_max);
+                
+                if (ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
+                {
+                    std::cout << "[SPLIT-K AUTODEDUCE] k_batch max value: " 
+                                << k_batch_max << std::endl;
+                    std::cout << "[SPLIT-K AUTODEDUCE] Final k_batch value: " 
+                                << k_batch_ << std::endl; 
+                }
+            }
+            else
+            {
+                k_batch_ = split_k;
+            }
 
             const auto descs =
                 conv_to_gemm_transformer_v2
@@ -751,7 +854,6 @@ struct DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle
         const std::array<ck::index_t, NDimSpatial>& conv_filter_strides_;
         const std::array<ck::index_t, NDimSpatial>& input_left_pads_;
         const std::array<ck::index_t, NDimSpatial>& input_right_pads_;
-        const index_t k_batch_;
         long_index_t c_space_size_bytes;
     };
 

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_xdl_cshuffle.hpp
@@ -655,7 +655,7 @@ struct DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle
                 const auto gemmM = a_grid_desc_kbatch_k0_m_k1.GetLength(I1);
                 const auto gemmN = b_grid_desc_kbatch_k0_n_k1.GetLength(I1);
 
-                const auto grid_size = GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN) * Conv_G_;
+                const auto grid_size = GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN) * Conv_G_ / NumGroupsToMerge;
                 k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size);
 
                 // Ensure that k_batch_ does not exceed the maximum value

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_xdl_cshuffle.hpp
@@ -512,44 +512,42 @@ struct DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle
         {
             constexpr int dynamic_smem_size = 0;
             constexpr index_t minimum_occupancy =
-                BlkGemmPipeSched == BlockGemmPipelineScheduler::Intrawave ? 1 : 2;            
+                BlkGemmPipeSched == BlockGemmPipelineScheduler::Intrawave ? 1 : 2;
             int max_occupancy = 0;
 
             if constexpr(BlkGemmPipelineVer == BlockGemmPipelineVersion::v4)
             {
                 hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
-                                    &max_occupancy,
-                                    kernel_grouped_conv_bwd_weight_xdl_cshuffle_v3_2lds<
-                                        GridwiseGemm,
-                                        remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
-                                        remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
-                                        remove_reference_t<
-                                            DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
-                                        ComputePtrOffsetOfStridedBatch<I1, I1, I0>,
-                                        NumGroupsToMerge,
-                                        true,
-                                        InMemoryDataOperationEnum::AtomicAdd,
-                                        minimum_occupancy>,
-                                    BlockSize,
-                                    dynamic_smem_size));
+                    &max_occupancy,
+                    kernel_grouped_conv_bwd_weight_xdl_cshuffle_v3_2lds<
+                        GridwiseGemm,
+                        remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
+                        remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
+                        remove_reference_t<DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
+                        ComputePtrOffsetOfStridedBatch<I1, I1, I0>,
+                        NumGroupsToMerge,
+                        true,
+                        InMemoryDataOperationEnum::AtomicAdd,
+                        minimum_occupancy>,
+                    BlockSize,
+                    dynamic_smem_size));
             }
-            else 
+            else
             {
                 hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
-                                    &max_occupancy,
-                                    kernel_grouped_conv_bwd_weight_xdl_cshuffle_v3<
-                                            GridwiseGemm,
-                                            remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
-                                            remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
-                                            remove_reference_t<
-                                                DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
-                                            ComputePtrOffsetOfStridedBatch<I1, I1, I0>,
-                                            NumGroupsToMerge,
-                                            true,
-                                            InMemoryDataOperationEnum::AtomicAdd,
-                                            minimum_occupancy>,
-                                    BlockSize,
-                                    dynamic_smem_size));
+                    &max_occupancy,
+                    kernel_grouped_conv_bwd_weight_xdl_cshuffle_v3<
+                        GridwiseGemm,
+                        remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
+                        remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
+                        remove_reference_t<DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
+                        ComputePtrOffsetOfStridedBatch<I1, I1, I0>,
+                        NumGroupsToMerge,
+                        true,
+                        InMemoryDataOperationEnum::AtomicAdd,
+                        minimum_occupancy>,
+                    BlockSize,
+                    dynamic_smem_size));
             }
             value_ = std::max(1, max_occupancy);
         }
@@ -629,49 +627,51 @@ struct DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle
                 conv_ngchw_to_nhwgc_transformer.TransposeWeiStrides(e_g_k_c_xs_lengths,
                                                                     e_g_k_c_xs_strides);
 
-            if (split_k < 0)
+            if(split_k < 0)
             {
                 constexpr int k_batch_initial = 1;
                 const auto descs_initial =
-                        conv_to_gemm_transformer_v2
-                            .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
-                                Conv_N_,
-                                Conv_K_,
-                                Conv_C_,
-                                input_spatial_lengths_,
-                                filter_spatial_lengths_,
-                                output_spatial_lengths_,
-                                b_g_n_c_wis_strides,
-                                e_g_k_c_xs_strides,
-                                a_g_n_k_wos_strides,
-                                conv_filter_strides,
-                                conv_filter_dilations,
-                                input_left_pads,
-                                input_right_pads,
-                                k_batch_initial);
+                    conv_to_gemm_transformer_v2
+                        .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
+                            Conv_N_,
+                            Conv_K_,
+                            Conv_C_,
+                            input_spatial_lengths_,
+                            filter_spatial_lengths_,
+                            output_spatial_lengths_,
+                            b_g_n_c_wis_strides,
+                            e_g_k_c_xs_strides,
+                            a_g_n_k_wos_strides,
+                            conv_filter_strides,
+                            conv_filter_dilations,
+                            input_left_pads,
+                            input_right_pads,
+                            k_batch_initial);
 
                 const auto& a_grid_desc_kbatch_k0_m_k1 = descs_initial[I0];
                 const auto& b_grid_desc_kbatch_k0_n_k1 = descs_initial[I1];
-                const auto gemmM = a_grid_desc_kbatch_k0_m_k1.GetLength(I1);
-                const auto gemmN = b_grid_desc_kbatch_k0_n_k1.GetLength(I1);
+                const auto gemmM                       = a_grid_desc_kbatch_k0_m_k1.GetLength(I1);
+                const auto gemmN                       = b_grid_desc_kbatch_k0_n_k1.GetLength(I1);
 
-                const auto grid_size = GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN) * Conv_G_ / NumGroupsToMerge;
+                const auto grid_size =
+                    GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN) * Conv_G_ /
+                    NumGroupsToMerge;
                 k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size);
 
                 // Ensure that k_batch_ does not exceed the maximum value
                 // for the GEMM pipeline
                 ck::index_t gemmK;
-                std::tie(std::ignore, std::ignore, gemmK) = 
+                std::tie(std::ignore, std::ignore, gemmK) =
                     get_bwd_weight_gemm_sizes<NDimSpatial>(a_g_n_k_wos_lengths, e_g_k_c_xs_lengths);
                 const auto k_batch_max = static_cast<index_t>((gemmK - 1) / KPerBlock);
-                k_batch_ = std::min(k_batch_, k_batch_max);
-                
-                if (ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
+                k_batch_               = std::min(k_batch_, k_batch_max);
+
+                if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
                 {
-                    std::cout << "[SPLIT-K AUTODEDUCE] k_batch max value: " 
-                                << k_batch_max << std::endl;
-                    std::cout << "[SPLIT-K AUTODEDUCE] Final k_batch value: " 
-                                << k_batch_ << std::endl; 
+                    std::cout << "[SPLIT-K AUTODEDUCE] k_batch max value: " << k_batch_max
+                              << std::endl;
+                    std::cout << "[SPLIT-K AUTODEDUCE] Final k_batch value: " << k_batch_
+                              << std::endl;
                 }
             }
             else

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle.hpp
@@ -528,31 +528,12 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffle
 
             if(split_k < 0)
             {
-                constexpr int k_batch_initial = 1;
-                const auto descs_initial =
-                    conv_to_gemm_transformer
-                        .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
-                            Conv_N_,
-                            Conv_K_,
-                            Conv_C_,
-                            input_spatial_lengths_,
-                            filter_spatial_lengths_,
-                            output_spatial_lengths_,
-                            b_g_n_c_wis_strides_transposed,
-                            e_g_k_c_xs_strides_transposed,
-                            a_g_n_k_wos_strides_transposed,
-                            conv_filter_strides,
-                            conv_filter_dilations,
-                            input_left_pads,
-                            input_right_pads,
-                            k_batch_initial);
-
-                const auto& c_grid_desc_m_n   = descs_initial[I2];
-                const auto& block_2_ctile_map = GridwiseGemm::MakeCBlockClusterAdaptor(
-                    c_grid_desc_m_n, M01, N01, k_batch_initial);
+                ck::index_t gemmM, gemmN;
+                std::tie(gemmM, gemmN, std::ignore) =
+                    get_bwd_weight_gemm_sizes<NDimSpatial>(a_g_n_k_wos_lengths, e_g_k_c_xs_lengths);
 
                 const auto grid_size =
-                    block_2_ctile_map.CalculateGridSize(c_grid_desc_m_n) * Conv_G_;
+                    calculate_mn_grid_size<MPerBlock, NPerBlock>(gemmM, gemmN) * Conv_G_;
                 k_batch_ = get_best_occupancy_k_batch_value(active_workgroups_per_cu.max_occupancy_,
                                                             grid_size);
             }

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle.hpp
@@ -19,6 +19,8 @@
 #include "ck/tensor_operation/gpu/grid/gridwise_gemm_xdlops_bwd_weight.hpp"
 #include "ck/tensor_operation/gpu/grid/gridwise_elementwise_2d.hpp"
 #include "ck/tensor_operation/gpu/device/impl/device_grouped_conv_utils.hpp"
+#include "ck/tensor_operation/gpu/device/impl/split_k_utils.hpp"
+#include "ck/tensor_operation/gpu/device/impl/split_k_arg.hpp"
 #include "ck/host_utility/device_prop.hpp"
 #include "ck/host_utility/kernel_launch.hpp"
 
@@ -421,7 +423,37 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffle
     using Block2CTileMap =
         decltype(GridwiseGemm::MakeCBlockClusterAdaptor(CGridDesc_M_N{}, 1, 1, 1));
 
-    struct Argument : public BaseArgument
+    struct MaximumActiveBlocksPerMultiprocessor
+    {
+        MaximumActiveBlocksPerMultiprocessor()
+        {
+            constexpr int dynamic_smem_size = 0;
+            int max_occupancy = 0;
+            hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+                                &max_occupancy,
+                                kernel_batched_gemm_xdlops_bwd_weight<
+                                    GridwiseGemm,
+                                    ADataType,
+                                    BDataType,
+                                    CDataType,
+                                    OutElementwiseOperation,
+                                    InElementwiseOperation,
+                                    WeiElementwiseOperation,
+                                    remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>, 
+                                    remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>, 
+                                    remove_reference_t<DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>, 
+                                    remove_reference_t<DeviceOp::Block2CTileMap>,
+                                    ComputePtrOffsetOfStridedBatch<>,
+                                    false>, // Both true/false give the same occupancy.
+                                BlockSize,
+                                dynamic_smem_size));
+            value_ = std::max(1, max_occupancy);
+        }
+        int value_;
+    };
+    
+
+    struct Argument : public BaseArgument, public ArgumentSplitK
     {
         Argument(const InDataType* p_in_grid,
                  WeiDataType* p_wei_grid,
@@ -465,9 +497,10 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffle
               output_spatial_lengths_{},
               conv_filter_strides_{conv_filter_strides},
               input_left_pads_{input_left_pads},
-              input_right_pads_{input_right_pads},
-              k_batch_{split_k}
+              input_right_pads_{input_right_pads}
         {
+            static MaximumActiveBlocksPerMultiprocessor max_occupancy;
+
             c_space_size_bytes =
                 ck::accumulate_n<long_index_t>(
                     e_g_k_c_xs_lengths.begin(), NDimSpatial + I3, 1, std::multiplies<>()) *
@@ -493,6 +526,39 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffle
             std::array<index_t, NDimSpatial + 3> e_g_k_c_xs_strides_transposed =
                 conv_ngchw_to_nhwgc_transformer.TransposeWeiStrides(e_g_k_c_xs_lengths,
                                                                     e_g_k_c_xs_strides);
+
+            if (split_k < 0)
+            {
+                constexpr int k_batch_initial = 1;
+                const auto descs_initial =
+                        conv_to_gemm_transformer
+                            .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
+                                Conv_N_,
+                                Conv_K_,
+                                Conv_C_,
+                                input_spatial_lengths_,
+                                filter_spatial_lengths_,
+                                output_spatial_lengths_,
+                                b_g_n_c_wis_strides_transposed,
+                                e_g_k_c_xs_strides_transposed,
+                                a_g_n_k_wos_strides_transposed,
+                                conv_filter_strides,
+                                conv_filter_dilations,
+                                input_left_pads,
+                                input_right_pads,
+                                k_batch_initial);
+
+                const auto& c_grid_desc_m_n   = descs_initial[I2];
+                const auto& block_2_ctile_map = GridwiseGemm::MakeCBlockClusterAdaptor(c_grid_desc_m_n, M01, N01, k_batch_initial);
+
+                const auto grid_size_mn = block_2_ctile_map.CalculateGridSize(c_grid_desc_m_n);            
+                k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size_mn, Conv_G_);
+            }
+            else 
+            {
+                k_batch_ = split_k;
+            }
+
             const auto descs =
                 conv_to_gemm_transformer
                     .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
@@ -658,7 +724,6 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffle
         const std::array<ck::index_t, NDimSpatial>& conv_filter_strides_;
         const std::array<ck::index_t, NDimSpatial>& input_left_pads_;
         const std::array<ck::index_t, NDimSpatial>& input_right_pads_;
-        const index_t k_batch_;
         long_index_t c_space_size_bytes;
     };
 

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle.hpp
@@ -423,9 +423,9 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffle
     using Block2CTileMap =
         decltype(GridwiseGemm::MakeCBlockClusterAdaptor(CGridDesc_M_N{}, 1, 1, 1));
 
-    struct MaximumActiveBlocksPerMultiprocessor
+    struct ActiveWorkgroupsPerCU
     {
-        MaximumActiveBlocksPerMultiprocessor()
+        ActiveWorkgroupsPerCU()
         {
             constexpr int dynamic_smem_size = 0;
             int max_occupancy               = 0;
@@ -447,9 +447,9 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffle
                     false>, // Both true/false give the same occupancy.
                 BlockSize,
                 dynamic_smem_size));
-            value_ = std::max(1, max_occupancy);
+            max_occupancy_ = std::max(1, max_occupancy);
         }
-        int value_;
+        int max_occupancy_;
     };
 
     struct Argument : public BaseArgument, public ArgumentSplitK
@@ -498,7 +498,7 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffle
               input_left_pads_{input_left_pads},
               input_right_pads_{input_right_pads}
         {
-            static MaximumActiveBlocksPerMultiprocessor max_occupancy;
+            static ActiveWorkgroupsPerCU active_workgroups_per_cu;
 
             c_space_size_bytes =
                 ck::accumulate_n<long_index_t>(
@@ -553,7 +553,8 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffle
 
                 const auto grid_size =
                     block_2_ctile_map.CalculateGridSize(c_grid_desc_m_n) * Conv_G_;
-                k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size);
+                k_batch_ = get_best_occupancy_k_batch_value(active_workgroups_per_cu.max_occupancy_,
+                                                            grid_size);
             }
             else
             {

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle.hpp
@@ -551,8 +551,8 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffle
                 const auto& c_grid_desc_m_n   = descs_initial[I2];
                 const auto& block_2_ctile_map = GridwiseGemm::MakeCBlockClusterAdaptor(c_grid_desc_m_n, M01, N01, k_batch_initial);
 
-                const auto grid_size_mn = block_2_ctile_map.CalculateGridSize(c_grid_desc_m_n);            
-                k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size_mn, Conv_G_);
+                const auto grid_size = block_2_ctile_map.CalculateGridSize(c_grid_desc_m_n) * Conv_G_; 
+                k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size);
             }
             else 
             {

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle.hpp
@@ -428,30 +428,29 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffle
         MaximumActiveBlocksPerMultiprocessor()
         {
             constexpr int dynamic_smem_size = 0;
-            int max_occupancy = 0;
+            int max_occupancy               = 0;
             hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
-                                &max_occupancy,
-                                kernel_batched_gemm_xdlops_bwd_weight<
-                                    GridwiseGemm,
-                                    ADataType,
-                                    BDataType,
-                                    CDataType,
-                                    OutElementwiseOperation,
-                                    InElementwiseOperation,
-                                    WeiElementwiseOperation,
-                                    remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>, 
-                                    remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>, 
-                                    remove_reference_t<DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>, 
-                                    remove_reference_t<DeviceOp::Block2CTileMap>,
-                                    ComputePtrOffsetOfStridedBatch<>,
-                                    false>, // Both true/false give the same occupancy.
-                                BlockSize,
-                                dynamic_smem_size));
+                &max_occupancy,
+                kernel_batched_gemm_xdlops_bwd_weight<
+                    GridwiseGemm,
+                    ADataType,
+                    BDataType,
+                    CDataType,
+                    OutElementwiseOperation,
+                    InElementwiseOperation,
+                    WeiElementwiseOperation,
+                    remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
+                    remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
+                    remove_reference_t<DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
+                    remove_reference_t<DeviceOp::Block2CTileMap>,
+                    ComputePtrOffsetOfStridedBatch<>,
+                    false>, // Both true/false give the same occupancy.
+                BlockSize,
+                dynamic_smem_size));
             value_ = std::max(1, max_occupancy);
         }
         int value_;
     };
-    
 
     struct Argument : public BaseArgument, public ArgumentSplitK
     {
@@ -527,34 +526,36 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffle
                 conv_ngchw_to_nhwgc_transformer.TransposeWeiStrides(e_g_k_c_xs_lengths,
                                                                     e_g_k_c_xs_strides);
 
-            if (split_k < 0)
+            if(split_k < 0)
             {
                 constexpr int k_batch_initial = 1;
                 const auto descs_initial =
-                        conv_to_gemm_transformer
-                            .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
-                                Conv_N_,
-                                Conv_K_,
-                                Conv_C_,
-                                input_spatial_lengths_,
-                                filter_spatial_lengths_,
-                                output_spatial_lengths_,
-                                b_g_n_c_wis_strides_transposed,
-                                e_g_k_c_xs_strides_transposed,
-                                a_g_n_k_wos_strides_transposed,
-                                conv_filter_strides,
-                                conv_filter_dilations,
-                                input_left_pads,
-                                input_right_pads,
-                                k_batch_initial);
+                    conv_to_gemm_transformer
+                        .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
+                            Conv_N_,
+                            Conv_K_,
+                            Conv_C_,
+                            input_spatial_lengths_,
+                            filter_spatial_lengths_,
+                            output_spatial_lengths_,
+                            b_g_n_c_wis_strides_transposed,
+                            e_g_k_c_xs_strides_transposed,
+                            a_g_n_k_wos_strides_transposed,
+                            conv_filter_strides,
+                            conv_filter_dilations,
+                            input_left_pads,
+                            input_right_pads,
+                            k_batch_initial);
 
                 const auto& c_grid_desc_m_n   = descs_initial[I2];
-                const auto& block_2_ctile_map = GridwiseGemm::MakeCBlockClusterAdaptor(c_grid_desc_m_n, M01, N01, k_batch_initial);
+                const auto& block_2_ctile_map = GridwiseGemm::MakeCBlockClusterAdaptor(
+                    c_grid_desc_m_n, M01, N01, k_batch_initial);
 
-                const auto grid_size = block_2_ctile_map.CalculateGridSize(c_grid_desc_m_n) * Conv_G_; 
+                const auto grid_size =
+                    block_2_ctile_map.CalculateGridSize(c_grid_desc_m_n) * Conv_G_;
                 k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size);
             }
-            else 
+            else
             {
                 k_batch_ = split_k;
             }

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle_v3.hpp
@@ -494,40 +494,17 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
 
             if(split_k < 0)
             {
-                constexpr int k_batch_initial = 1;
-                const auto descs_initial =
-                    conv_to_gemm_transformer
-                        .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
-                            Conv_N_,
-                            Conv_K_,
-                            Conv_C_,
-                            input_spatial_lengths_,
-                            filter_spatial_lengths_,
-                            output_spatial_lengths_,
-                            b_g_n_c_wis_strides,
-                            e_g_k_c_xs_strides,
-                            a_g_n_k_wos_strides,
-                            conv_filter_strides,
-                            conv_filter_dilations,
-                            input_left_pads,
-                            input_right_pads,
-                            k_batch_initial);
-
-                const auto& a_grid_desc_kbatch_k0_m_k1 = descs_initial[I0];
-                const auto& b_grid_desc_kbatch_k0_n_k1 = descs_initial[I1];
-                const auto gemmM                       = a_grid_desc_kbatch_k0_m_k1.GetLength(I1);
-                const auto gemmN                       = b_grid_desc_kbatch_k0_n_k1.GetLength(I1);
+                ck::index_t gemmM, gemmN, gemmK;
+                std::tie(gemmM, gemmN, gemmK) =
+                    get_bwd_weight_gemm_sizes<NDimSpatial>(a_g_n_k_wos_lengths, e_g_k_c_xs_lengths);
 
                 const auto grid_size =
-                    GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN) * Conv_G_;
+                    calculate_mn_grid_size<MPerBlock, NPerBlock>(gemmM, gemmN) * Conv_G_;
                 k_batch_ = get_best_occupancy_k_batch_value(active_workgroups_per_cu.max_occupancy_,
                                                             grid_size);
 
                 // Ensure that k_batch_ does not exceed the maximum value
-                // for the GEMM pipeline
-                ck::index_t gemmK;
-                std::tie(std::ignore, std::ignore, gemmK) =
-                    get_bwd_weight_gemm_sizes<NDimSpatial>(a_g_n_k_wos_lengths, e_g_k_c_xs_lengths);
+                // for the GEMM pipeline.
                 const auto k_batch_max = static_cast<index_t>((gemmK - 1) / K0PerBlock);
                 k_batch_               = std::min(k_batch_, k_batch_max);
 

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle_v3.hpp
@@ -520,8 +520,8 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
                 const auto gemmM = a_grid_desc_kbatch_k0_m_k1.GetLength(I1);
                 const auto gemmN = b_grid_desc_kbatch_k0_n_k1.GetLength(I1);
 
-                const auto grid_size_mn = GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN);
-                k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size_mn, Conv_G_);
+                const auto grid_size = GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN) * Conv_G_;
+                k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size);
 
                 // Ensure that k_batch_ does not exceed the maximum value
                 // for the GEMM pipeline

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle_v3.hpp
@@ -389,42 +389,40 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
         {
             constexpr int dynamic_smem_size = 0;
             constexpr index_t minimum_occupancy =
-                BlkGemmPipeSched == BlockGemmPipelineScheduler::Intrawave ? 1 : 2;            
+                BlkGemmPipeSched == BlockGemmPipelineScheduler::Intrawave ? 1 : 2;
             int max_occupancy = 0;
 
             if constexpr(BlkGemmPipelineVer == BlockGemmPipelineVersion::v4)
             {
                 hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
-                                    &max_occupancy,
-                                    kernel_grouped_conv_bwd_weight_xdl_cshuffle_v3_2lds<
-                                        GridwiseGemm,
-                                        remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
-                                        remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
-                                        remove_reference_t<
-                                            DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
-                                        ComputePtrOffsetOfStridedBatch<I1, I1, I0>,
-                                        true,
-                                        InMemoryDataOperationEnum::AtomicAdd,
-                                        minimum_occupancy>,
-                                    BlockSize,
-                                    dynamic_smem_size));
+                    &max_occupancy,
+                    kernel_grouped_conv_bwd_weight_xdl_cshuffle_v3_2lds<
+                        GridwiseGemm,
+                        remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
+                        remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
+                        remove_reference_t<DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
+                        ComputePtrOffsetOfStridedBatch<I1, I1, I0>,
+                        true,
+                        InMemoryDataOperationEnum::AtomicAdd,
+                        minimum_occupancy>,
+                    BlockSize,
+                    dynamic_smem_size));
             }
-            else 
+            else
             {
                 hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
-                                    &max_occupancy,
-                                    kernel_grouped_conv_bwd_weight_xdl_cshuffle_v3<
-                                            GridwiseGemm,
-                                            remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
-                                            remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
-                                            remove_reference_t<
-                                                DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
-                                            ComputePtrOffsetOfStridedBatch<I1, I1, I0>,
-                                            true,
-                                            InMemoryDataOperationEnum::AtomicAdd,
-                                            minimum_occupancy>,
-                                    BlockSize,
-                                    dynamic_smem_size));
+                    &max_occupancy,
+                    kernel_grouped_conv_bwd_weight_xdl_cshuffle_v3<
+                        GridwiseGemm,
+                        remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
+                        remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
+                        remove_reference_t<DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
+                        ComputePtrOffsetOfStridedBatch<I1, I1, I0>,
+                        true,
+                        InMemoryDataOperationEnum::AtomicAdd,
+                        minimum_occupancy>,
+                    BlockSize,
+                    dynamic_smem_size));
             }
             value_ = std::max(1, max_occupancy);
         }
@@ -494,49 +492,50 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
                       end(a_g_n_k_wos_lengths),
                       begin(output_spatial_lengths_));
 
-            if (split_k < 0)
+            if(split_k < 0)
             {
                 constexpr int k_batch_initial = 1;
                 const auto descs_initial =
-                        conv_to_gemm_transformer
-                            .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
-                                Conv_N_,
-                                Conv_K_,
-                                Conv_C_,
-                                input_spatial_lengths_,
-                                filter_spatial_lengths_,
-                                output_spatial_lengths_,
-                                b_g_n_c_wis_strides,
-                                e_g_k_c_xs_strides,
-                                a_g_n_k_wos_strides,
-                                conv_filter_strides,
-                                conv_filter_dilations,
-                                input_left_pads,
-                                input_right_pads,
-                                k_batch_initial);
+                    conv_to_gemm_transformer
+                        .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
+                            Conv_N_,
+                            Conv_K_,
+                            Conv_C_,
+                            input_spatial_lengths_,
+                            filter_spatial_lengths_,
+                            output_spatial_lengths_,
+                            b_g_n_c_wis_strides,
+                            e_g_k_c_xs_strides,
+                            a_g_n_k_wos_strides,
+                            conv_filter_strides,
+                            conv_filter_dilations,
+                            input_left_pads,
+                            input_right_pads,
+                            k_batch_initial);
 
                 const auto& a_grid_desc_kbatch_k0_m_k1 = descs_initial[I0];
                 const auto& b_grid_desc_kbatch_k0_n_k1 = descs_initial[I1];
-                const auto gemmM = a_grid_desc_kbatch_k0_m_k1.GetLength(I1);
-                const auto gemmN = b_grid_desc_kbatch_k0_n_k1.GetLength(I1);
+                const auto gemmM                       = a_grid_desc_kbatch_k0_m_k1.GetLength(I1);
+                const auto gemmN                       = b_grid_desc_kbatch_k0_n_k1.GetLength(I1);
 
-                const auto grid_size = GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN) * Conv_G_;
+                const auto grid_size =
+                    GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN) * Conv_G_;
                 k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size);
 
                 // Ensure that k_batch_ does not exceed the maximum value
                 // for the GEMM pipeline
                 ck::index_t gemmK;
-                std::tie(std::ignore, std::ignore, gemmK) = 
+                std::tie(std::ignore, std::ignore, gemmK) =
                     get_bwd_weight_gemm_sizes<NDimSpatial>(a_g_n_k_wos_lengths, e_g_k_c_xs_lengths);
                 const auto k_batch_max = static_cast<index_t>((gemmK - 1) / K0PerBlock);
-                k_batch_ = std::min(k_batch_, k_batch_max);
-                
-                if (ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
+                k_batch_               = std::min(k_batch_, k_batch_max);
+
+                if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
                 {
-                    std::cout << "[SPLIT-K AUTODEDUCE] k_batch max value: " 
-                                << k_batch_max << std::endl;
-                    std::cout << "[SPLIT-K AUTODEDUCE] Final k_batch value: " 
-                                << k_batch_ << std::endl; 
+                    std::cout << "[SPLIT-K AUTODEDUCE] k_batch max value: " << k_batch_max
+                              << std::endl;
+                    std::cout << "[SPLIT-K AUTODEDUCE] Final k_batch value: " << k_batch_
+                              << std::endl;
                 }
             }
             else

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle_v3.hpp
@@ -20,6 +20,8 @@
 #include "ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_conv_v3.hpp"
 #include <ck/tensor_operation/gpu/grid/block_to_ctile_map.hpp>
 #include "ck/tensor_operation/gpu/device/impl/device_grouped_conv_utils.hpp"
+#include "ck/tensor_operation/gpu/device/impl/split_k_utils.hpp"
+#include "ck/tensor_operation/gpu/device/impl/split_k_arg.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 #include "ck/tensor_operation/gpu/device/matrix_padder.hpp"
 
@@ -381,7 +383,55 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
         decltype(GridwiseGemm::MakeCGridDescriptor_MBlock_MPerBlock_NBlock_NPerBlock(
             CGridDesc_M_N{}, 1, 1));
 
-    struct Argument : public BaseArgument
+    struct MaximumActiveBlocksPerMultiprocessor
+    {
+        MaximumActiveBlocksPerMultiprocessor()
+        {
+            constexpr int dynamic_smem_size = 0;
+            constexpr index_t minimum_occupancy =
+                BlkGemmPipeSched == BlockGemmPipelineScheduler::Intrawave ? 1 : 2;            
+            int max_occupancy = 0;
+
+            if constexpr(BlkGemmPipelineVer == BlockGemmPipelineVersion::v4)
+            {
+                hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+                                    &max_occupancy,
+                                    kernel_grouped_conv_bwd_weight_xdl_cshuffle_v3_2lds<
+                                        GridwiseGemm,
+                                        remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
+                                        remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
+                                        remove_reference_t<
+                                            DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
+                                        ComputePtrOffsetOfStridedBatch<I1, I1, I0>,
+                                        true,
+                                        InMemoryDataOperationEnum::AtomicAdd,
+                                        minimum_occupancy>,
+                                    BlockSize,
+                                    dynamic_smem_size));
+            }
+            else 
+            {
+                hip_check_error(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+                                    &max_occupancy,
+                                    kernel_grouped_conv_bwd_weight_xdl_cshuffle_v3<
+                                            GridwiseGemm,
+                                            remove_reference_t<DeviceOp::AGridDesc_K0_M_K1>,
+                                            remove_reference_t<DeviceOp::BGridDesc_K0_N_K1>,
+                                            remove_reference_t<
+                                                DeviceOp::CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock>,
+                                            ComputePtrOffsetOfStridedBatch<I1, I1, I0>,
+                                            true,
+                                            InMemoryDataOperationEnum::AtomicAdd,
+                                            minimum_occupancy>,
+                                    BlockSize,
+                                    dynamic_smem_size));
+            }
+            value_ = std::max(1, max_occupancy);
+        }
+        int value_;
+    };
+
+    struct Argument : public BaseArgument, public ArgumentSplitK
     {
         Argument(const InDataType* p_in_grid,
                  WeiDataType* p_wei_grid,
@@ -424,9 +474,10 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
               output_spatial_lengths_{},
               conv_filter_strides_{conv_filter_strides},
               input_left_pads_{input_left_pads},
-              input_right_pads_{input_right_pads},
-              k_batch_{split_k}
+              input_right_pads_{input_right_pads}
         {
+            static MaximumActiveBlocksPerMultiprocessor max_occupancy;
+
             c_space_size_bytes =
                 ck::accumulate_n<long_index_t>(
                     e_g_k_c_xs_lengths.begin(), NDimSpatial + I3, 1, std::multiplies<>()) *
@@ -442,6 +493,56 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
             std::copy(begin(a_g_n_k_wos_lengths) + spatial_offset,
                       end(a_g_n_k_wos_lengths),
                       begin(output_spatial_lengths_));
+
+            if (split_k < 0)
+            {
+                constexpr int k_batch_initial = 1;
+                const auto descs_initial =
+                        conv_to_gemm_transformer
+                            .template MakeABCGridDescriptor_A_K0_M_K1_B_K0_N_K1_C_M_N<NDimSpatial>(
+                                Conv_N_,
+                                Conv_K_,
+                                Conv_C_,
+                                input_spatial_lengths_,
+                                filter_spatial_lengths_,
+                                output_spatial_lengths_,
+                                b_g_n_c_wis_strides,
+                                e_g_k_c_xs_strides,
+                                a_g_n_k_wos_strides,
+                                conv_filter_strides,
+                                conv_filter_dilations,
+                                input_left_pads,
+                                input_right_pads,
+                                k_batch_initial);
+
+                const auto& a_grid_desc_kbatch_k0_m_k1 = descs_initial[I0];
+                const auto& b_grid_desc_kbatch_k0_n_k1 = descs_initial[I1];
+                const auto gemmM = a_grid_desc_kbatch_k0_m_k1.GetLength(I1);
+                const auto gemmN = b_grid_desc_kbatch_k0_n_k1.GetLength(I1);
+
+                const auto grid_size_mn = GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN);
+                k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size_mn, Conv_G_);
+
+                // Ensure that k_batch_ does not exceed the maximum value
+                // for the GEMM pipeline
+                ck::index_t gemmK;
+                std::tie(std::ignore, std::ignore, gemmK) = 
+                    get_bwd_weight_gemm_sizes<NDimSpatial>(a_g_n_k_wos_lengths, e_g_k_c_xs_lengths);
+                const auto k_batch_max = static_cast<index_t>((gemmK - 1) / K0PerBlock);
+                k_batch_ = std::min(k_batch_, k_batch_max);
+                
+                if (ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
+                {
+                    std::cout << "[SPLIT-K AUTODEDUCE] k_batch max value: " 
+                                << k_batch_max << std::endl;
+                    std::cout << "[SPLIT-K AUTODEDUCE] Final k_batch value: " 
+                                << k_batch_ << std::endl; 
+                }
+            }
+            else
+            {
+                k_batch_ = split_k;
+            }
 
             const auto descs =
                 conv_to_gemm_transformer
@@ -513,7 +614,6 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
         const std::array<ck::index_t, NDimSpatial>& conv_filter_strides_;
         const std::array<ck::index_t, NDimSpatial>& input_left_pads_;
         const std::array<ck::index_t, NDimSpatial>& input_right_pads_;
-        const index_t k_batch_;
         long_index_t c_space_size_bytes;
     };
 

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle_v3.hpp
@@ -383,9 +383,9 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
         decltype(GridwiseGemm::MakeCGridDescriptor_MBlock_MPerBlock_NBlock_NPerBlock(
             CGridDesc_M_N{}, 1, 1));
 
-    struct MaximumActiveBlocksPerMultiprocessor
+    struct ActiveWorkgroupsPerCU
     {
-        MaximumActiveBlocksPerMultiprocessor()
+        ActiveWorkgroupsPerCU()
         {
             constexpr int dynamic_smem_size = 0;
             constexpr index_t minimum_occupancy =
@@ -424,9 +424,9 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
                     BlockSize,
                     dynamic_smem_size));
             }
-            value_ = std::max(1, max_occupancy);
+            max_occupancy_ = std::max(1, max_occupancy);
         }
-        int value_;
+        int max_occupancy_;
     };
 
     struct Argument : public BaseArgument, public ArgumentSplitK
@@ -474,7 +474,7 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
               input_left_pads_{input_left_pads},
               input_right_pads_{input_right_pads}
         {
-            static MaximumActiveBlocksPerMultiprocessor max_occupancy;
+            static ActiveWorkgroupsPerCU active_workgroups_per_cu;
 
             c_space_size_bytes =
                 ck::accumulate_n<long_index_t>(
@@ -520,7 +520,8 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
 
                 const auto grid_size =
                     GridwiseGemm::Block2CTileMap::CalculateGridSize(gemmM, gemmN) * Conv_G_;
-                k_batch_ = get_best_occupancy_k_batch_value(max_occupancy.value_, grid_size);
+                k_batch_ = get_best_occupancy_k_batch_value(active_workgroups_per_cu.max_occupancy_,
+                                                            grid_size);
 
                 // Ensure that k_batch_ does not exceed the maximum value
                 // for the GEMM pipeline

--- a/include/ck/tensor_operation/gpu/device/impl/split_k_arg.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/split_k_arg.hpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+
+struct ArgumentSplitK
+{
+  index_t k_batch_{1};
+};
+
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/include/ck/tensor_operation/gpu/device/impl/split_k_arg.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/split_k_arg.hpp
@@ -3,14 +3,13 @@
 
 #pragma once
 
-
 namespace ck {
 namespace tensor_operation {
 namespace device {
 
 struct ArgumentSplitK
 {
-  index_t k_batch_{1};
+    index_t k_batch_{1};
 };
 
 } // namespace device

--- a/include/ck/tensor_operation/gpu/device/impl/split_k_utils.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/split_k_utils.hpp
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+#include <numeric>
+#include <hip/hip_runtime.h>
+#include "ck/utility/env.hpp"
+#include "ck/utility/number.hpp"
+#include "ck/host_utility/hip_check_error.hpp"
+#include "ck/ck.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+
+struct DeviceProperties
+{
+  DeviceProperties()
+  {
+    hipDeviceProp_t dev_prop;
+    hipDevice_t dev;
+    hip_check_error(hipGetDevice(&dev));
+    hip_check_error(hipGetDeviceProperties(&dev_prop, dev));
+
+    num_cu_ = dev_prop.multiProcessorCount;
+  };
+  int num_cu_;
+};
+
+inline ck::index_t get_best_occupancy_k_batch_value(int max_occupancy, ck::index_t grid_size_mn, ck::index_t num_conv_groups)
+{
+    static DeviceProperties device_properties;
+    const int max_capacity = max_occupancy * device_properties.num_cu_;
+
+    constexpr ck::index_t k_batch_max = 1024;
+    const auto total_grid_size = grid_size_mn * num_conv_groups;
+    ck::index_t k_batch = static_cast<ck::index_t>(max_capacity / std::gcd(max_capacity, total_grid_size));
+    if (k_batch > k_batch_max || k_batch == 0)
+    {
+      // TODO: This could be improved by using Euclidian algorithm to find the optimal k_batch.
+      auto min_remainder = max_capacity;
+      for (ck::index_t k = 1; k <= k_batch_max; ++k)
+      {
+        const auto remainder = (total_grid_size * k) % max_capacity;
+        // For equal remainder values, prefer smaller k values.
+        if (remainder < min_remainder)
+        {
+          min_remainder = remainder;
+          k_batch = k;
+        }
+      }
+    }
+    
+    if (ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
+    {
+      std::cout << "[SPLIT-K AUTODEDUCE] Max active thread blocks per CU for GEMM kernel:  " << max_occupancy << std::endl;
+      std::cout << "[SPLIT-K AUTODEDUCE] Output grid size:  " << grid_size_mn << std::endl;
+      std::cout << "[SPLIT-K AUTODEDUCE] Number of conv groups:  " << num_conv_groups << std::endl;
+      std::cout << "[SPLIT-K AUTODEDUCE] Optimal split-k value " << k_batch << std::endl;
+    }
+    return k_batch;
+}
+
+template <ck::index_t NDimSpatial>
+inline auto get_bwd_weight_gemm_sizes(
+  const std::array<index_t, NDimSpatial + 3>& a_g_n_k_wos_lengths,
+  const std::array<index_t, NDimSpatial + 3>& e_g_k_c_xs_lengths)
+{
+  static constexpr auto I1 = Number<1>{};
+  static constexpr auto I2 = Number<2>{};
+
+  // The input array has elements in the order: G, N, K, Do, Ho, Wo
+  // GemmK = N * Do * Ho * Wo for the BWD weight pass.
+  constexpr index_t spatial_offset = 3; 
+  const index_t DoHoWo = std::accumulate(begin(a_g_n_k_wos_lengths) + spatial_offset,
+                                      end(a_g_n_k_wos_lengths),
+                                      index_t{1},
+                                      std::multiplies<>{});
+  const auto gemmK = a_g_n_k_wos_lengths[I1] * DoHoWo;
+
+  // The GEMM M dimension is the number of output channels.
+  const auto gemmM = e_g_k_c_xs_lengths[I1];
+
+  // The output array has elements in the order: G, K, C, X, Y, Z
+  // GemmN = C * X * Y * Z for the BWD weight pass.
+  const index_t XYZ = std::accumulate(begin(e_g_k_c_xs_lengths) + spatial_offset,
+                                      end(e_g_k_c_xs_lengths),
+                                      index_t{1},
+                                      std::multiplies<>{});
+  const auto gemmN = e_g_k_c_xs_lengths[I2] * XYZ;
+  return std::make_tuple(gemmM, gemmN, gemmK);
+}
+
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/include/ck/tensor_operation/gpu/device/impl/split_k_utils.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/split_k_utils.hpp
@@ -80,6 +80,14 @@ get_bwd_weight_gemm_sizes(const std::array<index_t, NDimSpatial + 3>& a_g_n_k_wo
     return std::make_tuple(gemmM, gemmN, gemmK);
 }
 
+template <ck::index_t MPerBlock, ck::index_t NPerBlock>
+inline ck::index_t calculate_mn_grid_size(ck::index_t gemmM, ck::index_t gemmN)
+{
+    const auto M0 = math::integer_divide_ceil(gemmM, MPerBlock);
+    const auto N0 = math::integer_divide_ceil(gemmN, NPerBlock);
+    return M0 * N0;
+}
+
 } // namespace device
 } // namespace tensor_operation
 } // namespace ck

--- a/include/ck/tensor_operation/gpu/device/impl/split_k_utils.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/split_k_utils.hpp
@@ -15,16 +15,16 @@ namespace device {
 
 struct DeviceProperties
 {
-  DeviceProperties()
-  {
-    hipDeviceProp_t dev_prop;
-    hipDevice_t dev;
-    hip_check_error(hipGetDevice(&dev));
-    hip_check_error(hipGetDeviceProperties(&dev_prop, dev));
+    DeviceProperties()
+    {
+        hipDeviceProp_t dev_prop;
+        hipDevice_t dev;
+        hip_check_error(hipGetDevice(&dev));
+        hip_check_error(hipGetDeviceProperties(&dev_prop, dev));
 
-    num_cu_ = dev_prop.multiProcessorCount;
-  };
-  int num_cu_;
+        num_cu_ = dev_prop.multiProcessorCount;
+    };
+    int num_cu_;
 };
 
 inline ck::index_t get_best_occupancy_k_batch_value(int max_occupancy, ck::index_t grid_size)
@@ -33,49 +33,51 @@ inline ck::index_t get_best_occupancy_k_batch_value(int max_occupancy, ck::index
     const int max_capacity = max_occupancy * device_properties.num_cu_;
 
     ck::index_t k_batch = 1;
-    const auto optimal_split = static_cast<ck::index_t>(std::floor((1.0 * max_capacity) / grid_size));
-    if (optimal_split > 1)
+    const auto optimal_split =
+        static_cast<ck::index_t>(std::floor((1.0 * max_capacity) / grid_size));
+    if(optimal_split > 1)
     {
-      k_batch = optimal_split;
-    } 
-    
-    if (ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
+        k_batch = optimal_split;
+    }
+
+    if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
     {
-      std::cout << "[SPLIT-K AUTODEDUCE] Max active thread blocks per CU for GEMM kernel:  " << max_occupancy << std::endl;
-      std::cout << "[SPLIT-K AUTODEDUCE] Output grid size:  " << grid_size << std::endl;
-      std::cout << "[SPLIT-K AUTODEDUCE] Optimal split-k value " << k_batch << std::endl;
+        std::cout << "[SPLIT-K AUTODEDUCE] Max active thread blocks per CU for GEMM kernel:  "
+                  << max_occupancy << std::endl;
+        std::cout << "[SPLIT-K AUTODEDUCE] Output grid size:  " << grid_size << std::endl;
+        std::cout << "[SPLIT-K AUTODEDUCE] Optimal split-k value " << k_batch << std::endl;
     }
     return k_batch;
 }
 
 template <ck::index_t NDimSpatial>
-inline auto get_bwd_weight_gemm_sizes(
-  const std::array<index_t, NDimSpatial + 3>& a_g_n_k_wos_lengths,
-  const std::array<index_t, NDimSpatial + 3>& e_g_k_c_xs_lengths)
+inline auto
+get_bwd_weight_gemm_sizes(const std::array<index_t, NDimSpatial + 3>& a_g_n_k_wos_lengths,
+                          const std::array<index_t, NDimSpatial + 3>& e_g_k_c_xs_lengths)
 {
-  static constexpr auto I1 = Number<1>{};
-  static constexpr auto I2 = Number<2>{};
+    static constexpr auto I1 = Number<1>{};
+    static constexpr auto I2 = Number<2>{};
 
-  // The input array has elements in the order: G, N, K, Do, Ho, Wo
-  // GemmK = N * Do * Ho * Wo for the BWD weight pass.
-  constexpr index_t spatial_offset = 3; 
-  const index_t DoHoWo = std::accumulate(begin(a_g_n_k_wos_lengths) + spatial_offset,
-                                      end(a_g_n_k_wos_lengths),
-                                      index_t{1},
-                                      std::multiplies<>{});
-  const auto gemmK = a_g_n_k_wos_lengths[I1] * DoHoWo;
+    // The input array has elements in the order: G, N, K, Do, Ho, Wo
+    // GemmK = N * Do * Ho * Wo for the BWD weight pass.
+    constexpr index_t spatial_offset = 3;
+    const index_t DoHoWo             = std::accumulate(begin(a_g_n_k_wos_lengths) + spatial_offset,
+                                           end(a_g_n_k_wos_lengths),
+                                           index_t{1},
+                                           std::multiplies<>{});
+    const auto gemmK                 = a_g_n_k_wos_lengths[I1] * DoHoWo;
 
-  // The GEMM M dimension is the number of output channels.
-  const auto gemmM = e_g_k_c_xs_lengths[I1];
+    // The GEMM M dimension is the number of output channels.
+    const auto gemmM = e_g_k_c_xs_lengths[I1];
 
-  // The output array has elements in the order: G, K, C, X, Y, Z
-  // GemmN = C * X * Y * Z for the BWD weight pass.
-  const index_t XYZ = std::accumulate(begin(e_g_k_c_xs_lengths) + spatial_offset,
-                                      end(e_g_k_c_xs_lengths),
-                                      index_t{1},
-                                      std::multiplies<>{});
-  const auto gemmN = e_g_k_c_xs_lengths[I2] * XYZ;
-  return std::make_tuple(gemmM, gemmN, gemmK);
+    // The output array has elements in the order: G, K, C, X, Y, Z
+    // GemmN = C * X * Y * Z for the BWD weight pass.
+    const index_t XYZ = std::accumulate(begin(e_g_k_c_xs_lengths) + spatial_offset,
+                                        end(e_g_k_c_xs_lengths),
+                                        index_t{1},
+                                        std::multiplies<>{});
+    const auto gemmN  = e_g_k_c_xs_lengths[I2] * XYZ;
+    return std::make_tuple(gemmM, gemmN, gemmK);
 }
 
 } // namespace device

--- a/include/ck/tensor_operation/gpu/device/impl/split_k_utils.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/split_k_utils.hpp
@@ -27,15 +27,13 @@ struct DeviceProperties
   int num_cu_;
 };
 
-inline ck::index_t get_best_occupancy_k_batch_value(int max_occupancy, ck::index_t grid_size_mn, ck::index_t num_conv_groups)
+inline ck::index_t get_best_occupancy_k_batch_value(int max_occupancy, ck::index_t grid_size)
 {
     static DeviceProperties device_properties;
     const int max_capacity = max_occupancy * device_properties.num_cu_;
 
-    // Empirically, when we have more than one group, we can oversubscribe by the number of groups.
-    // This is because the groups are independent and can be processed in parallel.
     ck::index_t k_batch = 1;
-    const auto optimal_split = static_cast<ck::index_t>(std::floor((1.0 * max_capacity) / (grid_size_mn)));
+    const auto optimal_split = static_cast<ck::index_t>(std::floor((1.0 * max_capacity) / grid_size));
     if (optimal_split > 1)
     {
       k_batch = optimal_split;
@@ -44,8 +42,7 @@ inline ck::index_t get_best_occupancy_k_batch_value(int max_occupancy, ck::index
     if (ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
     {
       std::cout << "[SPLIT-K AUTODEDUCE] Max active thread blocks per CU for GEMM kernel:  " << max_occupancy << std::endl;
-      std::cout << "[SPLIT-K AUTODEDUCE] Output grid size:  " << grid_size_mn << std::endl;
-      std::cout << "[SPLIT-K AUTODEDUCE] Number of conv groups:  " << num_conv_groups << std::endl;
+      std::cout << "[SPLIT-K AUTODEDUCE] Output grid size:  " << grid_size << std::endl;
       std::cout << "[SPLIT-K AUTODEDUCE] Optimal split-k value " << k_batch << std::endl;
     }
     return k_batch;

--- a/include/ck/tensor_operation/gpu/device/impl/split_k_utils.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/split_k_utils.hpp
@@ -32,24 +32,14 @@ inline ck::index_t get_best_occupancy_k_batch_value(int max_occupancy, ck::index
     static DeviceProperties device_properties;
     const int max_capacity = max_occupancy * device_properties.num_cu_;
 
-    constexpr ck::index_t k_batch_max = 1024;
-    const auto total_grid_size = grid_size_mn * num_conv_groups;
-    ck::index_t k_batch = static_cast<ck::index_t>(max_capacity / std::gcd(max_capacity, total_grid_size));
-    if (k_batch > k_batch_max || k_batch == 0)
+    // Empirically, when we have more than one group, we can oversubscribe by the number of groups.
+    // This is because the groups are independent and can be processed in parallel.
+    ck::index_t k_batch = 1;
+    const auto optimal_split = static_cast<ck::index_t>(std::floor((1.0 * max_capacity) / (grid_size_mn)));
+    if (optimal_split > 1)
     {
-      // TODO: This could be improved by using Euclidian algorithm to find the optimal k_batch.
-      auto min_remainder = max_capacity;
-      for (ck::index_t k = 1; k <= k_batch_max; ++k)
-      {
-        const auto remainder = (total_grid_size * k) % max_capacity;
-        // For equal remainder values, prefer smaller k values.
-        if (remainder < min_remainder)
-        {
-          min_remainder = remainder;
-          k_batch = k;
-        }
-      }
-    }
+      k_batch = optimal_split;
+    } 
     
     if (ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
     {

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -148,7 +148,7 @@
 #  <dilations>, (ie Dy, Dx for 2D)
 #  <left padding>, (ie LeftPy, LeftPx for 2D)
 #  <right padding>, (ie RightPy, RightPx for 2D)
-# SplitK
+# SplitK (-1 for internallly computed best split-K value, positive value to set k batches explicitly, or 'all' to test all internal split-K values)
 
  ################                   op   datatype  layout  verify  init  log  time  Ndims  G   N   K   C  Y  X  Hi  Wi  Sy  Sx  Dy  Dx  LeftPy  LeftPx  RightPy  RightPx  SplitK
 ./bin/ckProfiler grouped_conv_bwd_weight         1       1      0     1    0     1      2 32 256 256 512  3  3  28  28   1   1   1   1       1       0        0        0       1

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -148,7 +148,7 @@
 #  <dilations>, (ie Dy, Dx for 2D)
 #  <left padding>, (ie LeftPy, LeftPx for 2D)
 #  <right padding>, (ie RightPy, RightPx for 2D)
-# SplitK (-1 for internallly computed best split-K value, positive value to set k batches explicitly, or 'all' to test all internal split-K values)
+# SplitK (-1 for internally computed split-K value, positive value to set k batches explicitly, or 'all' to test all internal split-K values)
 
  ################                   op   datatype  layout  verify  init  log  time  Ndims  G   N   K   C  Y  X  Hi  Wi  Sy  Sx  Dy  Dx  LeftPy  LeftPx  RightPy  RightPx  SplitK
 ./bin/ckProfiler grouped_conv_bwd_weight         1       1      0     1    0     1      2 32 256 256 512  3  3  28  28   1   1   1   1       1       0        0        0       1

--- a/profiler/include/profiler/profile_grouped_conv_bwd_weight_impl.hpp
+++ b/profiler/include/profiler/profile_grouped_conv_bwd_weight_impl.hpp
@@ -262,7 +262,7 @@ bool profile_grouped_conv_bwd_weight_impl(int do_verification,
                     using AccDataType =
                         std::conditional_t<std::is_same_v<ComputeType, int8_t>, int32_t, float>;
                     const index_t num_accums         = output.GetElementSize() / conv_param.K_;
-                    const index_t num_accums_split_k = split_k_list[split_k_id];
+                    const index_t num_accums_split_k = split_k_value;
                     // Calculate thresholds
                     auto rtol =
                         ck::utils::get_relative_threshold<ComputeType, WeiDataType, AccDataType>(

--- a/profiler/include/profiler/profile_grouped_conv_bwd_weight_impl.hpp
+++ b/profiler/include/profiler/profile_grouped_conv_bwd_weight_impl.hpp
@@ -183,6 +183,7 @@ bool profile_grouped_conv_bwd_weight_impl(int do_verification,
         catch(const std::exception& e)
         {
             std::cerr << e.what() << '\n';
+            exit(EXIT_FAILURE);
         }
     }
 

--- a/profiler/include/profiler/profile_grouped_conv_bwd_weight_impl.hpp
+++ b/profiler/include/profiler/profile_grouped_conv_bwd_weight_impl.hpp
@@ -139,9 +139,9 @@ bool profile_grouped_conv_bwd_weight_impl(int do_verification,
     std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
 
     std::string best_op_name;
-    float best_avg_time      = 0;
-    float best_tflops        = 0;
-    float best_gb_per_sec    = 0;
+    float best_avg_time   = 0;
+    float best_tflops     = 0;
+    float best_gb_per_sec = 0;
     std::string best_split_k("1");
 
     // profile device Conv instances
@@ -171,14 +171,14 @@ bool profile_grouped_conv_bwd_weight_impl(int do_verification,
     range_copy(conv_param.input_left_pads_, begin(input_left_pads));
     range_copy(conv_param.input_right_pads_, begin(input_right_pads));
 
-    std::vector<ck::index_t> split_k_list = {/*auto deduce value*/-1, 1, 2, 4, 8, 16, 32, 64, 128};
+    std::vector<ck::index_t> split_k_list = {/*auto deduce value*/ -1, 1, 2, 4, 8, 16, 32, 64, 128};
 
-    if (split_k != "all")
+    if(split_k != "all")
     {
         try
         {
             ck::index_t split_k_value = std::stoi(split_k);
-            split_k_list = {split_k_value};
+            split_k_list              = {split_k_value};
         }
         catch(const std::exception& e)
         {
@@ -209,14 +209,15 @@ bool profile_grouped_conv_bwd_weight_impl(int do_verification,
                 out_element_op,
                 split_k_list[split_k_id]);
 
-            auto split_k_value = split_k_list[split_k_id];
+            auto split_k_value     = split_k_list[split_k_id];
             auto split_k_param_str = std::to_string(split_k_value);
-            auto* split_k_arg = dynamic_cast<ck::tensor_operation::device::ArgumentSplitK*>(argument_ptr.get());
-            if (split_k_arg && split_k_value < 0)
+            auto* split_k_arg =
+                dynamic_cast<ck::tensor_operation::device::ArgumentSplitK*>(argument_ptr.get());
+            if(split_k_arg && split_k_value < 0)
             {
-                split_k_value = split_k_arg->k_batch_;
+                split_k_value     = split_k_arg->k_batch_;
                 split_k_param_str = std::to_string(split_k_value) + " (best occupancy)";
-            }         
+            }
 
             const std::size_t workspace_sz = op_ptr->GetWorkSpaceSize(argument_ptr.get());
             DeviceMem workspace_dev(workspace_sz);

--- a/profiler/include/profiler/profile_grouped_conv_bwd_weight_impl.hpp
+++ b/profiler/include/profiler/profile_grouped_conv_bwd_weight_impl.hpp
@@ -11,6 +11,7 @@
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
+#include "ck/tensor_operation/gpu/device/impl/split_k_arg.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
 #include "ck/library/tensor_operation_instance/gpu/grouped_convolution_backward_weight.hpp"
@@ -40,7 +41,7 @@ bool profile_grouped_conv_bwd_weight_impl(int do_verification,
                                           bool do_log,
                                           bool time_kernel,
                                           const ck::utils::conv::ConvParam& conv_param,
-                                          ck::index_t split_k)
+                                          const std::string& split_k)
 {
     using InElementOp  = ck::tensor_operation::element_wise::PassThrough;
     using WeiElementOp = ck::tensor_operation::element_wise::PassThrough;
@@ -141,7 +142,7 @@ bool profile_grouped_conv_bwd_weight_impl(int do_verification,
     float best_avg_time      = 0;
     float best_tflops        = 0;
     float best_gb_per_sec    = 0;
-    ck::index_t best_split_k = 1;
+    std::string best_split_k("1");
 
     // profile device Conv instances
     bool all_pass = true;
@@ -170,11 +171,19 @@ bool profile_grouped_conv_bwd_weight_impl(int do_verification,
     range_copy(conv_param.input_left_pads_, begin(input_left_pads));
     range_copy(conv_param.input_right_pads_, begin(input_right_pads));
 
-    std::vector<ck::index_t> split_k_list = {1, 2, 4, 8, 16, 32, 64, 128};
+    std::vector<ck::index_t> split_k_list = {/*auto deduce value*/-1, 1, 2, 4, 8, 16, 32, 64, 128};
 
-    if(split_k > 0)
+    if (split_k != "all")
     {
-        split_k_list = {split_k};
+        try
+        {
+            ck::index_t split_k_value = std::stoi(split_k);
+            split_k_list = {split_k_value};
+        }
+        catch(const std::exception& e)
+        {
+            std::cerr << e.what() << '\n';
+        }
     }
 
     for(auto& op_ptr : op_ptrs)
@@ -200,6 +209,15 @@ bool profile_grouped_conv_bwd_weight_impl(int do_verification,
                 out_element_op,
                 split_k_list[split_k_id]);
 
+            auto split_k_value = split_k_list[split_k_id];
+            auto split_k_param_str = std::to_string(split_k_value);
+            auto* split_k_arg = dynamic_cast<ck::tensor_operation::device::ArgumentSplitK*>(argument_ptr.get());
+            if (split_k_arg && split_k_value < 0)
+            {
+                split_k_value = split_k_arg->k_batch_;
+                split_k_param_str = std::to_string(split_k_value) + " (best occupancy)";
+            }         
+
             const std::size_t workspace_sz = op_ptr->GetWorkSpaceSize(argument_ptr.get());
             DeviceMem workspace_dev(workspace_sz);
             op_ptr->SetWorkSpacePointer(argument_ptr.get(), workspace_dev.GetDeviceBuffer());
@@ -222,7 +240,7 @@ bool profile_grouped_conv_bwd_weight_impl(int do_verification,
 
                 std::cout << "Perf: " << std::setw(10) << avg_time << " ms, " << tflops
                           << " TFlops, " << gb_per_sec << " GB/s, " << op_name << ", SplitK "
-                          << split_k_list[split_k_id] << std::endl;
+                          << split_k_param_str << std::endl;
 
                 if(tflops > best_tflops)
                 {
@@ -230,7 +248,7 @@ bool profile_grouped_conv_bwd_weight_impl(int do_verification,
                     best_tflops     = tflops;
                     best_avg_time   = avg_time;
                     best_gb_per_sec = gb_per_sec;
-                    best_split_k    = split_k_list[split_k_id];
+                    best_split_k    = split_k_param_str;
                 }
 
                 if(do_verification)

--- a/profiler/src/profile_grouped_conv_bwd_weight.cpp
+++ b/profiler/src/profile_grouped_conv_bwd_weight.cpp
@@ -88,7 +88,7 @@ int profile_grouped_conv_bwd_weight(int argc, char* argv[])
 
     const auto params = ck::utils::conv::parse_conv_param(num_dim_spatial, 9, argv);
 
-    ck::index_t split_k = std::stoi(argv[8 + 1 + 4 + 6 * num_dim_spatial]);
+    const auto& split_k = std::string(argv[8 + 1 + 4 + 6 * num_dim_spatial]);
 
     using F32  = float;
     using F16  = ck::half_t;

--- a/profiler/src/profile_grouped_conv_bwd_weight.cpp
+++ b/profiler/src/profile_grouped_conv_bwd_weight.cpp
@@ -56,7 +56,9 @@ static void print_helper_msg()
               << "arg5: initialization (0: no init, 1: integer value, 2: decimal value)\n"
               << "arg6: print tensor value (0: no; 1: yes)\n"
               << "arg7: time kernel (0: no, 1: yes)\n"
-              << ck::utils::conv::get_conv_param_parser_helper_msg() << " SplitK (-1 for internally computed best split-K value, positive value to set k batches explicitly, or 'all' to test all internal split-K values)\n"
+              << ck::utils::conv::get_conv_param_parser_helper_msg()
+              << " SplitK (-1 for internally computed split-K value, positive value to set k "
+                 "batches explicitly, or 'all' to test all internal split-K values)\n"
               << std::endl;
 }
 

--- a/profiler/src/profile_grouped_conv_bwd_weight.cpp
+++ b/profiler/src/profile_grouped_conv_bwd_weight.cpp
@@ -56,7 +56,7 @@ static void print_helper_msg()
               << "arg5: initialization (0: no init, 1: integer value, 2: decimal value)\n"
               << "arg6: print tensor value (0: no; 1: yes)\n"
               << "arg7: time kernel (0: no, 1: yes)\n"
-              << ck::utils::conv::get_conv_param_parser_helper_msg() << " SplitK\n"
+              << ck::utils::conv::get_conv_param_parser_helper_msg() << " SplitK (-1 for internally computed best split-K value, positive value to set k batches explicitly, or 'all' to test all internal split-K values)\n"
               << std::endl;
 }
 

--- a/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight.cpp
+++ b/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight.cpp
@@ -108,7 +108,7 @@ class TestGroupedConvndBwdWeight : public ::testing::Test
                                        false, // do_log
                                        false, // time_kernel
                                        param,
-                                       split_k);
+                                       std::to_string(split_k));
                 }
             }
         }

--- a/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight.cpp
+++ b/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight.cpp
@@ -30,7 +30,7 @@ class TestGroupedConvndBwdWeight : public ::testing::Test
     using NDimSpatial = std::tuple_element_t<6, Tuple>;
 
     std::vector<ck::utils::conv::ConvParam> conv_params;
-    std::vector<ck::index_t> split_ks{1, 2};
+    std::vector<ck::index_t> split_ks{-1, 1, 2};
 
     bool skip_case(const ck::index_t split_k)
     {

--- a/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight_interface_xdl.cpp
+++ b/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight_interface_xdl.cpp
@@ -98,26 +98,26 @@ class TestGroupedConvndBwdWeight : public ::testing::Test
 
         bool is_supported = true;
 
-        for (const auto split_k : split_ks)
+        for(const auto split_k : split_ks)
         {
             auto argument = conv.MakeArgument(nullptr,
-                                            nullptr,
-                                            nullptr,
-                                            input_lengths,
-                                            input_strides,
-                                            filter_lengths,
-                                            weights_strides,
-                                            output_lengths,
-                                            output_strides,
-                                            conv_filter_strides,
-                                            conv_filter_dilations,
-                                            input_left_pads,
-                                            input_right_pads,
-                                            PassThrough{},
-                                            PassThrough{},
-                                            PassThrough{},
-                                            split_k);
-            is_supported &=conv.IsSupportedArgument(argument);
+                                              nullptr,
+                                              nullptr,
+                                              input_lengths,
+                                              input_strides,
+                                              filter_lengths,
+                                              weights_strides,
+                                              output_lengths,
+                                              output_strides,
+                                              conv_filter_strides,
+                                              conv_filter_dilations,
+                                              input_left_pads,
+                                              input_right_pads,
+                                              PassThrough{},
+                                              PassThrough{},
+                                              PassThrough{},
+                                              split_k);
+            is_supported &= conv.IsSupportedArgument(argument);
         }
         return is_supported;
     }

--- a/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight_interface_xdl.cpp
+++ b/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight_interface_xdl.cpp
@@ -52,7 +52,7 @@ class TestGroupedConvndBwdWeight : public ::testing::Test
     // clang-format on
 
     ck::utils::conv::ConvParam conv_param;
-    ck::index_t split_k{2};
+    std::vector<ck::index_t> split_ks{-1, 2};
 
     template <ck::index_t NDimSpatial>
     bool Run()
@@ -96,24 +96,30 @@ class TestGroupedConvndBwdWeight : public ::testing::Test
 
         auto conv = GroupedConvBwdWeightDeviceInstance{};
 
-        auto argument = conv.MakeArgument(nullptr,
-                                          nullptr,
-                                          nullptr,
-                                          input_lengths,
-                                          input_strides,
-                                          filter_lengths,
-                                          weights_strides,
-                                          output_lengths,
-                                          output_strides,
-                                          conv_filter_strides,
-                                          conv_filter_dilations,
-                                          input_left_pads,
-                                          input_right_pads,
-                                          PassThrough{},
-                                          PassThrough{},
-                                          PassThrough{},
-                                          split_k);
-        return conv.IsSupportedArgument(argument);
+        bool is_supported = true;
+
+        for (const auto split_k : split_ks)
+        {
+            auto argument = conv.MakeArgument(nullptr,
+                                            nullptr,
+                                            nullptr,
+                                            input_lengths,
+                                            input_strides,
+                                            filter_lengths,
+                                            weights_strides,
+                                            output_lengths,
+                                            output_strides,
+                                            conv_filter_strides,
+                                            conv_filter_dilations,
+                                            input_left_pads,
+                                            input_right_pads,
+                                            PassThrough{},
+                                            PassThrough{},
+                                            PassThrough{},
+                                            split_k);
+            is_supported &=conv.IsSupportedArgument(argument);
+        }
+        return is_supported;
     }
 };
 

--- a/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight_v3_interface_xdl.cpp
+++ b/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight_v3_interface_xdl.cpp
@@ -98,26 +98,26 @@ class TestGroupedConvndBwdWeight : public ::testing::Test
 
         bool is_supported = true;
 
-        for (const auto split_k : split_ks)
+        for(const auto split_k : split_ks)
         {
             auto argument = conv.MakeArgument(nullptr,
-                                          nullptr,
-                                          nullptr,
-                                          input_lengths,
-                                          input_strides,
-                                          filter_lengths,
-                                          weights_strides,
-                                          output_lengths,
-                                          output_strides,
-                                          conv_filter_strides,
-                                          conv_filter_dilations,
-                                          input_left_pads,
-                                          input_right_pads,
-                                          PassThrough{},
-                                          PassThrough{},
-                                          PassThrough{},
-                                          split_k);
-            is_supported &=conv.IsSupportedArgument(argument);
+                                              nullptr,
+                                              nullptr,
+                                              input_lengths,
+                                              input_strides,
+                                              filter_lengths,
+                                              weights_strides,
+                                              output_lengths,
+                                              output_strides,
+                                              conv_filter_strides,
+                                              conv_filter_dilations,
+                                              input_left_pads,
+                                              input_right_pads,
+                                              PassThrough{},
+                                              PassThrough{},
+                                              PassThrough{},
+                                              split_k);
+            is_supported &= conv.IsSupportedArgument(argument);
         }
         return is_supported;
     }

--- a/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight_v3_interface_xdl.cpp
+++ b/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight_v3_interface_xdl.cpp
@@ -52,7 +52,7 @@ class TestGroupedConvndBwdWeight : public ::testing::Test
     // clang-format on
 
     ck::utils::conv::ConvParam conv_param;
-    ck::index_t split_k{2};
+    std::vector<ck::index_t> split_ks{-1, 2};
 
     template <ck::index_t NDimSpatial>
     bool Run()
@@ -96,7 +96,11 @@ class TestGroupedConvndBwdWeight : public ::testing::Test
 
         auto conv = GroupedConvBwdWeightDeviceInstance{};
 
-        auto argument = conv.MakeArgument(nullptr,
+        bool is_supported = true;
+
+        for (const auto split_k : split_ks)
+        {
+            auto argument = conv.MakeArgument(nullptr,
                                           nullptr,
                                           nullptr,
                                           input_lengths,
@@ -113,7 +117,9 @@ class TestGroupedConvndBwdWeight : public ::testing::Test
                                           PassThrough{},
                                           PassThrough{},
                                           split_k);
-        return conv.IsSupportedArgument(argument);
+            is_supported &=conv.IsSupportedArgument(argument);
+        }
+        return is_supported;
     }
 };
 


### PR DESCRIPTION
## Proposed changes
Add option to automatically deduce the best split-K value for grouped backwards with weight convolutions. The logic is based on selecting split-K value $K_{\text{split}}$ such that the number workgroups is equal to the available theoretical capacity, i.e., 

$$\lambda_{\text{occupancy}}\times N_{\text{cu}} = M_{\text{tiles}} \times N_{\text{tiles}} \times N_{\text{groups}} \times K_{\text{split}}$$,

where $\lambda_{\text{occupancy}}$ is the maximum occupancy for the GEMM kernel that we can calculate with `hipOccupancyMaxActiveBlocksPerMultiprocessor` and $N_{\text{cu}}$ is the number of compute units. $M_{\text{tiles}}$ and $N_{\text{tiles}}$ are the number of output tiles, and $N_{\text{groups}}$ is the number of convolution groups.

The automatic deduction of the split-K value can triggered by providing a negative split-K value.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion


