### PR TITLE
fix build for test_ck_tile_fp8 on rhel8

### DIFF
--- a/test/ck_tile/data_type/CMakeLists.txt
+++ b/test/ck_tile/data_type/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 if(CK_USE_OCP_FP8 OR CK_USE_FNUZ_FP8)
     add_gtest_executable(test_ck_tile_fp8 test_fp8.cpp)
     target_compile_options(test_ck_tile_fp8 PRIVATE -Wno-float-equal)
+    target_compile_definitions(test_ck_tile_fp8 PUBLIC GTEST_HAS_RTTI=0)
     # conditionally specify the use of OCP_FP8
     if(CK_USE_OCP_FP8)
         target_compile_options(test_ck_tile_fp8 PRIVATE -DCK_TILE_USE_OCP_FP8)


### PR DESCRIPTION
## Proposed changes

Observing linking error when building on RHEL8
```
FAILED: bin/test_ck_tile_fp8 
: && /opt/rocm/llvm/bin/clang++ -O3 -DNDEBUG --offload-arch=gfx942 --hip-link --rtlib=compiler-rt -unwindlib=libgcc test/ck_tile/data_type/CMakeFiles/test_ck_tile_fp8.dir/test_fp8.cpp.o -o bin/test_ck_tile_fp8  -Wl,-rpath,:::::::::::::::::::::::::::::::::::::::::::::::::::  lib/libgtest_main.a  lib/libgtest.a  -lpthread  /opt/rocm/lib/libamdhip64.so.6.3.60300  /opt/rocm-6.3.0-14787/lib/llvm/lib/clang/18/lib/linux/libclang_rt.builtins-x86_64.a  /opt/rocm-6.3.0-14787/lib/libamdhip64.so.6.3.60300 && :
ld.lld: error: undefined symbol: typeinfo for _Float16
>>> referenced by test_fp8.cpp
>>>               test/ck_tile/data_type/CMakeFiles/test_ck_tile_fp8.dir/test_fp8.cpp.o:(testing::internal::TypeParameterizedTest<ConvertTest, testing::internal::TemplateSel<ConvertTest_ToFp8_Test>, testing::internal::Types<_Float16>>::Register(char const*, testing::internal::CodeLocation const&, char const*, char const*, int, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&))
>>> referenced by test_fp8.cpp
>>>               test/ck_tile/data_type/CMakeFiles/test_ck_tile_fp8.dir/test_fp8.cpp.o:(testing::internal::TypeParameterizedTest<ConvertTest, testing::internal::TemplateSel<ConvertTest_ToBf8_Test>, testing::internal::Types<_Float16>>::Register(char const*, testing::internal::CodeLocation const&, char const*, char const*, int, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&))
>>> referenced by test_fp8.cpp
>>>               test/ck_tile/data_type/CMakeFiles/test_ck_tile_fp8.dir/test_fp8.cpp.o:(testing::internal::TypeParameterizedTest<ConvertTest, testing::internal::TemplateSel<ConvertTest_FromFp8_Test>, testing::internal::Types<_Float16>>::Register(char const*, testing::internal::CodeLocation const&, char const*, char const*, int, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&))
>>> referenced 3 more times
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

The compilation flag for GTest to disable RTTI remediates the error; the test builds and passes

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

(when libstdc++ has typeinfo for _Float16 - in newer versions - this issue doesn't show up. RHEL8 ships with GCC8)

