### PR TITLE
use iglp to improve dim256 fmha fwd in qr_ks_vs pipeline

### DIFF
--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -58,6 +58,19 @@ struct BlockFmhaPipelineQRKSVS
     static constexpr bool kStoreLSE         = Problem::kStoreLSE;
     static constexpr bool kHasDropout       = Problem::kHasDropout;
 
+    using Gemm_0 = remove_cvref_t<decltype(Policy::template GetQKBlockGemm<Problem>())>;
+    static constexpr auto WG0_config = Gemm_0::Policy::template GetWarpGemmMWarpNWarp<Problem>();
+    using WG0                        = remove_cvref_t<decltype(WG0_config.template at<0>())>;
+    static constexpr index_t MWarp0  = WG0_config.template at<1>();
+    static constexpr index_t NWarp0  = WG0_config.template at<2>();
+    static constexpr index_t WG0_kM  = WG0 ::WarpGemmAttribute::Impl::kM;
+    static constexpr index_t WG0_kN  = WG0 ::WarpGemmAttribute::Impl::kN;
+    static constexpr index_t WG0_kK  = WG0 ::WarpGemmAttribute::Impl::kK;
+    static constexpr uint32_t DS_READ_BARRIER = 0x100; // Barrier for DS (data share) read
+    static constexpr uint32_t MFMA_BARRIER = 0x008; // Barrier for MFMA (matrix multiply-accumulate)
+    static constexpr int num_mfma_insts =
+        (kM0 / WG0_kM) * (kN0 / WG0_kN) * (kK0 / WG0_kK) / (MWarp0 * NWarp0);
+
     static_assert((CK_TILE_FMHA_FWD_FAST_EXP2 &&
                    (kHasLogitsSoftCap && Problem::BiasEnum == BlockAttentionBiasEnum::NO_BIAS ||
                     !kHasLogitsSoftCap)) ||
@@ -281,20 +294,23 @@ struct BlockFmhaPipelineQRKSVS
         index_t i_total_loops      = 0;
         constexpr index_t k0_loops = kQKHeaddim / kK0;
         constexpr index_t k1_loops = kN0 / kK1;
-        auto group_barrier_seq = (kQKHeaddim == 256)
-    ? []() {
-        static_for<0, 2, 1>{}([&](auto) {
-        __builtin_amdgcn_sched_group_barrier(0x100, 2, 0); // DS read
-        __builtin_amdgcn_sched_group_barrier(0x008, 2, 0); // MFMA
-        __builtin_amdgcn_sched_group_barrier(0x100, 1, 0); // DS read
-        __builtin_amdgcn_sched_group_barrier(0x008, 2, 0); // MFMA
-        __builtin_amdgcn_sched_group_barrier(0x100, 1, 0); // DS read
-        __builtin_amdgcn_sched_group_barrier(0x008, 4, 0); // MFMA
-        });
-    }
-    : []() {};
         // Use compile-time conditional for group barrier sequence
-        // (No runtime lambda selection)
+        - // (No runtime lambda selection)
+            auto schedule_gemm0 = [] {
+            if constexpr(kQKHeaddim == 256)
+            {
+                static_assert(num_mfma_insts % 8 == 0);
+                static_for<0, num_mfma_insts / 8, 1>{}([&](auto) {
+                    __builtin_amdgcn_sched_group_barrier(DS_READ_BARRIER, 2, 0); // DS read
+                    __builtin_amdgcn_sched_group_barrier(MFMA_BARRIER, 2, 0);    // MFMA
+                    __builtin_amdgcn_sched_group_barrier(DS_READ_BARRIER, 1, 0); // DS read
+                    __builtin_amdgcn_sched_group_barrier(MFMA_BARRIER, 2, 0);    // MFMA
+                    __builtin_amdgcn_sched_group_barrier(DS_READ_BARRIER, 1, 0); // DS read
+                    __builtin_amdgcn_sched_group_barrier(MFMA_BARRIER, 4, 0);    // MFMA
+                });
+            }
+        };
+
         static_assert(2 <= k0_loops);
         static_assert(1 <= k1_loops);
         do
@@ -336,7 +352,7 @@ struct BlockFmhaPipelineQRKSVS
                                           sequence<0, i_k0 * kK0>{},
                                           sequence<kM0, (i_k0 + 1) * kK0>{}),
                            k_lds_window);
-                    group_barrier_seq();
+                    schedule_gemm0();
                     block_sync_lds();
                     move_tile_window(k_dram_window, {0, kK0});
 
@@ -355,7 +371,7 @@ struct BlockFmhaPipelineQRKSVS
                                       sequence<0, (k0_loops - 2) * kK0>{},
                                       sequence<kM0, (k0_loops - 1) * kK0>{}),
                        k_lds_window);
-                group_barrier_seq();
+                schedule_gemm0();
                 block_sync_lds();
 
                 store_tile(k_lds_window, tile_elementwise_in(k_element_func, k_block_tile));
