### PR TITLE
MGX RTC integration prototype

### DIFF
--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -15,10 +15,13 @@ include(ROCMTest)
 
 rocm_setup_version(VERSION 1.0)
 
+execute_process(COMMAND python3 ${CK_ROOT}/tile_engine/ops/gemm/gemm_instance_builder.py -d fp16 -ly rrr --gen_mgx -j ${CMAKE_CURRENT_SOURCE_DIR}/mgx_config.json -w ${CMAKE_CURRENT_SOURCE_DIR}/include/ck/host)
+
 list(APPEND CMAKE_MODULE_PATH ${CK_ROOT}/cmake)
 include(Embed)
 file(GLOB_RECURSE KERNEL_FILES CONFIGURE_DEPENDS
-    ${CK_ROOT}/include/ck/*.hpp)
+    ${CK_ROOT}/include/ck/*.hpp
+    ${CK_ROOT}/include/ck_tile/*.hpp)
 
 add_embed_library(ck_headers ${KERNEL_FILES} RELATIVE ${CK_ROOT}/include)
 

--- a/codegen/include/ck/host/prototype_header.hpp
+++ b/codegen/include/ck/host/prototype_header.hpp
@@ -1,0 +1,181 @@
+#pragma once
+
+#include <string>
+#include <stdexcept>
+
+namespace ck::host {
+
+enum class DataType
+{
+    Half,
+    Float,
+    BF16,
+    FP8,
+    BF8
+};
+
+std::string ToString(DataType type)
+{
+    if(type == DataType::Half)
+    {
+        return "ck_tile::half_t";
+    }
+    else if(type == DataType::Float)
+    {
+        return "float";
+    }
+    else if(type == DataType::BF16)
+    {
+        return "bf16_t";
+    }
+    else if(type == DataType::FP8)
+    {
+        return "fp8_t";
+    }
+    else if(type == DataType::BF8)
+    {
+        return "bf8_t";
+    }
+    else
+    {
+        throw std::runtime_error("Unknown type");
+    }
+}
+
+enum class Layout
+{
+    RowMajor,
+    ColumnMajor,
+};
+
+std::string ToString(Layout layout)
+{
+    if(layout == Layout::RowMajor)
+    {
+        return "ck_tile::tensor_layout::gemm::RowMajor";
+    }
+    else if(layout == Layout::ColumnMajor)
+    {
+        return "ck_tile::tensor_layout::gemm::ColumnMajor";
+    }
+    else
+    {
+        throw std::runtime_error("Unknown layout");
+    }
+}
+
+enum class Scheduler
+{
+    Default,
+    InterWave,
+    IntraWave,
+};
+
+std::string ToString(Scheduler scheduler)
+{
+    if(scheduler == Scheduler::Default)
+    {
+        return "ck_tile::GemmPipelineScheduler::Default";
+    }
+    else if(scheduler == Scheduler::InterWave)
+    {
+        return "ck_tile::GemmPipelineScheduler::Interwave";
+    }
+    else if(scheduler == Scheduler::IntraWave)
+    {
+        return "ck_tile::GemmPipelineScheduler::Intrawave";
+    }
+    else
+    {
+        throw std::runtime_error("Unknown GemmPipelineScheduler value");
+    }
+}
+
+enum class Pipeline
+{
+    Mem,
+    V3,
+    V4
+};
+
+std::string PipelineToBaseGemmPipeline(Pipeline pipeline)
+{
+    if(pipeline == Pipeline::Mem)
+    {
+        return "ck_tile::BaseGemmPipelineAgBgCrMem";
+    }
+    else if(pipeline == Pipeline::V3)
+    {
+        return "ck_tile::BaseGemmPipelineAgBgCrCompV3";
+    }
+    else if(pipeline == Pipeline::V4)
+    {
+        return "ck_tile::BaseGemmPipelineAgBgCrCompV4";
+    }
+    else
+    {
+        throw std::runtime_error("Unknown Pipeline value");
+    }
+}
+
+std::string PipelineToGemmPipeline(Pipeline pipeline)
+{
+    if(pipeline == Pipeline::Mem)
+    {
+        return "ck_tile::GemmPipelineAgBgCrMem";
+    }
+    else if(pipeline == Pipeline::V3)
+    {
+        return "ck_tile::GemmPipelineAgBgCrCompV3";
+    }
+    else if(pipeline == Pipeline::V4)
+    {
+        return "ck_tile::GemmPipelineAgBgCrCompV4";
+    }
+    else
+    {
+        throw std::runtime_error("Unknown Pipeline value");
+    }
+}
+
+enum class Epilogue
+{
+    Default2D,
+    CShuffle
+};
+
+std::string ToString(Epilogue epilogue)
+{
+    if(epilogue == Epilogue::Default2D)
+    {
+        return "ck_tile::Default2DEpilogueSelector";
+    }
+    else if(epilogue == Epilogue::CShuffle)
+    {
+        return "ck_tile::CShuffleEpilogueSelector";
+    }
+    else
+    {
+        throw std::runtime_error("Unknown GemmEpilogueType value");
+    }
+}
+
+std::string ToString(bool val) { return val ? "true" : "false"; }
+
+struct GemmKernelInstanceParams
+{
+    Pipeline pipeline;
+    Scheduler scheduler;
+    Epilogue epilogue;
+    int tileM;
+    int tileN;
+    int tileK;
+    int warpM;
+    int warpN;
+    int warpK;
+    int warpTileM;
+    int warpTileN;
+    int warpTileK;
+};
+
+} // namespace ck::host

--- a/codegen/mgx_config.json
+++ b/codegen/mgx_config.json
@@ -1,0 +1,100 @@
+{
+  "problem": {
+  },
+  "tile_config": {
+    "tile_m": {
+      "values": [
+        256
+      ]
+    },
+    "tile_n": {
+      "values": [
+        128,
+        256
+      ]
+    },
+    "tile_k": {
+      "values": [
+        32
+      ]
+    },
+    "warp_m": {
+      "values": [
+        1,
+        2,
+        4
+      ]
+    },
+    "warp_n": {
+      "values": [
+        1,
+        2,
+        4
+      ]
+    },
+    "warp_k": {
+      "values": [
+        1
+      ]
+    },
+    "warp_tile_m": {
+      "values": [
+        4,
+        16, 
+        32
+      ]
+    },
+    "warp_tile_n": {
+      "values": [
+        16,
+        32,
+        64
+      ]
+    },
+    "warp_tile_k": {
+      "values": [
+        8,
+        16,
+        32,
+        64,
+        128
+      ]
+    }
+  },
+  "trait_config": {
+    "pipeline": {
+      "values": [
+        "compv3",
+        "compv4",
+        "mem"
+      ]
+    },
+    "scheduler": {
+      "values": [
+        "intrawave",
+        "interwave"
+      ]
+    },
+    "epilogue": {
+      "values": [
+        "cshuffle",
+        "default"
+      ]
+    },
+    "pad_m": {
+      "values": [
+        false
+      ]
+    },
+    "pad_n": {
+      "values": [
+        false
+      ]
+    },
+    "pad_k": {
+      "values": [
+        false
+      ]
+    }
+  }
+}

--- a/codegen/test/prototype.cpp
+++ b/codegen/test/prototype.cpp
@@ -1,0 +1,332 @@
+#include "ck/host/stringutils.hpp"
+#include "ck/host/utils.hpp"
+#include "ck/host/prototype_header.hpp"
+#include "ck/host/mgx_instances.hpp"
+#include "common.hpp"
+#include <iostream>
+#include <rtc/compile_kernel.hpp>
+#include <rtc/hip.hpp>
+#include <test.hpp>
+#include <cmath>
+#include <typeindex>
+
+using half = _Float16;
+
+using namespace ck::host;
+
+struct GemmProblem
+{
+    int M                = 0;
+    int N                = 0;
+    int K                = 0;
+    Layout ALayout       = Layout::RowMajor;
+    Layout BLayout       = Layout::RowMajor;
+    Layout CLayout       = Layout::RowMajor;
+    DataType ADataType   = DataType::Half;
+    DataType BDataType   = DataType::Half;
+    DataType CDataType   = DataType::Half;
+    DataType AccDataType = DataType::Float;
+    bool TransA          = false;
+    bool TransB          = false;
+    bool TransC          = false;
+};
+
+struct GemmSolution
+{
+    std::string kernel;
+    GemmKernelInstanceParams instance_params;
+};
+
+auto GetInstanceArray(DataType a_type, DataType b_type, DataType c_type)
+{
+    if(a_type == DataType::Half && b_type == DataType::Half && c_type == DataType::Half)
+    {
+        return std::make_tuple(fp16_fp16_fp16_instance_params.data(),
+                               fp16_fp16_fp16_instance_params.size());
+    }
+    else if(a_type == DataType::BF16 && b_type == DataType::BF16 && c_type == DataType::BF16)
+    {
+        return std::make_tuple(bf16_bf16_bf16_instance_params.data(),
+                               bf16_bf16_bf16_instance_params.size());
+    }
+    else if(a_type == DataType::FP8 && b_type == DataType::FP8 && c_type == DataType::Half)
+    {
+        return std::make_tuple(fp8_fp8_fp16_instance_params.data(),
+                               fp8_fp8_fp16_instance_params.size());
+    }
+    else if(a_type == DataType::BF8 && b_type == DataType::BF8 && c_type == DataType::Half)
+    {
+        return std::make_tuple(bf8_bf8_fp16_instance_params.data(),
+                               bf8_bf8_fp16_instance_params.size());
+    }
+    else
+    {
+        throw std::runtime_error("Invalid gemm input type configuration");
+    }
+}
+
+std::vector<GemmSolution> GetGemmSolutions(const GemmProblem& problem)
+{
+    static const std::string template_string = R"__ck__(
+    ck_tile::MGXPrototypeGemmKernel<${BaseGemmPipeline},
+                                    ${GemmPipeline},
+                                    ${DoubleSmemBuffer},
+                                    ${Scheduler},
+                                    ${EpilogueSelector},
+                                    ${TileM},
+                                    ${TileN},
+                                    ${TileK},
+                                    ${WarpM},
+                                    ${WarpN},
+                                    ${WarpK},
+                                    ${WarpTileM},
+                                    ${WarpTileN},
+                                    ${WarpTileK},
+                                    ${StructuredSparsity},
+                                    /**/
+                                    ${ALayout},
+                                    ${BLayout},
+                                    ${CLayout},
+                                    ${ADataType},
+                                    ${BDataType},
+                                    ${CDataType},
+                                    ${AccDataType},
+                                    ${permuteA},
+                                    ${permuteB},
+                                    ${TransposeC},
+                                    ${M},
+                                    ${N},
+                                    ${K},
+                                    ${KBatch},
+                                    ${PadM},
+                                    ${PadN},
+                                    ${PadK}>;
+    )__ck__";
+
+    constexpr auto should_pad = [](size_t dim, size_t dim_per_block) {
+        return dim % dim_per_block != 0;
+    };
+
+    std::vector<GemmSolution> solutions;
+
+    const auto [instance_params, num_instance_params] =
+        GetInstanceArray(problem.ADataType, problem.BDataType, problem.CDataType);
+    
+    for(auto i = 0; i < num_instance_params; ++i) 
+    {
+        const auto& ip = instance_params[i];
+
+        auto kernel_str = ck::host::InterpolateString(
+            template_string,
+            {
+                /**/
+                {"BaseGemmPipeline", PipelineToBaseGemmPipeline(ip.pipeline)},
+                {"GemmPipeline", PipelineToGemmPipeline(ip.pipeline)},
+                {"DoubleSmemBuffer", ToString(ip.pipeline == Pipeline::V4 ? true : false)},
+                {"Scheduler", ToString(ip.scheduler)},
+                {"EpilogueSelector", ToString(ip.epilogue)},
+                //
+                {"TileM", std::to_string(ip.tileM)},
+                {"TileN", std::to_string(ip.tileN)},
+                {"TileK", std::to_string(ip.tileK)},
+                //
+                {"WarpM", std::to_string(ip.warpM)},
+                {"WarpN", std::to_string(ip.warpN)},
+                {"WarpK", std::to_string(ip.warpK)},
+                //
+                {"WarpTileM", std::to_string(ip.warpTileM)},
+                {"WarpTileN", std::to_string(ip.warpTileN)},
+                {"WarpTileK", std::to_string(ip.warpTileK)},
+                //
+                {"StructuredSparsity", ToString(false)},
+                //
+                {"ALayout", ToString(problem.ALayout)},
+                {"BLayout", ToString(problem.BLayout)},
+                {"CLayout", ToString(problem.CLayout)},
+                //
+                {"ADataType", ToString(problem.ADataType)},
+                {"BDataType", ToString(problem.BDataType)},
+                {"CDataType", ToString(problem.CDataType)},
+                {"AccDataType", ToString(problem.AccDataType)},
+                //
+                {"permuteA", ToString(problem.TransA)},
+                {"permuteB", ToString(problem.TransB)},
+                {"TransposeC", ToString(problem.TransC)},
+                //
+                {"M", std::to_string(problem.M)},
+                {"N", std::to_string(problem.N)},
+                {"K", std::to_string(problem.K)},
+                {"KBatch", std::to_string(1)},
+                //
+                {"PadM", ToString(should_pad(problem.M, ip.tileM))},
+                {"PadN", ToString(should_pad(problem.N, ip.tileN))},
+                {"PadK", ToString(should_pad(problem.K, ip.tileK))}
+                /**/
+            });
+        solutions.push_back({kernel_str, ip});
+    }
+
+    return solutions;
+}
+
+const std::string info_string = R"__ck__(
+#include <hip/hip_runtime.h>
+#include <ck_tile/ops/gemm.hpp>
+#include <ck_tile/ops/epilogue.hpp>
+#include <ck_tile/ops/gemm/kernel/mgx_prototype_gemm_kernel.hpp>
+
+extern "C" __global__ void info_kernel(dim3* dims) {
+    using Kernel = ${KernelInstance}
+    constexpr int M = ${M};
+    constexpr int N = ${N};
+    constexpr int K = ${K};
+    constexpr int KBatch = ${KBatch};
+
+    constexpr ck_tile::GemmKernelArgs kernel_args{M, N, K, K, N, {}, N, KBatch};
+    static_assert(Kernel::IsSupportedArgument(kernel_args), "Invalid gemm");
+
+    dims[0] = Kernel::GridSize();
+    dims[1] = Kernel::BlockSize();
+}
+
+)__ck__";
+
+std::tuple<dim3, dim3> get_launch_dims(const std::string& template_str, int M, int N, int K)
+{
+    auto srcs     = get_headers_for_test();
+    auto main_src = ck::host::InterpolateString(info_string,
+                                                {{"KernelInstance", template_str},
+                                                 {"M", std::to_string(M)},
+                                                 {"N", std::to_string(N)},
+                                                 {"K", std::to_string(K)},
+                                                 {"KBatch", std::to_string(1)}});
+
+    srcs.push_back({"main.cpp", main_src});
+    rtc::compile_options opts;
+    opts.kernel_name = "info_kernel";
+    auto k           = rtc::compile_kernel(srcs, opts);
+
+    rtc::buffer<dim3> dims(2);
+    auto dims_gpu = to_gpu(dims);
+    k.launch(nullptr, 1, 1)(dims_gpu.data());
+    dims = rtc::from_gpu(dims_gpu);
+    dims[0].x *= dims[1].x;
+    dims[0].y *= dims[1].y;
+    dims[0].z *= dims[1].z;
+
+    return {dims[0], dims[1]};
+}
+
+const std::string rtc_string = R"__ck__(
+#include <ck_tile/ops/gemm/kernel/mgx_prototype_gemm_kernel.hpp>
+
+extern "C" __global__ void f(const ck_tile::half_t* a, const ck_tile::half_t* b, ck_tile::half_t* c) {
+    using Kernel = ${KernelInstance}
+
+    constexpr int M = ${M};
+    constexpr int N = ${N};
+    constexpr int K = ${K};
+    constexpr int KBatch = ${KBatch};
+
+    constexpr ck_tile::GemmKernelArgs kernel_args{M, N, K, K, N, {}, N, KBatch};
+
+    static_assert(Kernel::IsSupportedArgument(kernel_args), "Invalid gemm");
+
+    auto run_args = kernel_args;
+    run_args.a_ptr = a;
+    run_args.b_ptr = b;
+    run_args.e_ptr = c;
+    Kernel::Run(run_args);
+}
+
+)__ck__";
+
+TEST_CASE(prototype)
+{
+    GemmProblem problem{.M           = 100,
+                        .N           = 72,
+                        .K           = 144,
+                        .ALayout     = Layout::RowMajor,
+                        .BLayout     = Layout::RowMajor,
+                        .CLayout     = Layout::RowMajor,
+                        .ADataType   = DataType::Half,
+                        .BDataType   = DataType::Half,
+                        .CDataType   = DataType::Half,
+                        .AccDataType = DataType::Float,
+                        .TransA      = false,
+                        .TransB      = false,
+                        .TransC      = false};
+
+    const auto solutions = GetGemmSolutions(problem);
+    rtc::buffer<half> a(problem.M * problem.K);
+    rtc::buffer<half> b(problem.K * problem.N);
+    rtc::buffer<half> c(problem.M * problem.N);
+
+    constexpr auto set_buffer = [](rtc::buffer<half>& buff, float val) {
+        for(auto i = 0; i < buff.size(); ++i)
+        {
+            buff[i] = static_cast<half>(val);
+        }
+    };
+    set_buffer(a, 1.0f);
+    set_buffer(b, 1.0f);
+    auto a_gpu = to_gpu(a);
+    auto b_gpu = to_gpu(b);
+
+    int num_invalid = 0;
+    int num_failed  = 0;
+    for(auto i = 0u; i < solutions.size(); ++i)
+    {
+        std::cout << "Trying solution " << i << std::endl;
+        const auto gemm_kernel_str = solutions[i].kernel;
+        dim3 global_work_dims, local_work_dims;
+
+        try
+        {
+            auto ret         = get_launch_dims(gemm_kernel_str, problem.M, problem.N, problem.K);
+            global_work_dims = std::get<0>(ret);
+            local_work_dims  = std::get<1>(ret);
+            std::cout << "Got launch dims" << std::endl;
+        }
+        catch(...)
+        {
+            std::cout << "Invalid kernel instance" << std::endl;
+            ++num_invalid;
+            continue;
+        }
+
+        auto srcs     = get_headers_for_test();
+        auto main_src = ck::host::InterpolateString(rtc_string,
+                                                    {{"KernelInstance", gemm_kernel_str},
+                                                     {"M", std::to_string(problem.M)},
+                                                     {"N", std::to_string(problem.N)},
+                                                     {"K", std::to_string(problem.K)},
+                                                     {"KBatch", std::to_string(1)}});
+        srcs.push_back({"main.cpp", main_src});
+        rtc::compile_options opts;
+        opts.kernel_name = "f";
+        auto k           = rtc::compile_kernel(srcs, opts);
+
+        set_buffer(c, 0.0f);
+        auto c_gpu = to_gpu(c);
+        k.launch(nullptr, global_work_dims, local_work_dims)(
+            a_gpu.data(), b_gpu.data(), c_gpu.data());
+        std::cout << "Executed kernel" << std::endl;
+        c = rtc::from_gpu(c_gpu);
+
+        for(auto i = 0; i < c.size(); ++i)
+        {
+            if(static_cast<float>(c[i]) != problem.K)
+            {
+                std::cout << "ERROR: Mismatch on index " << i << ": " << static_cast<float>(c[i])
+                          << std::endl;
+                ++num_failed;
+                break;
+            }
+        }
+    }
+    std::cout << "Number of invalid kernels: " << num_invalid << std::endl;
+    std::cout << "Number of failed kernels: " << num_failed << std::endl;
+}
+
+int main(int argc, const char* argv[]) { test::run(argc, argv); }

