### PR TITLE
Revert "[CK_TILE] Eliminate fmha batch_prefill warning caused by failed to meet occupancy requirement"

### DIFF
--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_batch_prefill_pipeline_qr_ks_vs_async.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_batch_prefill_pipeline_qr_ks_vs_async.hpp
@@ -122,9 +122,6 @@ struct BlockFmhaBatchPrefillPipelineQRKSVSAsync
             {
                 if constexpr(kPadSeqLenK && BiasEnum == BlockAttentionBiasEnum::ELEMENTWISE_BIAS)
                     return 1;
-                // use larger K/V LDS buffer size will lower the occupancy
-                else if constexpr(64 <= kK0 || 64 <= kK1)
-                    return 1;
                 else
                     return 2;
             }


### PR DESCRIPTION
Reverts ROCm/composable_kernel#2389

We don't have to lower down occupancy setting in order to supress the compilation warning (`-Wpass-failed`). This may affect the kernel efficiency after all.

```
warning: <unknown>:0:0: failed to meet occupancy target given by 'amdgpu-waves-per-eu' in '_ZN7ck_tile6kentryILi256ELi2ENS_38FmhaBatchPrefillWithPagedKVCacheKernelINS_40BlockFmhaBatchPrefillPipelineQRKSVSAsyncINS_24BlockFmhaPipelineProblemIDF16_DF16_DF16_ffDF16_hfDF16_fDF16_NS_13TileFmhaShapeINS_8sequenceIJLi64ELi128ELi64ELi128ELi64ELi128EEEENS5_IJLi4ELi1ELi1EEEENS5_IJLi16ELi16ELi16EEEES7_S8_Lb1EEELb1ENS_17ComposedAttentionILj4ELb1EEENS_30SimplifiedGenericAttentionMaskILb1EEENS_14TileFmhaTraitsILb1ELb1ELb1ELb1ELb1ELNS_22BlockAttentionBiasEnumE0ELb0ELb0ELb0ELb0ELin1ELb0EEEEENS_35BlockFmhaPipelineQXKSVSCustomPolicyILb1ELb1ELi3ELi3EEEEENS_17Default2DEpilogueINS_24Default2DEpilogueProblemIfDF16_Lb1ELb1ELb1ELNS_21memory_operation_enumE0EEEvEEEEJNSQ_21FmhaFwdGroupModeKargsEEEEvDpT2_': desired occupancy was 2, final occupancy is 1 [-Wpass-failed]
```