### PR TITLE
[Util] add a RAII stuct which inserts markers into generated asm

### DIFF
--- a/include/ck_tile/core/utility/debug.hpp
+++ b/include/ck_tile/core/utility/debug.hpp
@@ -154,7 +154,6 @@ struct CK_PRINTF_WARP0 : public CK_PRINTF<ConvertTo, FMT, PREFIX, SUFFIX>
     }
 };
 
-/*
  /*
  * RAII struct which inserts start/end markers into the generated assembly.
  *
@@ -166,13 +165,10 @@ struct CK_PRINTF_WARP0 : public CK_PRINTF<ConvertTo, FMT, PREFIX, SUFFIX>
  *
  * Example:
  *   {
- *       AsmScopeMarker marker;   // Emits CK_ASM_SCOPE_START
- *
+ *       [[maybe_unused]] AsmScopeMarker marker;   // Emits CK_ASM_SCOPE_START
  *       // ... code you want to delimit in assembly ...
- *
  *   } // marker goes out of scope → Emits CK_ASM_SCOPE_END
  *
- */
  */
 struct AsmScopeMarker
 {

--- a/include/ck_tile/core/utility/debug.hpp
+++ b/include/ck_tile/core/utility/debug.hpp
@@ -162,13 +162,10 @@ struct AsmScopeMarker
     CK_TILE_HOST_DEVICE AsmScopeMarker()
     {
         // in some future version of clang we might be able to use string_view to customize
-        asm volatile (";;# CK_ASM_SCOPE_START");
+        asm volatile(";;# CK_ASM_SCOPE_START");
     }
- 
-    CK_TILE_HOST_DEVICE ~AsmScopeMarker()
-    {
-        asm volatile (";;# CK_ASM_SCOPE_END");
-    }
+
+    CK_TILE_HOST_DEVICE ~AsmScopeMarker() { asm volatile(";;# CK_ASM_SCOPE_END"); }
 };
 
 } // namespace ck_tile

--- a/include/ck_tile/core/utility/debug.hpp
+++ b/include/ck_tile/core/utility/debug.hpp
@@ -159,12 +159,8 @@ struct CK_PRINTF_WARP0 : public CK_PRINTF<ConvertTo, FMT, PREFIX, SUFFIX>
  */
 struct AsmScopeMarker
 {
-    CK_TILE_HOST_DEVICE AsmScopeMarker()
-    {
-        // in some future version of clang we might be able to use string_view to customize
-        asm volatile(";;# CK_ASM_SCOPE_START");
-    }
-
+    // in some future version of clang we might be able to use string_view to customize
+    CK_TILE_HOST_DEVICE AsmScopeMarker() { asm volatile(";;# CK_ASM_SCOPE_START"); }
     CK_TILE_HOST_DEVICE ~AsmScopeMarker() { asm volatile(";;# CK_ASM_SCOPE_END"); }
 };
 

--- a/include/ck_tile/core/utility/debug.hpp
+++ b/include/ck_tile/core/utility/debug.hpp
@@ -154,7 +154,7 @@ struct CK_PRINTF_WARP0 : public CK_PRINTF<ConvertTo, FMT, PREFIX, SUFFIX>
     }
 };
 
- /*
+/*
  * RAII struct which inserts start/end markers into the generated assembly.
  *
  * Usage:

--- a/include/ck_tile/core/utility/debug.hpp
+++ b/include/ck_tile/core/utility/debug.hpp
@@ -155,7 +155,24 @@ struct CK_PRINTF_WARP0 : public CK_PRINTF<ConvertTo, FMT, PREFIX, SUFFIX>
 };
 
 /*
- *  RAII struct which inserts markers into generated asm
+ /*
+ * RAII struct which inserts start/end markers into the generated assembly.
+ *
+ * Usage:
+ *   - Create an `AsmScopeMarker` object at the beginning of a scope or code block.
+ *   - Its constructor will emit a "CK_ASM_SCOPE_START" marker into the assembly.
+ *   - When the object goes out of scope (end of block, return, exception, etc.),
+ *     the destructor will emit a "CK_ASM_SCOPE_END" marker.
+ *
+ * Example:
+ *   {
+ *       AsmScopeMarker marker;   // Emits CK_ASM_SCOPE_START
+ *
+ *       // ... code you want to delimit in assembly ...
+ *
+ *   } // marker goes out of scope → Emits CK_ASM_SCOPE_END
+ *
+ */
  */
 struct AsmScopeMarker
 {

--- a/include/ck_tile/core/utility/debug.hpp
+++ b/include/ck_tile/core/utility/debug.hpp
@@ -153,4 +153,18 @@ struct CK_PRINTF_WARP0 : public CK_PRINTF<ConvertTo, FMT, PREFIX, SUFFIX>
             base_t::operator()(buf);
     }
 };
+
+struct AsmScopeMarker
+{
+    CK_TILE_HOST_DEVICE AsmScopeMarker()
+    {
+        asm __volatile__ ("; CK_ASM_SCOPE_START");
+    }
+ 
+    CK_TILE_HOST_DEVICE ~AsmScopeMarker()
+    {
+        asm __volatile__ ("; CK_ASM_SCOPE_END");
+    }
+};
+
 } // namespace ck_tile

--- a/include/ck_tile/core/utility/debug.hpp
+++ b/include/ck_tile/core/utility/debug.hpp
@@ -154,16 +154,20 @@ struct CK_PRINTF_WARP0 : public CK_PRINTF<ConvertTo, FMT, PREFIX, SUFFIX>
     }
 };
 
+/*
+ *  RAII struct which inserts markers into generated asm
+ */
 struct AsmScopeMarker
 {
     CK_TILE_HOST_DEVICE AsmScopeMarker()
     {
-        asm __volatile__ ("; CK_ASM_SCOPE_START");
+        // in some future version of clang we might be able to use string_view to customize
+        asm volatile (";;# CK_ASM_SCOPE_START");
     }
  
     CK_TILE_HOST_DEVICE ~AsmScopeMarker()
     {
-        asm __volatile__ ("; CK_ASM_SCOPE_END");
+        asm volatile (";;# CK_ASM_SCOPE_END");
     }
 };
 


### PR DESCRIPTION
## Proposed changes

... which may help comparing generated asm between c++ code changes

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