--- a/codegen/test/rtc/include/rtc/kernel.hpp
+++ b/codegen/test/rtc/include/rtc/kernel.hpp
@@ -40,6 +40,11 @@ struct kernel
     }
 
     void launch(hipStream_t stream,
+                dim3 grid_dims,
+                dim3 block_dims,
+                const std::vector<kernel_argument>& args) const;
+
+    void launch(hipStream_t stream,
                 std::size_t global,
                 std::size_t local,
                 const std::vector<kernel_argument>& args) const;
@@ -54,6 +59,14 @@ struct kernel
     {
         return [=](auto&&... xs) {
             launch(stream, global, local, std::vector<kernel_argument>{xs...}, zs...);
+        };
+    }
+
+    template <class... Ts>
+    auto launch(hipStream_t stream, dim3 grid_dims, dim3 block_dims, Ts... zs) const
+    {
+        return [=](auto&&... xs) {
+            launch(stream, grid_dims, block_dims, std::vector<kernel_argument>{xs...}, zs...);
         };
     }
 

--- a/codegen/test/rtc/src/compile_kernel.cpp
+++ b/codegen/test/rtc/src/compile_kernel.cpp
@@ -277,6 +277,7 @@ std::vector<std::vector<char>> compile_hip_src_with_hiprtc(const std::vector<src
 
 static kernel hiprtc_compile_kernel(const std::vector<src_file>& srcs, compile_options options)
 {
+    std::cout << "HIPRTC" << std::endl;
     options.flags += " -I. -O3";
     options.flags += " -std=c++17";
     options.flags += " -DCK_CODE_GEN_RTC";
@@ -292,11 +293,12 @@ static kernel hiprtc_compile_kernel(const std::vector<src_file>& srcs, compile_o
 
 kernel compile_kernel(const std::vector<src_file>& srcs, compile_options options)
 {
-#ifdef HIPRTC_FOR_CODEGEN_TESTS
-    return hiprtc_compile_kernel(srcs, options);
-#else
     return clang_compile_kernel(srcs, options);
-#endif
+// #ifdef HIPRTC_FOR_CODEGEN_TESTS
+//     return hiprtc_compile_kernel(srcs, options);
+// #else
+//     return clang_compile_kernel(srcs, options);
+// #endif
 }
 
 } // namespace rtc

--- a/codegen/test/rtc/src/kernel.cpp
+++ b/codegen/test/rtc/src/kernel.cpp
@@ -6,6 +6,7 @@
 #include <rtc/hip.hpp>
 #include <stdexcept>
 #include <cassert>
+#include <iostream>
 
 // extern declare the function since hip/hip_ext.h header is broken
 extern hipError_t hipExtModuleLaunchKernel(hipFunction_t, // NOLINT
@@ -68,13 +69,11 @@ kernel::kernel(const char* image, const std::string& name) : impl(std::make_shar
 
 void launch_kernel(hipFunction_t fun,
                    hipStream_t stream,
-                   std::size_t global,
-                   std::size_t local,
+                   dim3 grid_dims,
+                   dim3 block_dims,
                    void* kernargs,
                    std::size_t size)
 {
-    assert(global > 0);
-    assert(local > 0);
     void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
                       kernargs,
                       HIP_LAUNCH_PARAM_BUFFER_SIZE,
@@ -82,12 +81,12 @@ void launch_kernel(hipFunction_t fun,
                       HIP_LAUNCH_PARAM_END};
 
     auto status = hipExtModuleLaunchKernel(fun,
-                                           global,
-                                           1,
-                                           1,
-                                           local,
-                                           1,
-                                           1,
+                                           grid_dims.x,
+                                           grid_dims.y,
+                                           grid_dims.z,
+                                           block_dims.x,
+                                           block_dims.y,
+                                           block_dims.z,
                                            0,
                                            stream,
                                            nullptr,
@@ -96,6 +95,44 @@ void launch_kernel(hipFunction_t fun,
                                            nullptr);
     if(status != hipSuccess)
         throw std::runtime_error("Failed to launch kernel: " + hip_error(status));
+}
+
+void launch_kernel(hipFunction_t fun,
+                   hipStream_t stream,
+                   std::size_t global,
+                   std::size_t local,
+                   void* kernargs,
+                   std::size_t size)
+{
+    assert(global > 0);
+    assert(local > 0);
+    launch_kernel(fun,
+                  stream,
+                  dim3{static_cast<uint32_t>(global), 1, 1},
+                  dim3{static_cast<uint32_t>(local), 1, 1},
+                  kernargs,
+                  size);
+    // void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
+    //                   kernargs,
+    //                   HIP_LAUNCH_PARAM_BUFFER_SIZE,
+    //                   &size,
+    //                   HIP_LAUNCH_PARAM_END};
+
+    // auto status = hipExtModuleLaunchKernel(fun,
+    //                                        global,
+    //                                        1,
+    //                                        1,
+    //                                        local,
+    //                                        1,
+    //                                        1,
+    //                                        0,
+    //                                        stream,
+    //                                        nullptr,
+    //                                        reinterpret_cast<void**>(&config),
+    //                                        nullptr,
+    //                                        nullptr);
+    // if(status != hipSuccess)
+    //     throw std::runtime_error("Failed to launch kernel: " + hip_error(status));
 }
 
 void kernel::launch(hipStream_t stream,
@@ -108,6 +145,18 @@ void kernel::launch(hipStream_t stream,
     std::size_t size = args.size() * sizeof(void*);
 
     launch_kernel(impl->fun, stream, global, local, kernargs, size);
+}
+
+void kernel::launch(hipStream_t stream,
+                    dim3 grid_dims,
+                    dim3 block_dims,
+                    const std::vector<kernel_argument>& args) const
+{
+    assert(impl != nullptr);
+    std::vector<char> kernargs = pack_args(args);
+    std::size_t size           = kernargs.size();
+
+    launch_kernel(impl->fun, stream, grid_dims, block_dims, kernargs.data(), size);
 }
 
 void kernel::launch(hipStream_t stream,

--- a/include/ck_tile/core/tensor/load_tile_transpose.hpp
+++ b/include/ck_tile/core/tensor/load_tile_transpose.hpp
@@ -131,7 +131,7 @@ struct DefaultTranspose
         static constexpr bool suffix_valid_dim1 =
             util::is_sequence_suffix_v<decltype(quad_hs[I1]), decltype(input_hs[I1])>;
 
-        // 3. PS→RHS mapping constraints
+        // 3. PS->RHS mapping constraints
         static constexpr auto input_ps_major = InDstrEncode::ps_to_rhss_major_;
         static constexpr auto input_ps_minor = InDstrEncode::ps_to_rhss_minor_;
 
@@ -156,7 +156,7 @@ struct DefaultTranspose
             util::is_sequence_suffix_v<decltype(shifted_quad_ps_minor0),
                                        decltype(input_ps_minor_last)>;
 
-        // 4. YS→RHS mapping constraints
+        // 4. YS->RHS mapping constraints
         static constexpr auto input_ys_major = InDstrEncode::ys_to_rhs_major_;
         static constexpr auto input_ys_minor = InDstrEncode::ys_to_rhs_minor_;
         static constexpr auto quad_ys_major  = QuadEncoding::ys_to_rhs_major_;
@@ -263,7 +263,7 @@ struct TransposeTileDistributionTraits
         },
         number<InDstrEncode::NDimX>{});
 
-    // for PS→RHS mapping(both major and minor), we need to modify the last element (which is for
+    // for PS->RHS mapping(both major and minor), we need to modify the last element (which is for
     // thread distr) of the major sequence
     static constexpr auto dst_ps_to_rhss_major = generate_tuple(
         // for major because of dst_out_hs_lengthss is reversed, this index also need to be reversed

--- a/include/ck_tile/host/reference/reference_topk.hpp
+++ b/include/ck_tile/host/reference/reference_topk.hpp
@@ -15,11 +15,11 @@ namespace ck_tile {
 
 /*
     similiar to torch.topk()
-    x (Tensor) – the input tensor.
-    k (int) – the k in “top-k”
-    dim (int, optional) – the dimension to sort along
-    largest (bool, optional) – largest or smallest elements
-    sorted (bool, optional) – elements in sorted order or not
+    x (Tensor) - the input tensor.
+    k (int) - the k in "top-k"
+    dim (int, optional) - the dimension to sort along
+    largest (bool, optional) - largest or smallest elements
+    sorted (bool, optional) - elements in sorted order or not
 
     output:
     y_values

--- a/include/ck_tile/ops/fmha/block/block_dropout.hpp
+++ b/include/ck_tile/ops/fmha/block/block_dropout.hpp
@@ -121,7 +121,7 @@ struct BlockDropout
             sequence<1, 2>,
             sequence<0, 0>>{};
 
-        // Use Bwd WarpGemm to ensure that Fwd's random values ​​are consistent with Bwd.
+        // Use Bwd WarpGemm to ensure that Fwd's random values are consistent with Bwd.
         constexpr auto randval_block_inner_part_dstr_encoding = []() {
             if constexpr(std::is_same_v<typename BlockGemm::ADataType, half_t> &&
                          std::is_same_v<typename BlockGemm::BDataType, half_t> &&
@@ -443,7 +443,7 @@ struct BlockDropoutBwd<true, IsWG32_, IsStoreRandval_>
             sequence<1, 2>,
             sequence<0, 0>>{};
 
-        // Use Bwd WarpGemm to ensure that Fwd's random values ​​are consistent with Bwd.
+        // Use Bwd WarpGemm to ensure that Fwd's random values are consistent with Bwd.
         // except headdim256.
         constexpr auto randval_block_inner_part_dstr_encoding = []() {
             if constexpr(std::is_same_v<typename BlockGemm::ADataType, half_t> &&

--- a/include/ck_tile/ops/fused_moe/kernel/fused_moegemm_kernel.hpp
+++ b/include/ck_tile/ops/fused_moe/kernel/fused_moegemm_kernel.hpp
@@ -51,14 +51,14 @@
 //
 // * different from vLLM
 //   1) token_id stored in sorted_token_ids_ptr is actual token_id, not token_id*top_K expanded id
-//   2）need sorted_weight_ptr
+//   2)need sorted_weight_ptr
 //   3) use num_sorted_tiles_ptr, already divided by M_a
 //
 // * below used for indexing
 //  1) sorted_token_ids_ptr [max_num_tokens_padded]
 //  2) sorted_weight_ptr
 //  3) sorted_expert_ids_ptr
-//  4）num_tokens_post_padded_ptr/num_sorted_tiles_ptr (select one)
+//  4)num_tokens_post_padded_ptr/num_sorted_tiles_ptr (select one)
 //
 //   max_num_tokens_padded: opk_ids.numel() + num_experts * (block_size - 1)
 //

--- a/include/ck_tile/ops/fused_moe/kernel/moe_sorting_kernel.hpp
+++ b/include/ck_tile/ops/fused_moe/kernel/moe_sorting_kernel.hpp
@@ -98,14 +98,14 @@ namespace ck_tile {
 //
 // * different from vLLM
 //   1) token_id stored in sorted_token_ids_ptr is actual token_id, not token_id*top_K expanded id
-//   2）need sorted_weight_ptr
+//   2)need sorted_weight_ptr
 //   3) use num_sorted_tiles_ptr, already divided by M_a
 //
 // * below used for indexing
 //  1) sorted_token_ids_ptr [max_num_tokens_padded]
 //  2) sorted_weight_ptr
 //  3) sorted_expert_ids_ptr
-//  4）num_tokens_post_padded_ptr/num_sorted_tiles_ptr (select one)
+//  4)num_tokens_post_padded_ptr/num_sorted_tiles_ptr (select one)
 //
 //   max_num_tokens_padded: opk_ids.numel() + num_experts * (block_size - 1)
 

--- a/include/ck_tile/ops/gemm/kernel/gemm_kernel.hpp
+++ b/include/ck_tile/ops/gemm/kernel/gemm_kernel.hpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "ck_tile/core.hpp"
+#include "ck_tile/core/config.hpp"
 #include "ck_tile/ops/common.hpp"
 #include "ck_tile/host/concat.hpp"
 #include "ck_tile/host/kernel_launch.hpp"
@@ -83,6 +84,29 @@ struct GemmHostArgs
 template <index_t NumDTensor = 0>
 struct GemmKernelArgs
 {
+    constexpr GemmKernelArgs(index_t M_,
+                             index_t N_,
+                             index_t K_,
+                             index_t stride_A_,
+                             index_t stride_B_,
+                             const std::array<index_t, NumDTensor>& stride_Ds_,
+                             index_t stride_E_,
+                             index_t k_batch_)
+        : a_ptr{nullptr},
+          b_ptr{nullptr},
+          ds_ptr{}, // Default-initialized array of nullptrs
+          e_ptr{nullptr},
+          M{M_},
+          N{N_},
+          K{K_},
+          stride_A{stride_A_},
+          stride_B{stride_B_},
+          stride_Ds{stride_Ds_},
+          stride_E{stride_E_},
+          k_batch{k_batch_}
+    {
+    }
+
     /// @brief The A input tensor's pointer to device memory.
     const void* a_ptr;
     /// @brief The B input tensor's pointer to device memory.
@@ -200,7 +224,7 @@ struct GemmKernel
         // clang-format on
     }
 
-    CK_TILE_HOST static constexpr auto GridSize(index_t M, index_t N, index_t KBatch)
+    CK_TILE_HOST_DEVICE static constexpr auto GridSize(index_t M, index_t N, index_t KBatch)
     {
         return dim3(TilePartitioner::GridSize(M, N), 1, KBatch);
     }
@@ -222,9 +246,9 @@ struct GemmKernel
         return dim3(grid_size, 1, 1);
     }
 
-    CK_TILE_HOST static constexpr auto BlockSize() { return dim3(KernelBlockSize); }
+    CK_TILE_HOST_DEVICE static constexpr auto BlockSize() { return dim3(KernelBlockSize); }
 
-    CK_TILE_HOST static constexpr KernelArgs
+    CK_TILE_HOST_DEVICE static constexpr KernelArgs
     MakeKernelArgs(const GemmHostArgs<NumDTensor>& hostArgs)
     {
 
@@ -288,18 +312,26 @@ struct GemmKernel
         index_t splitted_k;
     };
 
-    CK_TILE_HOST static bool IsSupportedArgument(const KernelArgs& kargs)
+    template<bool EnableLogging = true> 
+    CK_TILE_HOST_DEVICE static constexpr bool IsSupportedArgument(const KernelArgs& kargs)
     {
+        constexpr auto conditional_log = [](const auto& message) {
+            if constexpr(EnableLogging)
+            {
+                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
+                {
+                    CK_TILE_ERROR(message);
+                }
+            }
+            return false;
+        };
+
         if constexpr(EpiloguePipeline::GetVectorSizeC() % 2 != 0 &&
                      is_any_of<EDataType, fp16_t, bf16_t>::value)
         {
             if(kargs.k_batch != 1)
             {
-                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                {
-                    CK_TILE_ERROR("Conditions not met for Kbatch >1 !");
-                }
-                return false;
+                return conditional_log("Conditions not met for Kbatch >1 !");
             }
         }
 
@@ -308,40 +340,25 @@ struct GemmKernel
             if(kargs.K % (TilePartitioner::KPerBlock * kargs.k_batch) != 0 &&
                GemmPipeline::kPadK == false) // k_batch is extra compared to flatmm
             {
-                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                {
-                    CK_TILE_ERROR("Can't support K that is not a multiple of k_batch * KPerBlock "
-                                  "without padding!");
-                }
-                return false;
+                return conditional_log(
+                    "Can't support K that is not a multiple of k_batch * KPerBlock "
+                    "without padding!");
             }
             if(kargs.K % GemmPipeline::GetVectorSizeA() != 0)
             {
-                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                {
-                    CK_TILE_ERROR("K is not a multiple of vector load size for A tensor!");
-                }
-                return false;
+                return conditional_log("K is not a multiple of vector load size for A tensor!");
             }
         }
         else
         {
             if(kargs.M % TilePartitioner::MPerBlock != 0 && GemmPipeline::kPadM == false)
             {
-                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                {
-                    CK_TILE_ERROR(
-                        "Can't support M that is not a multiple of MPerBlock without padding!");
-                }
-                return false;
+                return conditional_log(
+                    "Can't support M that is not a multiple of MPerBlock without padding!");
             }
             if(kargs.M % GemmPipeline::GetVectorSizeA() != 0)
             {
-                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                {
-                    CK_TILE_ERROR("M is not a multiple of vector load size for A tensor!");
-                }
-                return false;
+                return conditional_log("M is not a multiple of vector load size for A tensor!");
             }
         }
 
@@ -349,20 +366,12 @@ struct GemmKernel
         {
             if(kargs.N % TilePartitioner::NPerBlock != 0 && GemmPipeline::kPadN == false)
             {
-                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                {
-                    CK_TILE_ERROR(
-                        "Can't support N that is not a multiple of NPerBlock without padding!");
-                }
-                return false;
+                return conditional_log(
+                    "Can't support N that is not a multiple of NPerBlock without padding!");
             }
             if(kargs.N % GemmPipeline::GetVectorSizeB() != 0)
             {
-                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                {
-                    CK_TILE_ERROR("N is not a multiple of vector load size for B tensor!");
-                }
-                return false;
+                return conditional_log("N is not a multiple of vector load size for B tensor!");
             }
         }
         else
@@ -370,20 +379,12 @@ struct GemmKernel
             if(kargs.K % (TilePartitioner::KPerBlock * kargs.k_batch) != 0 &&
                GemmPipeline::kPadK == false) // again k_batch is extra compared to flatmm
             {
-                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                {
-                    CK_TILE_ERROR("Can't support K that is not a multiple of k_batch * KPerBlock "
-                                  "without padding!");
-                }
-                return false;
+                return conditional_log("Can't support K that is not a multiple of k_batch * KPerBlock "
+                                "without padding!");
             }
             if(kargs.K % GemmPipeline::GetVectorSizeB() != 0)
             {
-                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                {
-                    CK_TILE_ERROR("K is not a multiple of vector load size for B tensor!");
-                }
-                return false;
+                return conditional_log("K is not a multiple of vector load size for B tensor!");
             }
         }
 
@@ -398,40 +399,27 @@ struct GemmKernel
             {
                 if(kargs.N % TilePartitioner::NPerBlock != 0 && GemmPipeline::kPadN == false)
                 {
-                    if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                    {
-                        CK_TILE_ERROR("Can't support N for tensor D that is not a multiple of "
-                                      "NPerBlock without padding!");
-                    }
-                    DTesnorIsValid = false;
+                    DTesnorIsValid =
+                        conditional_log("Can't support N for tensor D that is not a multiple of "
+                                        "NPerBlock without padding!");
                 }
                 if(kargs.N % EpiloguePipeline::GetVectorSizeD(index) != 0)
                 {
-                    if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                    {
-                        CK_TILE_ERROR("N is not a multiple of vector load size for D tensor!");
-                    }
-                    DTesnorIsValid = false;
+                        DTesnorIsValid = conditional_log("N is not a multiple of vector load size for D tensor!");
                 }
             }
             else
             {
                 if(kargs.M % TilePartitioner::MPerBlock != 0 && GemmPipeline::kPadM == false)
                 {
-                    if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                    {
-                        CK_TILE_ERROR("Can't support M for tensor D that is not a multiple of "
-                                      "MPerBlock without padding!");
-                    }
-                    DTesnorIsValid = false;
+                    DTesnorIsValid =
+                        conditional_log("Can't support M for tensor D that is not a multiple of "
+                                        "MPerBlock without padding!");
                 }
                 if(kargs.M % EpiloguePipeline::GetVectorSizeD(index) != 0)
                 {
-                    if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                    {
-                        CK_TILE_ERROR("M is not a multiple of vector load size for D tensor!");
-                    }
-                    DTesnorIsValid = false;
+                    DTesnorIsValid =
+                        conditional_log("M is not a multiple of vector load size for D tensor!");
                 }
             }
         });
@@ -440,40 +428,24 @@ struct GemmKernel
         {
             if(kargs.N % TilePartitioner::NPerBlock != 0 && GemmPipeline::kPadN == false)
             {
-                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                {
-                    CK_TILE_ERROR(
-                        "Can't support N that is not a multiple of NPerBlock without padding!");
-                }
-                return false;
+                return conditional_log(
+                    "Can't support N that is not a multiple of NPerBlock without padding!");
             }
             if(kargs.N % EpiloguePipeline::GetVectorSizeC() != 0)
             {
-                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                {
-                    CK_TILE_ERROR("N is not a multiple of vector load size for C tensor!");
-                }
-                return false;
+                return conditional_log("N is not a multiple of vector load size for C tensor!");
             }
         }
         else
         {
             if(kargs.M % TilePartitioner::MPerBlock != 0 && GemmPipeline::kPadM == false)
             {
-                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                {
-                    CK_TILE_ERROR(
-                        "Can't support M that is not a multiple of MPerBlock without padding!");
-                }
-                return false;
+                return conditional_log(
+                    "Can't support M that is not a multiple of MPerBlock without padding!");
             }
             if(kargs.M % EpiloguePipeline::GetVectorSizeC() != 0)
             {
-                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-                {
-                    CK_TILE_ERROR("M is not a multiple of vector load size for C tensor!");
-                }
-                return false;
+                return conditional_log("M is not a multiple of vector load size for C tensor!");
             }
         }
         return DTesnorIsValid;

--- a/include/ck_tile/ops/gemm/kernel/gemm_tile_partitioner.hpp
+++ b/include/ck_tile/ops/gemm/kernel/gemm_tile_partitioner.hpp
@@ -260,7 +260,7 @@ struct GemmSpatiallyLocalTilePartitioner
      * @param K         GEMM's K dimension.
      * @return index_t  The number of loop iterations over K dimension.
      */
-    CK_TILE_HOST_DEVICE static auto GetLoopNum(index_t K) noexcept -> index_t
+    CK_TILE_HOST_DEVICE static constexpr auto GetLoopNum(index_t K) noexcept -> index_t
     {
         return integer_divide_ceil(K, KPerBlock);
     }

--- a/include/ck_tile/ops/gemm/kernel/mgx_prototype_gemm_kernel.hpp
+++ b/include/ck_tile/ops/gemm/kernel/mgx_prototype_gemm_kernel.hpp
@@ -1,0 +1,292 @@
+#pragma once
+
+#include "ck_tile/core/arch/arch.hpp"
+#include "ck_tile/ops/gemm/kernel/gemm_kernel.hpp"
+#include "ck_tile/ops/gemm.hpp"
+#include "ck_tile/ops/epilogue.hpp"
+#include "ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_scheduler.hpp"
+
+namespace ck_tile {
+
+struct Default2DEpilogueSelector
+{
+};
+struct CShuffleEpilogueSelector
+{
+};
+
+template <
+    /*Specified by instance builder - start*/
+    template <typename>
+    typename BaseGemmPipeline_,
+    template <typename>
+    typename GemmPipeline_,
+    bool DoubleSmemBuffer,
+    GemmPipelineScheduler Scheduler,
+    typename EpilogueSelector,
+    int TileM,
+    int TileN,
+    int TileK,
+    int WarpM,
+    int WarpN,
+    int WarpK,
+    int WarpTileM,
+    int WarpTileN,
+    int WarpTileK,
+    bool StructuredSparsity,
+    /*Specified by instance builder - end*/
+    /*Specified by gemm problem - start*/
+    typename ALayout,
+    typename BLayout,
+    typename CLayout,
+    typename ADataType,
+    typename BDataType,
+    typename CDataType,
+    typename AccDataType,
+    bool permuteA,
+    bool permuteB,
+    bool TransposeC,
+    int M,
+    int N,
+    int K,
+    int KBatch,
+    bool PadM,
+    bool PadN,
+    bool PadK
+    /*Specified by gemm problem - end*/
+    >
+struct MGXPrototypeGemmKernel
+{
+    /* Statically set by instance generator, why? */
+    static constexpr int kBlockPerCu                         = 1;
+    static constexpr ck_tile::index_t TileParitionerGroupNum = 8;
+    static constexpr ck_tile::index_t TileParitionerM01      = 4;
+
+    using GemmShape = ck_tile::TileGemmShape<ck_tile::sequence<TileM, TileN, TileK>,
+                                             ck_tile::sequence<WarpM, WarpN, WarpK>,
+                                             ck_tile::sequence<WarpTileM, WarpTileN, WarpTileK>,
+                                             permuteA,
+                                             permuteB>;
+
+    using TilePartitioner = ck_tile::
+        GemmSpatiallyLocalTilePartitioner<GemmShape, TileParitionerGroupNum, TileParitionerM01>;
+
+    using Traits = ck_tile::TileGemmTraits<PadM, PadN, PadK, ALayout, BLayout, CLayout>;
+
+    using GemmUniversalTraits = ck_tile::TileGemmUniversalTraits<PadM,
+                                                                 PadN,
+                                                                 PadK,
+                                                                 DoubleSmemBuffer,
+                                                                 ALayout,
+                                                                 BLayout,
+                                                                 CLayout,
+                                                                 TransposeC,
+                                                                 StructuredSparsity>;
+
+    using GemmPipelineProblem =
+        ck_tile::GemmPipelineProblem<ADataType, BDataType, AccDataType, GemmShape, Traits>;
+
+    using BaseGemmPipeline = BaseGemmPipeline_<GemmPipelineProblem>;
+
+    static constexpr ck_tile::index_t k_grain  = KBatch * TileK;
+    static constexpr ck_tile::index_t K_split  = (K + k_grain - 1) / k_grain * TileK;
+    static constexpr ck_tile::index_t num_loop = TilePartitioner::GetLoopNum(K_split);
+    static constexpr bool has_hot_loop         = BaseGemmPipeline::BlockHasHotloop(num_loop);
+    // TODO If the tail_num is Three, the compv4 pipeline uses it, if it isn't Three, it uses Two.
+    // Need to check if this is correct of if it's an error in the instance builder.
+    // If it's correct, need to handle that case.
+    static constexpr ck_tile::TailNumber tail_num = BaseGemmPipeline::GetBlockLoopTailNum(num_loop);
+
+    static constexpr auto memory_operation = KBatch == 1
+                                                 ? ck_tile::memory_operation_enum::set
+                                                 : ck_tile::memory_operation_enum::atomic_add;
+
+    using UniversalGemmProblem = ck_tile::UniversalGemmPipelineProblem<ADataType,
+                                                                       BDataType,
+                                                                       AccDataType,
+                                                                       GemmShape,
+                                                                       GemmUniversalTraits,
+                                                                       Scheduler,
+                                                                       has_hot_loop,
+                                                                       tail_num>;
+
+    using GemmPipeline = GemmPipeline_<UniversalGemmProblem>;
+
+    template <typename T>
+    struct EpilogueWrapper
+    {
+        using type = void;
+    };
+
+    template <>
+    struct EpilogueWrapper<Default2DEpilogueSelector>
+    {
+        using type = ck_tile::DefaultGemm2DEpilogue<
+            ck_tile::DefaultGemm2DEpilogueProblem<ADataType,
+                                                  BDataType,
+                                                  AccDataType,
+                                                  CDataType,
+                                                  CLayout,
+                                                  PadM,
+                                                  PadN,
+                                                  WarpTileM,
+                                                  WarpTileN,
+                                                  WarpTileK,
+                                                  UniversalGemmProblem::TransposeC,
+                                                  true,
+                                                  memory_operation>>;
+    };
+
+    template <>
+    struct EpilogueWrapper<CShuffleEpilogueSelector>
+    {
+        using type = ck_tile::CShuffleEpilogue<
+            ck_tile::CShuffleEpilogueProblem<ADataType,
+                                             BDataType,
+                                             ck_tile::tuple<>,
+                                             AccDataType,
+                                             CDataType,
+                                             ck_tile::tuple<>,
+                                             CLayout,
+                                             ck_tile::element_wise::PassThrough,
+                                             GemmPipelineProblem::kBlockSize,
+                                             TilePartitioner::MPerBlock,
+                                             TilePartitioner::NPerBlock,
+                                             WarpM,
+                                             WarpN,
+                                             WarpTileM,
+                                             WarpTileN,
+                                             WarpTileK,
+                                             UniversalGemmProblem::TransposeC,
+                                             memory_operation>>;
+    };
+
+    using GemmEpilogue = typename EpilogueWrapper<EpilogueSelector>::type;
+    using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;
+    using KernelArgs = GemmKernelArgs<0>;
+
+    CK_TILE_DEVICE static constexpr bool IsSupportedArgument(const KernelArgs& kargs)
+    {
+        if constexpr(has_hot_loop)
+        {
+            if constexpr(std::is_same_v<GemmPipeline,
+                                        ck_tile::GemmPipelineAgBgCrMem<UniversalGemmProblem>>)
+            {
+                // Handle One and Full cases directly
+                // if(tail_num == ck_tile::TailNumber::One)
+                // {
+                //     RunSplitk(ck_tile::bool_constant<true>{},
+                //               ck_tile::integral_constant<ck_tile::TailNumber,
+                //                                          ck_tile::TailNumber::One>{});
+                // }
+                // else if(tail_num == ck_tile::TailNumber::Full)
+                // {
+                //     RunSplitk(ck_tile::bool_constant<true>{},
+                //               ck_tile::integral_constant<ck_tile::TailNumber,
+                //                                          ck_tile::TailNumber::Full>{});
+                // }
+
+                // auto check_tail = [&](auto... TNs) {
+                //     (
+                //         [&] {
+                //// NOTE: can this condition be false for all enum values between Two and Seven? If
+                //// so, need to return false. There are also enum values that are not handled here.
+                //// Is it possible that they can occur at all?
+                ////             if constexpr(BaseGemmPipeline::PrefetchStages >
+                //                          static_cast<int>(decltype(TNs)::value))
+                //             {
+                //                 if(tail_num == decltype(TNs)::value)
+                //                 {
+                //                     RunSplitk(ck_tile::bool_constant<true>{},
+                //                               ck_tile::integral_constant<ck_tile::TailNumber,
+                //                                                          decltype(TNs)::value>{});
+                //                 }
+                //             }
+                //         }(),
+                //         ...);
+                // };
+
+                // check_tail(
+                //     ck_tile::integral_constant<ck_tile::TailNumber, ck_tile::TailNumber::Two>{},
+                //     ck_tile::integral_constant<ck_tile::TailNumber,
+                //     ck_tile::TailNumber::Three>{},
+                //     ck_tile::integral_constant<ck_tile::TailNumber, ck_tile::TailNumber::Four>{},
+                //     ck_tile::integral_constant<ck_tile::TailNumber, ck_tile::TailNumber::Five>{},
+                //     ck_tile::integral_constant<ck_tile::TailNumber, ck_tile::TailNumber::Six>{},
+                //     ck_tile::integral_constant<ck_tile::TailNumber,
+                //     ck_tile::TailNumber::Seven>{});
+                // return true;
+            }
+            else if constexpr(std::is_same_v<
+                                  GemmPipeline,
+                                  ck_tile::GemmPipelineAgBgCrCompV3<UniversalGemmProblem>>)
+            {
+                // if(tail_num == ck_tile::TailNumber::Full)
+                // {
+                //     RunSplitk(ck_tile::bool_constant<true>{},
+                //               ck_tile::integral_constant<ck_tile::TailNumber,
+                //                                          ck_tile::TailNumber::Full>{});
+                // }
+                // else if(tail_num == ck_tile::TailNumber::Odd)
+                // {
+                //     RunSplitk(ck_tile::bool_constant<true>{},
+                //               ck_tile::integral_constant<ck_tile::TailNumber,
+                //                                          ck_tile::TailNumber::Odd>{});
+                // }
+                // else if(tail_num == ck_tile::TailNumber::Even)
+                // {
+                //     RunSplitk(ck_tile::bool_constant<true>{},
+                //               ck_tile::integral_constant<ck_tile::TailNumber,
+                //                                          ck_tile::TailNumber::Even>{});
+                // }
+                // else
+                // {
+                //     throw std::runtime_error(
+                //         "The tail number is wrong. It should be Full, Odd, or Even.");
+                // }
+                return false;
+            }
+            else if constexpr(std::is_same_v<
+                                  GemmPipeline,
+                                  ck_tile::GemmPipelineAgBgCrCompV4<UniversalGemmProblem>>)
+            {
+                // if(tail_num == ck_tile::TailNumber::Three)
+                // {
+                //     RunSplitk(ck_tile::bool_constant<true>{},
+                //               ck_tile::integral_constant<ck_tile::TailNumber,
+                //                                          ck_tile::TailNumber::Three>{});
+                // }
+                // else
+                // {
+                //     RunSplitk(ck_tile::bool_constant<true>{},
+                //               ck_tile::integral_constant<ck_tile::TailNumber,
+                //                                          ck_tile::TailNumber::Two>{});
+                // }
+                return false;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if constexpr(tail_num != ck_tile::TailNumber::Full &&
+                         tail_num != ck_tile::TailNumber::Odd &&
+                         tail_num != ck_tile::TailNumber::Even)
+            {
+                return false;
+            }
+        }
+
+        return Kernel::template IsSupportedArgument<false>(kargs);
+    }
+
+    CK_TILE_DEVICE static void Run(const KernelArgs& kargs) { Kernel{}(kargs); }
+
+    CK_TILE_DEVICE static constexpr auto GridSize() { return Kernel::GridSize(M, N, KBatch); }
+
+    CK_TILE_DEVICE static constexpr auto BlockSize() { return Kernel::BlockSize(); }
+};
+
+} // namespace ck_tile

--- a/tile_engine/ops/gemm/gemm_instance_builder.py
+++ b/tile_engine/ops/gemm/gemm_instance_builder.py
@@ -11,7 +11,7 @@ import argparse
 import itertools
 from pathlib import Path
 from typing import List, Optional
-from json_config import GemmConfig, RangeConfigParam
+from json_config import GemmConfig, RangeConfigParam, EnumConfigParam
 from codegen_utils import (
     DATA_TYPE_MAP,
     LAYOUT_MAP,
@@ -780,6 +780,44 @@ private:
 """
         (self.output_dir / "gemm_dispatcher.hpp").write_text(content)
 
+    def generate_mgx_instance_file(self):
+        pipeline_to_pipeline_enum = {
+            "mem": "Pipeline::Mem",
+            "compv3": "Pipeline::V3",
+            "compv4": "Pipeline::V4",
+        }
+        epilogue_to_epilogue_enum = {
+            "default": "Epilogue::Default2D",
+            "cshuffle": "Epilogue::CShuffle",
+        }
+        scheduler_to_scheduler_enum = {
+            "default": "Scheduler::Default",
+            "intrawave": "Scheduler::IntraWave",
+            "interwave": "Scheduler::InterWave",
+        }
+        self._generate_all_traits()
+        self._get_valid_trait_tile_combinations()
+        instance_strings = []
+        for traits in self.valid_trait_tile_combinations.keys():
+            pipeline, epilogue, scheduler = traits.split("_")[:3]
+            for tiles in self.valid_trait_tile_combinations[traits][0]:
+                instance_strings.append(
+                    "GemmKernelInstanceParams{"
+                    + f"{pipeline_to_pipeline_enum[pipeline]}, {scheduler_to_scheduler_enum[scheduler]}, {epilogue_to_epilogue_enum[epilogue]}, "
+                    + ", ".join(map(str, tiles))
+                    + "}"
+                )
+
+        a_type = self.config.problem.datatype_map["matrix_a"]
+        b_type = self.config.problem.datatype_map["matrix_b"]
+        c_type = self.config.problem.datatype_map["matrix_c"]
+        instances = (
+            f"constexpr inline std::array<GemmKernelInstanceParams, {len(instance_strings)}> {a_type}_{b_type}_{c_type}_instance_params{{\n\t"
+            + ",\n\t".join(instance_strings)
+            + "\n};"
+        )
+        return instances
+
 
 def do_list_blobs(
     args: argparse.Namespace, user_provide_config: Optional[GemmConfig] = None
@@ -795,6 +833,47 @@ def do_gen_blobs(
     generator.generate_all_instance_files()
 
 
+def do_gen_mgx(
+    args: argparse.Namespace, user_provided_config: Optional[GemmConfig] = None
+):
+    input_type_combinations = [
+        ("fp16", "fp16", "fp16"),
+        ("bf16", "bf16", "bf16"),
+        ("fp8", "fp8", "fp16"),
+        ("bf8", "bf8", "fp16"),
+    ]
+
+    all_instances = []
+    for a_type, b_type, c_type in input_type_combinations:
+        user_provided_config.problem.datatypes = (
+            EnumConfigParam(values=[a_type]),
+            EnumConfigParam(values=[b_type]),
+            EnumConfigParam(values=[c_type]),
+        )
+        generator = GemmCodeGenerator(args.working_path, user_provided_config)
+        # a and b data types are used in is_tile_valid, combination can be invalid based on that
+        # layout isn't used to validate
+        all_instances.append(generator.generate_mgx_instance_file())
+        
+    all_instances_str = "\n\n".join(all_instances)
+    file_content = f"""
+#pragma once
+
+#include "ck/host/prototype_header.hpp"
+#include <array>
+
+namespace ck::host {{
+
+    {all_instances_str}
+
+}}  // namespace ck::host
+"""
+    w_p = Path(args.working_path)
+    file_path = w_p / "mgx_instances.hpp"
+    with file_path.open("w") as f:
+        f.write(file_content)
+
+
 def main(args):
     gemm_config = (
         GemmConfig.from_json(args.config_json, args.datatype, args.layout)
@@ -806,6 +885,8 @@ def main(args):
         do_list_blobs(args, gemm_config)
     elif args.gen_blobs:
         do_gen_blobs(args, gemm_config)
+    elif args.gen_mgx:
+        do_gen_mgx(args, gemm_config)
     else:
         logging.warning(
             "No mode specified (use --list_blobs or --gen_blobs). Generating by default..."
@@ -854,6 +935,12 @@ if __name__ == "__main__":
         "--gen_blobs",
         action="store_true",
         help="Generate all kernel instances into different files",
+    )
+    parser.add_argument(
+        "-mgx",
+        "--gen_mgx",
+        action="store_true",
+        help="Generate instances for use with MIGraphX",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Prototype of proposed approach to integrating ck_tile in migraphx.
It implements a framework to use GemmKernel in an RTC context as a proof of concept. If this were to move forward, it would be applied to any kernels that MGX would use.

GemmKernel was refactored after work on the prototype was started, but the principle of the prototype remains the same and should be applicable to the refactored version as well.

### Goals

The goal of MIGraphX(MGX) is to utilize CK Tile in an RTC context. The intent is to use CK Tile constructs solely within code strings which get JIT compiled via HIPRTC. 

With this in mind, MGX wishes to limit any exposure of CK code in host code, as pulling CK into host code would lead to increased compilation times. The goal is only to expose the minimum necessary code from the codegen part. 

As for using CK Tile headers for RTC, the headers are collected, converted into character arrays in cpp files, which in turn get compiled into a binary object(created by a CMAKE invocation), and makes the headers available as strings to MGX host code, thus avoiding the host being exposed to the headers directly while the RTC compiler can have access to all necessary headers.

### Usage 

MGX defines a Problem(in this case a GEMM problem) which describes the inputs to the desired operation. 
Based on the Problem, it receives back a set of Solutions. 
The solutions contain the full set of information necessary to create a fully instantiated CK Tile kernel, as well as a string, which contains this full instantiation. 
MGX then iterates through all the solutions, using the instance strings to interpolate a kernel string, which is then JIT compiled. If the compilation fails, the instance is rejected as invalid.
This usage can be found in the test body of prototype.cpp

### Instance selection 
The python instance generator has been modified to generate instance data as suited to MGX. It creates separate arrays of instances for each combination of input types, as instance details can vary depending on the input types. These are then selected based on the Problem and used to create Solutions.

In order to use only valid instances of CK kernels, MGX need to be able to reject invalid ones at compilation time. To facilitate this, modifications have been made to certain parts of the CK code to make them constexpr.