### PR TITLE
Remove filter for only batch on receipt 4

### DIFF
--- a/example/ck_tile/01_fmha/codegen/ops/fmha_bwd.py
+++ b/example/ck_tile/01_fmha/codegen/ops/fmha_bwd.py
@@ -775,7 +775,6 @@ def get_bwd_blobs(filter_list: str, receipt, mask_impl, optdim_list) -> Tuple[Fm
                 cond &= bias in ['no', 'bias']
                 cond &= dropout in ['no', 'dropout_wg32',  'dropout_wg16']
                 cond &= dpad == dvpad
-                cond &= mode == 'batch'
                 cond &= deterministic == "f"
                 if not cond:
                     continue


### PR DESCRIPTION
Filtering by F_mode caused linker errors in Pytorch. Remove the filter as we will likely need the grouped functionality at some point anyways.