### PR TITLE
[CK_TILE] Fix CI Build Error

### DIFF
--- a/include/ck_tile/ops/gemm/warp/warp_gemm_attribute_wmma_impl.hpp
+++ b/include/ck_tile/ops/gemm/warp/warp_gemm_attribute_wmma_impl.hpp
@@ -35,6 +35,9 @@ struct WarpGemmAttributeWmmaImpl
     static constexpr index_t kN = Traits::kN;
     static constexpr index_t kK = Traits::kK;
 
+    static constexpr index_t kAMBlock = Traits::kAMBlock;
+    static constexpr index_t kBNBlock = Traits::kBNBlock;
+
     static constexpr index_t kRepeat      = Traits::kRepeat;
     static constexpr index_t kAMLane      = Traits::kAMLane;
     static constexpr index_t kBNLane      = Traits::kBNLane;

--- a/include/ck_tile/ops/gemm/warp/warp_gemm_attribute_wmma_impl_base_traits.hpp
+++ b/include/ck_tile/ops/gemm/warp/warp_gemm_attribute_wmma_impl_base_traits.hpp
@@ -22,6 +22,9 @@ struct WmmaTraitsBase<gfx11_t, ADType, BDType, CDType>
     static constexpr index_t kN = 16;
     static constexpr index_t kK = 16;
 
+    static constexpr index_t kAMBlock = 1;
+    static constexpr index_t kBNBlock = 1;
+
     static constexpr index_t kRepeat      = 2;
     static constexpr index_t kAMLane      = 16;
     static constexpr index_t kBNLane      = 16;
@@ -60,6 +63,9 @@ struct WmmaTraitsBase<gfx12_t, ADType, BDType, CDType>
     static constexpr index_t kM = 16;
     static constexpr index_t kN = 16;
     static constexpr index_t kK = 16;
+
+    static constexpr index_t kAMBlock = 1;
+    static constexpr index_t kBNBlock = 1;
 
     static constexpr index_t kRepeat      = 1;
     static constexpr index_t kAMLane      = 16;


### PR DESCRIPTION
## Proposed changes

