### PR TITLE
[CI fix] remove std::format

### DIFF
--- a/test/ck_tile/batched_transpose/test_batched_transpose.cpp
+++ b/test/ck_tile/batched_transpose/test_batched_transpose.cpp
@@ -122,8 +122,7 @@ class TestCkTileBatchedTranspose //              N    C    H    W    layout_in==
         if(Config::kPipelineId == PipelineTag::LDSLoadTranspose &&
            device_name.find("gfx950") == std::string::npos)
         {
-            GTEST_SKIP_(
-                std::format("LDS Load Transpose cannot be launched with {}", device_name).c_str());
+            GTEST_SKIP_("LDS Load Transpose cannot be launched with this device");
         }
 
         const auto host_args = ck_tile::BatchedTransposeHostArgs{x_dev.GetDeviceBuffer(),


### PR DESCRIPTION
## Proposed changes

`std::format` belongs to STL formatting library which is introduced in C++20.
Even though we enable C++20 for the CK builds, the availability of library features depends on the environment, namely the installed libstdc++ version.
The legacy OS docker images which we are using in CI ship with outdated libstdc++, and using `std::format` trigger a build error
```
 .../test/ck_tile/batched_transpose/test_batched_transpose.cpp:126:22: error: no member named 'format' in namespace 'std'
   126 |                 std::format("LDS Load Transpose cannot be launched with {}", device_name).c_str());
       |                 ~~~~~^
```
One possible way to make C++20 library features available would be to install gcc14 and libstdc++6-devel-gcc14 IF we could change the legacy OS docker image's installed packages

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