@@ -366,7 +382,7 @@ struct BlockFmhaPipelineQRKSVS
                                       sequence<0, (k0_loops - 1) * kK0>{},
                                       sequence<kM0, k0_loops * kK0>{}),
                        k_lds_window);
-                group_barrier_seq();
+                schedule_gemm0();
             }
 
             // STAGE 2, scale_s, add bias, mask, softmax

--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -295,8 +295,8 @@ struct BlockFmhaPipelineQRKSVS
         constexpr index_t k0_loops = kQKHeaddim / kK0;
         constexpr index_t k1_loops = kN0 / kK1;
         // Use compile-time conditional for group barrier sequence
-        - // (No runtime lambda selection)
-            auto schedule_gemm0 = [] {
+        // (No runtime lambda selection)
+        auto schedule_gemm0 = [] {
             if constexpr(kQKHeaddim == 256)
             {
                 static_assert(num_mfma_insts % 8 == 0);

--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -281,6 +281,18 @@ struct BlockFmhaPipelineQRKSVS
         index_t i_total_loops      = 0;
         constexpr index_t k0_loops = kQKHeaddim / kK0;
         constexpr index_t k1_loops = kN0 / kK1;
+        auto group_barrier_seq = (kQKHeaddim == 256)
+    ? []() {
+        static_for<0, 2, 1>{}([&](auto) {
+        __builtin_amdgcn_sched_group_barrier(0x100, 2, 0); // DS read
+        __builtin_amdgcn_sched_group_barrier(0x008, 2, 0); // MFMA
+        __builtin_amdgcn_sched_group_barrier(0x100, 1, 0); // DS read
+        __builtin_amdgcn_sched_group_barrier(0x008, 2, 0); // MFMA
+        __builtin_amdgcn_sched_group_barrier(0x100, 1, 0); // DS read
+        __builtin_amdgcn_sched_group_barrier(0x008, 4, 0); // MFMA
+        });
+    }
+    : []() {};
 
         static_assert(2 <= k0_loops);
         static_assert(1 <= k1_loops);
@@ -323,6 +335,7 @@ struct BlockFmhaPipelineQRKSVS
                                           sequence<0, i_k0 * kK0>{},
                                           sequence<kM0, (i_k0 + 1) * kK0>{}),
                            k_lds_window);
+                    group_barrier_seq();
                     block_sync_lds();
                     move_tile_window(k_dram_window, {0, kK0});
 
@@ -341,6 +354,7 @@ struct BlockFmhaPipelineQRKSVS
                                       sequence<0, (k0_loops - 2) * kK0>{},
                                       sequence<kM0, (k0_loops - 1) * kK0>{}),
                        k_lds_window);
+                group_barrier_seq();
                 block_sync_lds();
 
                 store_tile(k_lds_window, tile_elementwise_in(k_element_func, k_block_tile));
@@ -351,6 +365,7 @@ struct BlockFmhaPipelineQRKSVS
                                       sequence<0, (k0_loops - 1) * kK0>{},
                                       sequence<kM0, k0_loops * kK0>{}),
                        k_lds_window);
+                group_barrier_seq();
             }
 
             // STAGE 2, scale_s, add bias, mask, softmax

--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -58,18 +58,19 @@ struct BlockFmhaPipelineQRKSVS
     static constexpr bool kStoreLSE         = Problem::kStoreLSE;
     static constexpr bool kHasDropout       = Problem::kHasDropout;
 
