### PR TITLE
[CK_TILE][FMHA] Extend GenericAttentionMask to support local query token indices

### DIFF
--- a/include/ck_tile/ops/elementwise/unary_element_wise_operation.hpp
+++ b/include/ck_tile/ops/elementwise/unary_element_wise_operation.hpp
@@ -1308,7 +1308,7 @@ struct Swish
 
 struct SoftRelu
 {
-    SoftRelu(float alpha = 1.f) : alpha_(alpha){};
+    SoftRelu(float alpha = 1.f) : alpha_(alpha) {};
 
     template <typename T>
     CK_TILE_HOST_DEVICE void operator()(T& y, const T& x) const
@@ -1327,7 +1327,7 @@ struct SoftRelu
 struct Power
 {
     Power(float alpha = 0.f, float beta = 1.f, float gamma = 2.f)
-        : alpha_(alpha), beta_(beta), gamma_(gamma){};
+        : alpha_(alpha), beta_(beta), gamma_(gamma) {};
 
     template <typename T>
     CK_TILE_HOST_DEVICE void operator()(T& y, const T& x) const
@@ -1349,7 +1349,7 @@ struct Power
 
 struct ClippedRelu
 {
-    ClippedRelu(float alpha = 0.f, float beta = 1.f) : alpha_(alpha), beta_(beta){};
+    ClippedRelu(float alpha = 0.f, float beta = 1.f) : alpha_(alpha), beta_(beta) {};
 
     template <typename T>
     CK_TILE_HOST_DEVICE void operator()(T& y, const T& x) const
@@ -1368,7 +1368,7 @@ struct ClippedRelu
 
 struct LeakyRelu
 {
-    LeakyRelu(float alpha = 0.01f) : alpha_(alpha){};
+    LeakyRelu(float alpha = 0.01f) : alpha_(alpha) {};
 
     template <typename T>
     CK_TILE_HOST_DEVICE void operator()(T& y, const T& x) const
@@ -1385,7 +1385,7 @@ struct LeakyRelu
 
 struct Elu
 {
-    Elu(float alpha = 1.f) : alpha_(alpha){};
+    Elu(float alpha = 1.f) : alpha_(alpha) {};
 
     template <typename T>
     CK_TILE_HOST_DEVICE void operator()(T& y, const T& x) const
@@ -1402,7 +1402,7 @@ struct Elu
 
 struct Logistic
 {
-    Logistic(float alpha = 1.f) : alpha_(alpha){};
+    Logistic(float alpha = 1.f) : alpha_(alpha) {};
 
     template <typename T>
     CK_TILE_HOST_DEVICE void operator()(T& y, const T& x) const

--- a/include/ck_tile/ops/fmha/block/block_masking.hpp
+++ b/include/ck_tile/ops/fmha/block/block_masking.hpp
@@ -85,22 +85,36 @@ struct GenericAttentionMask
 
     static constexpr const char* name = impl::MaskName<IsMasking, IsLocal>::name;
 
-    CK_TILE_HOST_DEVICE GenericAttentionMask(index_t y_total_, index_t x_total_)
+    CK_TILE_HOST_DEVICE constexpr GenericAttentionMask(index_t y_total_, index_t x_total_)
         : GenericAttentionMask(0, 0, y_total_, x_total_)
     {
     }
 
     CK_TILE_HOST_DEVICE
-    GenericAttentionMask(index_t y_, index_t x_, index_t y_total_, index_t x_total_)
+    constexpr GenericAttentionMask(index_t y_, index_t x_, index_t y_total_, index_t x_total_)
         : y(y_), x(x_), y_total(y_total_), x_total(x_total_)
     {
     }
+
+    // Constructs from global mask parameters, adjusting them to be relative to the tile's origin.
+    CK_TILE_HOST_DEVICE
+    constexpr GenericAttentionMask(
+        index_t y_, index_t x_, index_t y_total_, index_t x_total_, index_t y_offset
+        /*, index_t x_offset*/)
+        : GenericAttentionMask(
+              /*y=*/y_ - y_offset /*+ x_offset*/,
+              /*x=*/x_ + y_offset /*- x_offset*/,
+              /*y_total=*/y_total_ - y_offset,
+              /*x_total=*/x_total_ /*- x_offset*/)
+    {
+    }
+
     template <typename MaskCoordinates>
-    CK_TILE_HOST_DEVICE GenericAttentionMask(const MaskCoordinates& mask_coord)
-        : y(mask_coord.at(number<0>{})),
-          x(mask_coord.at(number<1>{})),
-          y_total(mask_coord.at(number<2>{})),
-          x_total(mask_coord.at(number<3>{}))
+    CK_TILE_HOST_DEVICE constexpr GenericAttentionMask(const MaskCoordinates& mask_coord)
+        : GenericAttentionMask(/*y=*/mask_coord.at(number<0>{}),
+                               /*x=*/mask_coord.at(number<1>{}),
+                               /*y_total=*/mask_coord.at(number<2>{}),
+                               /*x_total=*/mask_coord.at(number<3>{}))
     {
     }
 
@@ -250,22 +264,40 @@ struct SimplifiedGenericAttentionMask
 
     static constexpr const char* name = impl::SimplifiedMaskName<IsMasking>::name;
 
-    CK_TILE_HOST_DEVICE SimplifiedGenericAttentionMask(index_t y_total_, index_t x_total_)
+    CK_TILE_HOST_DEVICE
+    constexpr SimplifiedGenericAttentionMask(index_t y_total_, index_t x_total_)
         : SimplifiedGenericAttentionMask(0, 0, y_total_, x_total_)
     {
     }
 
     CK_TILE_HOST_DEVICE
-    SimplifiedGenericAttentionMask(index_t y_, index_t x_, index_t y_total_, index_t x_total_)
+    constexpr SimplifiedGenericAttentionMask(index_t y_,
+                                             index_t x_,
+                                             index_t y_total_,
+                                             index_t x_total_)
         : y(y_), x(x_), y_total(y_total_), x_total(x_total_)
     {
     }
+
+    // Constructs from global mask parameters, adjusting them to be relative to the tile's origin.
+    CK_TILE_HOST_DEVICE
+    constexpr SimplifiedGenericAttentionMask(
+        index_t y_, index_t x_, index_t y_total_, index_t x_total_, index_t y_offset
+        /*, index_t x_offset*/)
+        : SimplifiedGenericAttentionMask(
+              /*y=*/y_ - y_offset /*+ x_offset*/,
+              /*x=*/x_ + y_offset /*- x_offset*/,
+              /*y_total=*/y_total_ - y_offset,
+              /*x_total=*/x_total_ /*- x_offset*/)
+    {
+    }
+
     template <typename MaskCoordinates>
-    CK_TILE_HOST_DEVICE SimplifiedGenericAttentionMask(const MaskCoordinates& mask_coord)
-        : y(mask_coord.at(number<0>{})),
-          x(mask_coord.at(number<1>{})),
-          y_total(mask_coord.at(number<2>{})),
-          x_total(mask_coord.at(number<3>{}))
+    CK_TILE_HOST_DEVICE constexpr SimplifiedGenericAttentionMask(const MaskCoordinates& mask_coord)
+        : SimplifiedGenericAttentionMask(/*y=*/mask_coord.at(number<0>{}),
+                                         /*x=*/mask_coord.at(number<1>{}),
+                                         /*y_total=*/mask_coord.at(number<2>{}),
+                                         /*x_total=*/mask_coord.at(number<3>{}))
     {
     }
 
@@ -624,10 +656,11 @@ make_generic_attention_mask_from_lr_window(index_t left_size,
                                            index_t right_size,
                                            index_t y_total,
                                            index_t x_total,
-                                           bool is_top_left = true)
+                                           bool is_top_left = true,
+                                           int y_offset     = 0)
 {
     auto r = make_generic_attention_mask_coordinates_from_lr_window(
         left_size, right_size, y_total, x_total, is_top_left);
-    return MaskType{r.at(number<0>{}), r.at(number<1>{}), y_total, x_total};
+    return MaskType{r.at(number<0>{}), r.at(number<1>{}), y_total, x_total, y_offset};
 }
 } // namespace ck_tile

--- a/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp
+++ b/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp
@@ -1365,7 +1365,8 @@ struct FmhaFwdKernel
                     kargs.window_size_right,
                     kargs.seqlen_q,
                     kargs.seqlen_k,
-                    kargs.mask_type == GenericAttentionMaskEnum::MASK_FROM_TOP_LEFT);
+                    kargs.mask_type == GenericAttentionMaskEnum::MASK_FROM_TOP_LEFT,
+                    i_m0);
             else
                 return FmhaMask{kargs.seqlen_q, kargs.seqlen_k};
         }();

--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs_async.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs_async.hpp
@@ -277,7 +277,7 @@ struct BlockFmhaPipelineQRKSVSAsync
         __builtin_amdgcn_sched_barrier(0);
         const auto q_origin = q_dram_window.get_window_origin();
         const auto [seqlen_k_start, seqlen_k_end] =
-            mask.GetTileRangeAlongX(q_origin.at(number<0>{}), number<kM0>{}, number<kN0>{});
+            mask.GetTileRangeAlongX(0, number<kM0>{}, number<kN0>{});
 
         const auto num_total_loop = integer_divide_ceil(seqlen_k_end - seqlen_k_start, kN0);
 
@@ -479,17 +479,15 @@ struct BlockFmhaPipelineQRKSVSAsync
             move_tile_window(bias_dram_window, {0, kN0});
             if constexpr(kPadSeqLenK || FmhaMask::IsMasking)
             {
-                const auto k_origin      = k_dram_block_window.get_window_origin();
-                bool need_perpixel_check = mask.IsEdgeTile(q_origin.at(number<0>{}),
-                                                           k_origin.at(number<0>{}),
-                                                           number<kM0>{},
-                                                           number<kN0>{});
+                const auto k_origin = k_dram_block_window.get_window_origin();
+                bool need_perpixel_check =
+                    mask.IsEdgeTile(0, k_origin.at(number<0>{}), number<kM0>{}, number<kN0>{});
 
                 if(need_perpixel_check)
                 {
                     set_tile_if(
                         s_acc, -numeric<SMPLComputeDataType>::infinity(), [&](auto tile_idx) {
-                            const auto row = q_origin.at(number<0>{}) + tile_idx.at(number<0>{});
+                            const auto row = tile_idx.at(number<0>{});
                             const auto col = k_origin.at(number<0>{}) + tile_idx.at(number<1>{});
                             return !variant.LogitsMask(variant_params,
                                                        block_indices.batch_idx,


### PR DESCRIPTION
## Proposed changes

Absorb the query tile origin into GenericAttentionMask/SimplifiedGenericAttentionMask data members so that we won't have to re-calculate them everytime while masking the S tile.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

