### PR TITLE
[CK_TILE][FMHA][Feature] Add support for large hdim

### DIFF
--- a/example/ck_tile/01_fmha/CMakeLists.txt
+++ b/example/ck_tile/01_fmha/CMakeLists.txt
@@ -107,7 +107,7 @@ if(FMHA_FWD_FAST_EXP2)
 else()
   list(APPEND EXAMPLE_FMHA_FWD_COMPILE_OPTIONS -Wno-undefined-func-template -DCK_TILE_FMHA_FWD_FAST_EXP2=0)
 endif()
-list(APPEND EXAMPLE_FMHA_BWD_COMPILE_OPTIONS -Wno-undefined-func-template -fgpu-flush-denormals-to-zero)
+list(APPEND EXAMPLE_FMHA_BWD_COMPILE_OPTIONS -Wno-undefined-func-template -fgpu-flush-denormals-to-zero -fbracket-depth=512)
 
 # conditionally enable call to the fwd_splitkv API in fmha_fwd example
 if("fwd_splitkv" IN_LIST FMHA_FWD_ENABLE_APIS)

--- a/example/ck_tile/01_fmha/codegen/ops/fmha_bwd.py
+++ b/example/ck_tile/01_fmha/codegen/ops/fmha_bwd.py
@@ -149,8 +149,33 @@ void fmha_bwd_dq_dk_dv_oneshot_<dq_dk_dv_trait_{F_idx}>(const ck_tile::stream_co
     auto [kargs, grids]                    = fmha_bwd_dq_dk_dv_create_kargs_and_grids<k_>(a);
     constexpr dim3 blocks                  = k_::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = k_::kBlockPerCu;
-    ck_tile::make_kernel<blocks.x, kBlockPerCu>(k_{{}}, grids, blocks, 0, kargs)(
-        ck_tile::stream_config{{s.stream_id_}});
+
+    // shared memory size need by fmha_bwd_dq_dk_dv_kernel_{F_idx} kernel
+    auto shared_mem_bytes = fmha_bwd_dq_dk_dv_kernel_{F_idx}::GetSmemSize();
+
+    // device properties
+    hipDeviceProp_t deviceProps;
+    HIP_CHECK_ERROR(hipGetDeviceProperties(&deviceProps, 0));
+    auto shared_mem_bytes_limit = deviceProps.sharedMemPerBlock;
+
+    // use dynamic shared memory if it is less than device limit
+    // otherwise, use workspace memory which is global memory
+
+    if (static_cast<size_t>(shared_mem_bytes) > shared_mem_bytes_limit) {{
+        // use workspace memory
+        char *workspace = nullptr;
+        auto workspace_size = shared_mem_bytes * grids.x * grids.y * grids.z;
+        HIP_CHECK_ERROR(hipMallocAsync(&workspace, workspace_size, s.stream_id_));
+
+        ck_tile::make_kernel<blocks.x, kBlockPerCu>(k_{{}}, grids, blocks, 0, kargs, workspace)(
+            ck_tile::stream_config{{s.stream_id_}});
+
+        HIP_CHECK_ERROR(hipFreeAsync(workspace, s.stream_id_));
+    }} else {{
+        // use dynamic shared memory
+        ck_tile::make_kernel<blocks.x, kBlockPerCu>(k_{{}}, grids, blocks, shared_mem_bytes, kargs)(
+            ck_tile::stream_config{{s.stream_id_}});
+    }}
 }}
 
 template <>
@@ -358,6 +383,8 @@ def get_fmha_bwd_dq_dk_dv_tile_ppl_dict_from_dtype(dtype : str) -> Optional[dict
             '128' : [FmhaBwdDQDKDVTileSize( 16, 128, 128, 16, 128, 16, 32, 128, 128, 1, 4, 1, 4, 1, 1, 1, 4, 1, 16, 16, 32, 16, 16, 16, 1),
                         "kr_ktr_vr_iglp", "kr_ktr_vr"],
             '256' : [FmhaBwdDQDKDVTileSize( 16,  64, 256, 16, 256, 16, 32, 256, 256, 1, 4, 1, 4, 1, 1, 1, 4, 1, 16, 16, 32, 16, 16, 16, 1),
+                        "kr_ktr_vr_iglp", "kr_ktr_vr"],
+            '512' : [FmhaBwdDQDKDVTileSize( 16,  64, 512, 16, 512, 16, 32, 512, 512, 1, 4, 1, 4, 1, 1, 1, 4, 1, 16, 16, 32, 16, 16, 16, 1),
                         "kr_ktr_vr_iglp", "kr_ktr_vr"]
         }
     else:

--- a/include/ck_tile/ops/fmha/kernel/fmha_bwd_kernel.hpp
+++ b/include/ck_tile/ops/fmha/kernel/fmha_bwd_kernel.hpp
@@ -1085,11 +1085,24 @@ struct FmhaBwdDQDKDVKernel
                             VGradEpiloguePipeline::GetSmemSize());
     }
 
+    CK_TILE_DEVICE void operator()(Kargs kargs, char* workspace) const
+    {
+    	// use workspace as shared memory
+    	auto smem_size_per_block = GetSmemSize();
+        auto block_id = gridDim.x * gridDim.y * blockIdx.z + gridDim.x * blockIdx.y + blockIdx.x;
+        return operator_core(kargs, workspace + block_id * smem_size_per_block);
+    }
+
     CK_TILE_DEVICE void operator()(Kargs kargs) const
     {
-        // allocate LDS
-        __shared__ char smem_ptr[GetSmemSize()];
+        // use dynamic shared memory
+        extern __shared__ char smem_ptr[];
 
+        return operator_core(kargs, smem_ptr);
+    }
+
+    CK_TILE_DEVICE void operator_core(Kargs kargs, char* smem_ptr) const
+    {
         // divide problem
         const auto [i_tile_n, i_nhead, i_batch] = GetTileIndex();
 

--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_bwd_pipeline_default_policy.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_bwd_pipeline_default_policy.hpp
@@ -587,7 +587,7 @@ struct BlockFmhaBwdPipelineDefaultPolicy
         constexpr index_t kMPerBlock = Problem::kM0;
         constexpr index_t kKPerBlock = Problem::kQKHeaddim;
 
-        constexpr index_t K1 = 16 / sizeof(AccDataType);
+        constexpr index_t K1 = 32 / sizeof(AccDataType);
         constexpr index_t K0 = kKPerBlock / K1;
 
         constexpr index_t M2 = get_warp_size() / K0;


### PR DESCRIPTION
* root cause: fhma_bwd not support if hdim > 256 due to the use of LDS goes beyond the hardware limitations.

* solution: use workspace(global) memory instead of LDS When the required LDS size exceeds the hardware limit.

## Proposed changes

Please describe the motivation behind the pull request, whether it enables a new feature or fixes a bug. If there are associated pull requests or issues, please link them to the pull request.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