-    using Gemm_0 = remove_cvref_t<decltype(Policy::template GetQKBlockGemm<Problem>())>;
-    static constexpr auto WG0_config = Gemm_0::Policy::template GetWarpGemmMWarpNWarp<Problem>();
-    using WG0                        = remove_cvref_t<decltype(WG0_config.template at<0>())>;
-    static constexpr index_t MWarp0  = WG0_config.template at<1>();
-    static constexpr index_t NWarp0  = WG0_config.template at<2>();
-    static constexpr index_t WG0_kM  = WG0 ::WarpGemmAttribute::Impl::kM;
-    static constexpr index_t WG0_kN  = WG0 ::WarpGemmAttribute::Impl::kN;
-    static constexpr index_t WG0_kK  = WG0 ::WarpGemmAttribute::Impl::kK;
-    static constexpr uint32_t DS_READ_BARRIER = 0x100; // Barrier for DS (data share) read
-    static constexpr uint32_t MFMA_BARRIER = 0x008; // Barrier for MFMA (matrix multiply-accumulate)
-    static constexpr int num_mfma_insts =
-        (kM0 / WG0_kM) * (kN0 / WG0_kN) * (kK0 / WG0_kK) / (MWarp0 * NWarp0);
+    using BlockGemm0 = remove_cvref_t<decltype(Policy::template GetQKBlockGemm<Problem>())>;
+    static constexpr auto WarpGemmConfig =
+        BlockGemm0::Policy::template GetWarpGemmMWarpNWarp<Problem>();
+    using WarpGemm0                     = remove_cvref_t<decltype(WarpGemmConfig.template at<0>())>;
+    static constexpr index_t Gemm0MWarp = WarpGemmConfig.template at<1>();
+    static constexpr index_t Gemm0NWarp = WarpGemmConfig.template at<2>();
+    static constexpr index_t WarpGemm0M = WarpGemm0::WarpGemmAttribute::Impl::kM;
+    static constexpr index_t WarpGemm0N = WarpGemm0::WarpGemmAttribute::Impl::kN;
+    static constexpr index_t WarpGemm0K = WarpGemm0::WarpGemmAttribute::Impl::kK;
+    static constexpr int NumMfmaInsts =
+        (kM0 / WarpGemm0M) * (kN0 / WarpGemm0N) * (kK0 / WarpGemm0K) / (Gemm0MWarp * Gemm0NWarp);
+    static constexpr uint32_t DS_READ = 0x100; // Barrier for DS (data share) read
+    static constexpr uint32_t MFMA    = 0x008; // Barrier for MFMA (matrix multiply-accumulate)
 
     static_assert((CK_TILE_FMHA_FWD_FAST_EXP2 &&
                    (kHasLogitsSoftCap && Problem::BiasEnum == BlockAttentionBiasEnum::NO_BIAS ||
@@ -299,14 +300,14 @@ struct BlockFmhaPipelineQRKSVS
         auto schedule_gemm0 = [] {
             if constexpr(kQKHeaddim == 256)
             {
-                static_assert(num_mfma_insts % 8 == 0);
-                static_for<0, num_mfma_insts / 8, 1>{}([&](auto) {
-                    __builtin_amdgcn_sched_group_barrier(DS_READ_BARRIER, 2, 0); // DS read
-                    __builtin_amdgcn_sched_group_barrier(MFMA_BARRIER, 2, 0);    // MFMA
-                    __builtin_amdgcn_sched_group_barrier(DS_READ_BARRIER, 1, 0); // DS read
-                    __builtin_amdgcn_sched_group_barrier(MFMA_BARRIER, 2, 0);    // MFMA
-                    __builtin_amdgcn_sched_group_barrier(DS_READ_BARRIER, 1, 0); // DS read
-                    __builtin_amdgcn_sched_group_barrier(MFMA_BARRIER, 4, 0);    // MFMA
+                static_assert(NumMfmaInsts % 8 == 0);
+                static_for<0, NumMfmaInsts / 8, 1>{}([&](auto) {
+                    __builtin_amdgcn_sched_group_barrier(DS_READ, 2, 0); // DS read
+                    __builtin_amdgcn_sched_group_barrier(MFMA, 2, 0);    // MFMA
+                    __builtin_amdgcn_sched_group_barrier(DS_READ, 1, 0); // DS read
+                    __builtin_amdgcn_sched_group_barrier(MFMA, 2, 0);    // MFMA
+                    __builtin_amdgcn_sched_group_barrier(DS_READ, 1, 0); // DS read
+                    __builtin_amdgcn_sched_group_barrier(MFMA, 4, 0);    // MFMA
                 });
             }
         };

--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -293,7 +293,8 @@ struct BlockFmhaPipelineQRKSVS
         });
     }
     : []() {};
-
+        // Use compile-time conditional for group barrier sequence
+        // (No runtime lambda selection)
         static_assert(2 <= k0_loops);
         static_assert(1 <= k1_loops);
         do

--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qx_ks_vs_custom_policy.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qx_ks_vs_custom_policy.hpp
@@ -506,7 +506,7 @@ struct BlockFmhaPipelineQXKSVSCustomPolicy : BlockFmhaPipelineQXCustomPolicy<QLo
 
         constexpr auto k_lds_block_desc_0 = make_naive_tensor_descriptor(
             make_tuple(number<kKPerBlock / kKPack>{}, number<kNPerBlock>{}, number<kKPack>{}),
-            make_tuple(number<(kNPerBlock + 2) * kKPack>{}, number<kKPack>{}, number<1>{}),
+            make_tuple(number<(kNPerBlock + 1) * kKPack>{}, number<kKPack>{}, number<1>{}),
             number<8>{},
             number<1>{});
 

--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qx_ks_vs_custom_policy.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qx_ks_vs_custom_policy.hpp
@@ -500,7 +500,7 @@ struct BlockFmhaPipelineQXKSVSCustomPolicy : BlockFmhaPipelineQXCustomPolicy<QLo
 
         constexpr auto k_lds_block_desc_0 = make_naive_tensor_descriptor(
             make_tuple(number<kKPerBlock / kKPack>{}, number<kNPerBlock>{}, number<kKPack>{}),
-            make_tuple(number<(kNPerBlock + 1) * kKPack>{}, number<kKPack>{}, number<1>{}),
+            make_tuple(number<(kNPerBlock + 2) * kKPack>{}, number<kKPack>{}, number<1>{}),
             number<8>{},
             number<1>{});
 


### PR DESCRIPTION
## Proposed changes

use iglp in qr_ks_vs pipeline and increase k_lds_padding to improve dim256 fmha fwd .

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

