### PR TITLE
fix(gemm_universal): define CK_TILE_USE_WMMA with default value...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,13 +221,20 @@ if (SUPPORTED_GPU_TARGETS MATCHES "gfx94" OR SUPPORTED_GPU_TARGETS MATCHES "gfx9
     add_definitions(-DCK_USE_GFX94)
     set(CK_USE_GFX94 "ON")
 endif()
+
+# new macro CK_TILE_USE_WMMA in order to separately compile examples for MFMA/WMMA
+set(CK_TILE_USE_WMMA 0)
+
 if (SUPPORTED_GPU_TARGETS MATCHES "gfx11" OR SUPPORTED_GPU_TARGETS MATCHES "gfx12")
     message(STATUS "Enabling WMMA instances")
     add_definitions(-DCK_USE_WMMA)
     set(CK_USE_WMMA "ON")
-    add_definitions(-DCK_TILE_USE_WMMA)
-    set(CK_TILE_USE_WMMA "ON")
+    set(CK_TILE_USE_WMMA 1)
 endif()
+
+# define the macro with the current value (0 or 1)
+add_definitions(-DCK_TILE_USE_WMMA=${CK_TILE_USE_WMMA})
+
 if (SUPPORTED_GPU_TARGETS MATCHES "gfx12")
     message(STATUS "Enabling WMMA FP8 gemms on native architectures")
     add_definitions(-DCK_USE_WMMA_FP8)


### PR DESCRIPTION
...to stop compilation error.

## Proposed changes
PR #2713 introduced a macro in gemm_utils.hpp in ck_tile/03_gemm. This macro however remains undefined when building for arch not gfx11 or gfx 12, leading to compilation error.

`In file included from /root/workspace/example/ck_tile/03_gemm/universal_gemm.cpp:13:
/root/workspace/example/ck_tile/03_gemm/gemm_utils.hpp:175:5: error: 'CK_TILE_USE_WMMA' is not defined, evaluates to 0 [-Werror,-Wundef]
  175 | #if CK_TILE_USE_WMMA
      |     ^
/root/workspace/example/ck_tile/03_gemm/universal_gemm.cpp:338:5: error: 'CK_TILE_USE_WMMA' is not defined, evaluates to 0 [-Werror,-Wundef]
  338 | #if CK_TILE_USE_WMMA`

In this PR, we set a default value (false) for the macro to resolve the compilation error.




