### PR TITLE
Fix merge mfma_wmma (part 1) regression

### DIFF
--- a/include/ck/tensor_operation/gpu/warp/xdlops_gemm.hpp
+++ b/include/ck/tensor_operation/gpu/warp/xdlops_gemm.hpp
@@ -1937,7 +1937,7 @@ struct XdlopsGemm
     template <bool SwizzleA>
     __device__ static auto GetGfx11InputBlkIdx()
     {
-        const auto laneId = GetLaneId() % mfma_instr.num_threads_per_blk;
+        auto laneId = GetLaneId() % mfma_instr.num_threads_per_blk;
         if constexpr(SwizzleA)
         {
             laneId = ((laneId & 1) << 3) | (laneId >> 1);


### PR DESCRIPTION
root cause: a typo in GetGfx11InputBlkIdx, const is added by mistake during code cleanup.

## Proposed changes

Please describe the motivation behind the pull request, whether it enables a new feature or fixes a bug. If there are associated pull requests or issues, please link them to the pull request.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

