### PR TITLE
Update composable kernel version to 1.2.0 for rocm 7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Documentation for Composable Kernel available at [https://rocm.docs.amd.com/projects/composable_kernel/en/latest/](https://rocm.docs.amd.com/projects/composable_kernel/en/latest/).
 
-## Composable Kernel 1.1.0 for ROCm 7.0.0
+## Composable Kernel 1.2.0 for ROCm 7.0.0
 
 ### Added
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(NOT WIN32)
     set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "")
 endif()
 
-set(version 1.1.0)
+set(version 1.2.0)
 # Check support for CUDA/HIP in Cmake
 project(composable_kernel VERSION ${version} LANGUAGES CXX HIP)
 include(CTest)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -400,8 +400,8 @@ def cmake_build(Map conf=[:]){
                     echo "Build packages"
                     sh 'ninja -j64 package'
                     archiveArtifacts artifacts: 'composablekernel-dev*.deb'
-                    sh 'mv composablekernel-dev_*.deb composablekernel-dev_all_targets_1.1.0_amd64.deb'
-                    sh 'mv composablekernel-ckprofiler_*.deb composablekernel-ckprofiler_1.1.0_amd64.deb'
+                    sh 'mv composablekernel-dev_*.deb composablekernel-dev_all_targets_1.2.0_amd64.deb'
+                    sh 'mv composablekernel-ckprofiler_*.deb composablekernel-ckprofiler_1.2.0_amd64.deb'
                     stash includes: "composablekernel-**.deb", name: "packages"
                 }
             }

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -272,7 +272,7 @@ sphinx-design==0.6.1
     # via rocm-docs-core
 sphinx-external-toc==1.0.1
     # via rocm-docs-core
-sphinx-notfound-page==1.2.0
+sphinx-notfound-page==1.1.0
     # via rocm-docs-core
 sphinxcontrib-applehelp==2.0.0
     # via sphinx

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -272,7 +272,7 @@ sphinx-design==0.6.1
     # via rocm-docs-core
 sphinx-external-toc==1.0.1
     # via rocm-docs-core
-sphinx-notfound-page==1.1.0
+sphinx-notfound-page==1.2.0
     # via rocm-docs-core
 sphinxcontrib-applehelp==2.0.0
     # via sphinx


### PR DESCRIPTION
## Proposed changes

This PR updates composable_kernel version to 1.2.0 from 1.1.0 at locations where needed. 
PR is only supposed to be merged by @illsilin.
PR needs approval from @spolifroni-amd @illsilin @afagaj.  


