### PR TITLE
[Test Infra] keep going with running CI when clang-format stage fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1027,15 +1027,15 @@ pipeline {
                     }
                     steps{
                         buildHipClangJobAndReboot(setup_args:setup_args, setup_cmd: "", build_cmd: "", execute_cmd: execute_cmd, no_reboot:true)
+                        catchError(buildResult: null, stageResult: 'FAILURE'){
+                            sh 'exit 1'
+                        }
                     }
-                }
-            }
-            catchError(buildResult: null, stageResult: 'FAILURE'){
-                sh 'exit 1'
-            }
-            post{
-                always{
-                    cleanWs()
+                    post{
+                        always{
+                            cleanWs()
+                        }
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1027,7 +1027,14 @@ pipeline {
                     }
                     steps{
                         buildHipClangJobAndReboot(setup_args:setup_args, setup_cmd: "", build_cmd: "", execute_cmd: execute_cmd, no_reboot:true)
-                        cleanWs()
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE'){
+                            sh 'exit 1'
+                        }
+                    }
+                    post{
+                        always{
+                            cleanWs()
+                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1027,15 +1027,15 @@ pipeline {
                     }
                     steps{
                         buildHipClangJobAndReboot(setup_args:setup_args, setup_cmd: "", build_cmd: "", execute_cmd: execute_cmd, no_reboot:true)
-                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE'){
-                            sh 'exit 1'
-                        }
                     }
-                    post{
-                        always{
-                            cleanWs()
-                        }
-                    }
+                }
+            }
+            catchError(buildResult: null, stageResult: 'FAILURE'){
+                sh 'exit 1'
+            }
+            post{
+                always{
+                    cleanWs()
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1027,7 +1027,7 @@ pipeline {
                     }
                     steps{
                         buildHipClangJobAndReboot(setup_args:setup_args, setup_cmd: "", build_cmd: "", execute_cmd: execute_cmd, no_reboot:true)
-                        catchError(buildResult: null, stageResult: 'FAILURE'){
+                        catchError(buildResult: null, stageResult: null){
                             sh 'exit 1'
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1026,7 +1026,7 @@ pipeline {
                                 | xargs -n 1 -P 1 -I{} -t sh -c \'clang-format-12 -style=file {} | diff - {}\'"
                     }
                     steps{
-                        buildHipClangJobAndReboot(setup_args:setup_args, setup_cmd: "", build_cmd: "", execute_cmd: execute_cmd, no_reboot:true)
+                        buildHipClangJob(setup_args:setup_args, setup_cmd: "", build_cmd: "", execute_cmd: execute_cmd)
                         catchError(buildResult: null, stageResult: null){
                             sh 'exit 1'
                         }

--- a/example/ck_tile/35_batched_transpose/batched_transpose_api.cpp
+++ b/example/ck_tile/35_batched_transpose/batched_transpose_api.cpp
@@ -104,10 +104,7 @@ float batched_transpose(batched_transpose_trait t,
         {
             return transpose_fn_bf16_64_64_64_64_8_8_false_false(a, s);
         }
-        else
-        {
-            return transpose_fn_bf16_64_64_64_64_8_8_true_true(a, s);
-        }
+        else { return transpose_fn_bf16_64_64_64_64_8_8_true_true(a, s); }
     }
     return -1;
 }


### PR DESCRIPTION
## Proposed changes

Please describe the motivation behind the pull request, whether it enables a new feature or fixes a bug. If there are associated pull requests or issues, please link them to the pull request.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

