### PR TITLE
Replace auto with function template for c++17 compatiblity

### DIFF
--- a/test/ck_tile/utility/print/test_print_static_encoding_pattern.cpp
+++ b/test/ck_tile/utility/print/test_print_static_encoding_pattern.cpp
@@ -12,13 +12,15 @@ namespace ck_tile {
 class PrintStaticEncodingPatternTest : public PrintTest
 {
     protected:
-    void TestY0Y1Y2(const std::string& output, auto Y0, auto Y1, auto Y2)
+    template <typename T0, typename T1, typename T2>
+    void TestY0Y1Y2(const std::string& output, T0 Y0, T1 Y1, T2 Y2)
     {
         std::stringstream expected;
         expected << "<Y0, Y1, Y2>: <" << Y0 << ", " << Y1 << ", " << Y2 << ">";
         EXPECT_TRUE(output.find(expected.str()) != std::string::npos);
     }
-    void TestX0X1(const std::string& output, auto X0, auto X1)
+    template <typename T0, typename T1>
+    void TestX0X1(const std::string& output, T0 X0, T1 X1)
     {
         std::stringstream expected;
         expected << "<X0, X1>: <" << X0 << ", " << X1 << ">";


### PR DESCRIPTION
In #2443, a helper function was added test new print functionality, but it used `auto` for the parameter types.

We need to support c++17 for downstream libraries, so we cannot use `auto` there. This PR replaces `auto` with the equivalent function template implementation.