Observed the following build error from post-merge CI triggered by https://github.com/ROCm/composable_kernel/pull/2466 
```
[2025-08-17T23:14:10.773Z] [206/920] Building CXX object tile_engine/ops/gemm/CMakeFiles/gemm_objlib_mem_default_intrawave_false_false_false_false_1_fp16_rcr.dir/fp16/rcr/gemm_mem_default_intrawave_false_false_false_false_256x128x32_1x4x1.cpp.o
[2025-08-17T23:14:10.774Z] FAILED: [code=1] tile_engine/ops/gemm/CMakeFiles/gemm_objlib_mem_default_intrawave_false_false_false_false_1_fp16_rcr.dir/fp16/rcr/gemm_mem_default_intrawave_false_false_false_false_256x128x32_1x4x1.cpp.o 
[2025-08-17T23:14:10.774Z] sccache /opt/rocm/llvm/bin/clang++ -DCK_ENABLE_BF16 -DCK_ENABLE_BF8 -DCK_ENABLE_FP16 -DCK_ENABLE_FP32 -DCK_ENABLE_FP64 -DCK_ENABLE_FP8 -DCK_ENABLE_INT8 -DCK_TILE_WAVE32_ENABLED -DCK_TIME_KERNEL=1 -DCK_USE_WMMA -DDL_KERNELS -DDPP_KERNELS -DUSE_PROF_API=1 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -I/home/jenkins/workspace/MLLIBS_composable_kernel_develop/tile_engine/include -I/home/jenkins/workspace/MLLIBS_composable_kernel_develop/library/include -I/home/jenkins/workspace/MLLIBS_composable_kernel_develop/include -I/home/jenkins/workspace/MLLIBS_composable_kernel_develop/build/include -isystem /opt/rocm/include -O3 -O3 -DNDEBUG -std=c++20   -Wall -Wextra -Wcomment -Wendif-labels -Wformat -Winit-self -Wreturn-type -Wsequence-point -Wswitch -Wtrigraphs -Wundef -Wuninitialized -Wunreachable-code -Wunused -Wno-reserved-identifier -Wno-option-ignored -Wsign-compare -Wno-extra-semi-stmt -Wno-unused-template -Wno-missing-field-initializers -Wno-error=deprecated-declarations -Wall -Wextra -Wcomment -Wendif-labels -Wformat -Winit-self -Wreturn-type -Wsequence-point -Wswitch -Wtrigraphs -Wundef -Wuninitialized -Wunreachable-code -Wunused -Wno-reserved-identifier -Wno-option-ignored -Wsign-compare -Wno-extra-semi-stmt -Wno-unused-template -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-conversion -Wno-double-promotion -Wno-exit-time-destructors -Wno-extra-semi -Wno-float-conversion -Wno-gnu-anonymous-struct -Wno-gnu-zero-variadic-macro-arguments -Wno-missing-prototypes -Wno-nested-anon-types -Wno-padded -Wno-return-std-move-in-c++11 -Wno-shorten-64-to-32 -Wno-sign-conversion -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-weak-vtables -Wno-covered-switch-default -Wno-unsafe-buffer-usage -Wno-unused-lambda-capture -Wno-nvcc-compat -Wno-bit-int-extension -Wno-pass-failed -Wno-switch-default -Wno-unique-object-duplication -Wno-nrvo -fno-offload-uniform-block -mllvm --lsr-drop-solution=1 -mllvm -enable-post-misched=0 -mllvm -amdgpu-coerce-illegal-types=1 -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -mcumode -mno-wavefrontsize64 -Werror -Weverything -fcolor-diagnostics -x hip --offload-arch=gfx11-generic -MD -MT tile_engine/ops/gemm/CMakeFiles/gemm_objlib_mem_default_intrawave_false_false_false_false_1_fp16_rcr.dir/fp16/rcr/gemm_mem_default_intrawave_false_false_false_false_256x128x32_1x4x1.cpp.o -MF tile_engine/ops/gemm/CMakeFiles/gemm_objlib_mem_default_intrawave_false_false_false_false_1_fp16_rcr.dir/fp16/rcr/gemm_mem_default_intrawave_false_false_false_false_256x128x32_1x4x1.cpp.o.d -o tile_engine/ops/gemm/CMakeFiles/gemm_objlib_mem_default_intrawave_false_false_false_false_1_fp16_rcr.dir/fp16/rcr/gemm_mem_default_intrawave_false_false_false_false_256x128x32_1x4x1.cpp.o -c /home/jenkins/workspace/MLLIBS_composable_kernel_develop/build/tile_engine/ops/gemm/fp16/rcr/gemm_mem_default_intrawave_false_false_false_false_256x128x32_1x4x1.cpp
[2025-08-17T23:14:10.774Z] In file included from /home/jenkins/workspace/MLLIBS_composable_kernel_develop/build/tile_engine/ops/gemm/fp16/rcr/gemm_mem_default_intrawave_false_false_false_false_256x128x32_1x4x1.cpp:6:
[2025-08-17T23:14:10.774Z] In file included from /home/jenkins/workspace/MLLIBS_composable_kernel_develop/build/tile_engine/ops/gemm/fp16/rcr/gemm_mem_default_intrawave_false_false_false_false.hpp:8:
[2025-08-17T23:14:10.774Z] In file included from /home/jenkins/workspace/MLLIBS_composable_kernel_develop/include/ck_tile/ops/epilogue.hpp:7:
[2025-08-17T23:14:10.774Z] In file included from /home/jenkins/workspace/MLLIBS_composable_kernel_develop/include/ck_tile/ops/epilogue/default_2d_and_dynamic_quant_epilogue.hpp:6:
[2025-08-17T23:14:10.774Z] /home/jenkins/workspace/MLLIBS_composable_kernel_develop/include/ck_tile/ops/epilogue/default_2d_epilogue.hpp:163:54: error: no member named 'kBNBlock' in 'ck_tile::WarpGemmAttributeWmmaImpl<ck_tile::WmmaTraits<gfx11_t, fp16_t, fp16_t, float, 16, 16, 16>>'
[2025-08-17T23:14:10.774Z]   163 |                         WG::WarpGemmAttribute::Impl::kBNBlock) /
[2025-08-17T23:14:10.774Z]       |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
```
To fix it, add the **kBNBlock** into **ck_tile::WarpGemmAttributeWmmaImpl**

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

