### PR TITLE
fix the clang-format

### DIFF
--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_bwd_pipeline_default_policy.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_bwd_pipeline_default_policy.hpp
@@ -415,12 +415,12 @@ struct BlockFmhaBwdPipelineDefaultPolicy
             constexpr index_t N2_m = kNPerBlock / (N1_m * N0);
             constexpr auto dstr_m  = make_static_tile_distribution(
                 tile_distribution_encoding<
-                    sequence<>,
-                    tuple<sequence<N0, N1_m, N2_m>, sequence<K0_m, K1_m, K2>>,
-                    tuple<sequence<1>, sequence<1, 2>>, // N0, N1 K1
-                    tuple<sequence<0>, sequence<1, 1>>,
-                    sequence<2, 1, 2>, // K0 N2 K2
-                    sequence<0, 2, 2>>{});
+                     sequence<>,
+                     tuple<sequence<N0, N1_m, N2_m>, sequence<K0_m, K1_m, K2>>,
+                     tuple<sequence<1>, sequence<1, 2>>, // N0, N1 K1
+                     tuple<sequence<0>, sequence<1, 1>>,
+                     sequence<2, 1, 2>, // K0 N2 K2
+                     sequence<0, 2, 2>>{});
             static_assert(container_reduce(dstr_m.get_lengths(), std::multiplies<index_t>{}, 1) ==
                           kNPerBlock * kKPerBlock);
             return dstr_m;
@@ -464,12 +464,12 @@ struct BlockFmhaBwdPipelineDefaultPolicy
             constexpr index_t N0_m = kNPerBlock / (N2_m * N1);
             constexpr auto dstr_m  = make_static_tile_distribution(
                 tile_distribution_encoding<
-                    sequence<>,
-                    tuple<sequence<N0_m, N1, N2_m>, sequence<K0_m, K1_m, K2>>,
-                    tuple<sequence<1>, sequence<1, 2>>, // N1, N2 K1
-                    tuple<sequence<1>, sequence<2, 1>>,
-                    sequence<2, 1, 2>, // K0 N0 K2
-                    sequence<0, 0, 2>>{});
+                     sequence<>,
+                     tuple<sequence<N0_m, N1, N2_m>, sequence<K0_m, K1_m, K2>>,
+                     tuple<sequence<1>, sequence<1, 2>>, // N1, N2 K1
+                     tuple<sequence<1>, sequence<2, 1>>,
+                     sequence<2, 1, 2>, // K0 N0 K2
+                     sequence<0, 0, 2>>{});
             static_assert(container_reduce(dstr_m.get_lengths(), std::multiplies<index_t>{}, 1) ==
                           kNPerBlock * kKPerBlock);
             return dstr_m;
@@ -515,12 +515,12 @@ struct BlockFmhaBwdPipelineDefaultPolicy
             constexpr index_t M2_m = kMPerBlock / (M1_m * M0);
             constexpr auto dstr_m  = make_static_tile_distribution(
                 tile_distribution_encoding<
-                    sequence<>,
-                    tuple<sequence<M0, M1_m, M2_m>, sequence<K0_m, K1_m, K2>>,
-                    tuple<sequence<1>, sequence<1, 2>>, // M0, M1 K1
-                    tuple<sequence<0>, sequence<1, 1>>,
-                    sequence<2, 1, 2>, // K0 M2 K2
-                    sequence<0, 2, 2>>{});
+                     sequence<>,
+                     tuple<sequence<M0, M1_m, M2_m>, sequence<K0_m, K1_m, K2>>,
+                     tuple<sequence<1>, sequence<1, 2>>, // M0, M1 K1
+                     tuple<sequence<0>, sequence<1, 1>>,
+                     sequence<2, 1, 2>, // K0 M2 K2
+                     sequence<0, 2, 2>>{});
             static_assert(container_reduce(dstr_m.get_lengths(), std::multiplies<index_t>{}, 1) ==
                           kMPerBlock * kKPerBlock);
             return dstr_m;
@@ -566,12 +566,12 @@ struct BlockFmhaBwdPipelineDefaultPolicy
             constexpr index_t M2_m = kMPerBlock / (M1_m * M0);
             constexpr auto dstr_m  = make_static_tile_distribution(
                 tile_distribution_encoding<
-                    sequence<>,
-                    tuple<sequence<M0, M1_m, M2_m>, sequence<K0_m, K1_m, K2>>,
-                    tuple<sequence<1>, sequence<1, 2>>, // M0, M1 K1
-                    tuple<sequence<0>, sequence<1, 1>>,
-                    sequence<2, 1, 2>, // K0 M2 K2
-                    sequence<0, 2, 2>>{});
+                     sequence<>,
+                     tuple<sequence<M0, M1_m, M2_m>, sequence<K0_m, K1_m, K2>>,
+                     tuple<sequence<1>, sequence<1, 2>>, // M0, M1 K1
+                     tuple<sequence<0>, sequence<1, 1>>,
+                     sequence<2, 1, 2>, // K0 M2 K2
+                     sequence<0, 2, 2>>{});
             static_assert(container_reduce(dstr_m.get_lengths(), std::multiplies<index_t>{}, 1) ==
                           kMPerBlock * kKPerBlock);
             return dstr_m;

--- a/include/ck_tile/remod.py
+++ b/include/ck_tile/remod.py
@@ -1,8 +1,14 @@
-from datetime import datetime import pathlib from pathlib import Path import subprocess import os
-    import copy
+from datetime import datetime
+import pathlib
+from pathlib import Path
+import subprocess
+import os
+import copy
 
-        NS = 'ck_tile' OPS = 'ops' REF = 'ref' OPS_COMMON =
-            'common' #common header will be duplicated into ops/* other module
+NS = 'ck_tile'
+OPS = 'ops'
+REF = 'ref'
+OPS_COMMON = 'common' #common header will be duplicated into ops/* other module
 
 HEADER_COMMON = f"""// SPDX-License-Identifier: MIT
 // Copyright (c) 2018-{datetime.now().year}, Advanced Micro Devices, Inc. All rights reserved.\n

--- a/script/clang-format-overwrite.sh
+++ b/script/clang-format-overwrite.sh
@@ -1,2 +1,2 @@
 find . -name deps -prune -o -name build -prune -o -iname '*.h' -o -iname '*.hpp' -o -iname '*.cpp' -o -iname '*.h.in' -o -iname '*.hpp.in' -o -iname '*.cpp.in' -o -iname '*.cl' -o -iname '*.cuh' -o -iname '*.cu' -o -iname '*.inc' | xargs -n 1 -P 16 -I{} -t sh -c 'clang-format-18 -i -style=file {}'
-git status --porcelain | awk '$1 != "D" && (match($2, "\\.cpp|hpp|inc")) {print $2}' | xargs -n 1 -P 16 -I{} -t sh -c 'clang-format-18 -i -style=file {}'
+git status --porcelain | awk '$1 != "D" && (match($2, "\\.cpp|.hpp|.inc")) {print $2}' | xargs -n 1 -P 16 -I{} -t sh -c 'clang-format-18 -i -style=file {}'


### PR DESCRIPTION
## Proposed changes

Fix the clang-format-overwrite script, remod.py script, and clang format from latest PR.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x ] I have added inline documentation which enables the maintainers with understanding the motivation
- [x ] I have removed the stale documentation which is no longer relevant after this pull request
- [x ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x ] I have run `clang-format` on all changed files
- [x ] Any dependent changes have been merged

