### PR TITLE
Add a daily CI cron job to build pytorch.

### DIFF
--- a/Dockerfile.pytorch
+++ b/Dockerfile.pytorch
@@ -1,0 +1,23 @@
+ARG BASE_DOCKER="rocm/pytorch-nightly:latest"
+FROM $BASE_DOCKER
+ARG CK_PYTORCH_BRANCH="develop"
+RUN groupadd -g 109 render && \
+    usermod -u 1001 jenkins && \
+    groupmod -g 1001 jenkins && \
+    cd /tmp/pytorch && \
+    rm -rf build && \
+    cd /tmp/pytorch/third_party && \
+    rm -rf composable_kernel && \
+    git clone -b "$CK_PYTORCH_BRANCH" https://github.com/ROCm/composable_kernel.git && \
+    cd /tmp/pytorch/third_party/aiter/3rdparty && \
+    rm -rf composable_kernel && \
+    git clone -b "$CK_PYTORCH_BRANCH" https://github.com/ROCm/composable_kernel.git && \
+    cd /tmp/pytorch/third_party/fbgemm/external && \
+    rm -rf composable_kernel && \
+    git clone -b "$CK_PYTORCH_BRANCH" https://github.com/ROCm/composable_kernel.git && \
+    cd /tmp/pytorch/third_party/flash-attention/csrc && \
+    rm -rf composable_kernel && \
+    git clone -b "$CK_PYTORCH_BRANCH" https://github.com/ROCm/composable_kernel.git && \
+    chown -R jenkins:jenkins /tmp/pytorch && \
+    chmod -R a+rwx /tmp/pytorch && \
+    sudo usermod -aG irc jenkins

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -871,6 +871,73 @@ def run_aiter_tests(Map conf=[:]){
     }
 }
 
+
+def run_pytorch_tests(Map conf=[:]){
+    show_node_info()
+    env.HSA_ENABLE_SDMA=0
+    checkout scm
+    //use the latest pytorch-nightly image
+    def image = "rocm/pytorch-nightly:latest"
+    def dockerOpts="--network=host --device=/dev/kfd --device=/dev/dri --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --user=jenkins -v=/var/jenkins/:/var/jenkins"
+    def variant = env.STAGE_NAME
+    def retimage
+    def video_id = sh(returnStdout: true, script: 'getent group video | cut -d: -f3')
+    def render_id = sh(returnStdout: true, script: 'getent group render | cut -d: -f3')
+    dockerOpts = dockerOpts + " --group-add=${video_id} --group-add=${render_id} "
+    echo "Docker flags: ${dockerOpts}"
+
+    gitStatusWrapper(credentialsId: "${env.ck_git_creds}", gitHubContext: "Jenkins - ${variant}", account: 'ROCm', repo: 'composable_kernel') {
+        try
+        {
+            echo "Pulling image: ${image}"
+            retimage = docker.image("${image}")
+            withDockerRegistry([ credentialsId: "ck_docker_cred", url: "" ]) {
+                retimage.pull()
+            }
+        }
+        catch(Exception ex)
+        {
+            error "Unable to locate image: ${image}"
+        }
+    }
+
+    withDockerContainer(image: image, args: dockerOpts) {
+        timeout(time: 45, unit: 'MINUTES'){
+            try{
+                dir("/tmp/pytorch/third_party"){
+                    sh "rm -rf composable_kernel"
+                    sh "git clone https://github.com/ROCm/composable_kernel.git"
+                }
+                dir("/tmp/pytorch/third_party/aiter/3rdparty"){
+                    sh "rm -rf composable_kernel"
+                    sh "git clone https://github.com/ROCm/composable_kernel.git"
+                }
+                dir("/tmp/pytorch/third_party/fbgemm/external"){
+                    sh "rm -rf composable_kernel"
+                    sh "git clone https://github.com/ROCm/composable_kernel.git"
+                }
+                dir("/tmp/pytorch/third_party/flash-attention/csrc"){
+                    sh "rm -rf composable_kernel"
+                    sh "git clone https://github.com/ROCm/composable_kernel.git"
+                }
+                dir("/tmp/pytorch"){
+                    sh "rm -rf build"
+                    sh "python3 tools/amd_build/build_amd.py"
+                    sh "USE_ROCM_CK_SDPA=1 PYTORCH_ROCM_ARCH=gfx942 python setup.py develop"
+                }
+            }
+            catch(e){
+                echo "Throwing error exception while building Pytorch"
+                echo 'Exception occurred: ' + e.toString()
+                throw e
+            }
+            finally{
+                echo "Finished building Pytorch"
+            }
+        }
+    }
+}
+
 //launch develop branch daily jobs
 CRON_SETTINGS = BRANCH_NAME == "develop" ? '''0 23 * * * % RUN_FULL_QA=true;DISABLE_DL_KERNELS=true;RUN_CK_TILE_FMHA_TESTS=true;RUN_TILE_ENGINE_GEMM_TESTS=true;RUN_PERFORMANCE_TESTS=true;RUN_ALL_UNIT_TESTS=true
                                               0 21 * * * % RUN_GROUPED_CONV_LARGE_CASES_TESTS=true;hipTensor_test=true;BUILD_GFX908=true;BUILD_GFX942=true;BUILD_GFX950=true;RUN_PERFORMANCE_TESTS=true;RUN_ALL_UNIT_TESTS=true
@@ -1013,6 +1080,10 @@ pipeline {
             defaultValue: false,
             description: "Run all unit tests (default: OFF)")
         booleanParam(
+            name: "RUN_PYTORCH_TESTS",
+            defaultValue: false,
+            description: "Try building PYTORCH with latest CK develop branch (default: OFF)")
+        booleanParam(
             name: "RUN_AITER_TESTS",
             defaultValue: false,
             description: "Run AITER tests with latest CK develop branch (default: OFF)")
@@ -1099,6 +1170,24 @@ pipeline {
                     }
                     steps{
                         buildHipClangJobAndReboot(setup_args:setup_args, setup_cmd: "", build_cmd: "", execute_cmd: execute_cmd, no_reboot:true)
+                        cleanWs()
+                    }
+                }
+            }
+        }
+         stage("Run Pytorch Tests")
+        {
+            parallel
+            {
+                stage("Run Pytorch Tests on gfx942")
+                {
+                    when {
+                        beforeAgent true
+                        expression { params.RUN_PYTORCH_TESTS.toBoolean() }
+                    }
+                    agent{ label rocmnode("gfx942")}
+                    steps{
+                        run_pytorch_tests()
                         cleanWs()
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -908,10 +908,10 @@ def run_pytorch_tests(Map conf=[:]){
     withDockerContainer(image: image, args: dockerOpts) {
         timeout(time: 45, unit: 'MINUTES'){
             try{
-                dir("/tmp/pytorch"){
-                    sh "python3 tools/amd_build/build_amd.py"
-                    sh "USE_ROCM_CK_SDPA=1 PYTORCH_ROCM_ARCH=gfx942 python setup.py develop"
-                }
+                sh "rocminfo"
+                sh "python3 --version"
+                sh "python3 /tmp/pytorch/tools/amd_build/build_amd.py"
+                sh "USE_ROCM_CK_SDPA=1 PYTORCH_ROCM_ARCH=gfx942 python /tmp/pytorch/setup.py develop"
             }
             catch(e){
                 echo "Throwing error exception while building Pytorch"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,12 +192,16 @@ def buildDocker(install_prefix){
         image_name = "rocm/composable_kernel:ck_aiter"
         dockerArgs = dockerArgs + " --no-cache -f Dockerfile.aiter --build-arg AITER_BRANCH='${params.aiter_branch}' --build-arg CK_AITER_BRANCH='${params.ck_aiter_branch}' . "
     }
-    else{
+     else if(params.RUN_PYTORCH_TESTS){
+        image_name = "rocm/composable_kernel:ck_pytorch"
+        dockerArgs = dockerArgs + " --no-cache -f Dockerfile.pytorch --build-arg CK_PYTORCH_BRANCH='${params.ck_pytorch_branch}' . "
+    }
+   else{
         dockerArgs = dockerArgs + " -f Dockerfile . "
     }
     echo "Build Args: ${dockerArgs}"
     try{
-        if(params.BUILD_DOCKER || params.RUN_AITER_TESTS){
+        if(params.BUILD_DOCKER || params.RUN_AITER_TESTS || params.RUN_PYTORCH_TESTS){
             //force building the new docker if that parameter is true
             echo "Building image: ${image_name}"
             retimage = docker.build("${image_name}", dockerArgs)
@@ -877,8 +881,8 @@ def run_pytorch_tests(Map conf=[:]){
     env.HSA_ENABLE_SDMA=0
     checkout scm
     //use the latest pytorch-nightly image
-    def image = "rocm/pytorch-nightly:latest"
-    def dockerOpts="--network=host --device=/dev/kfd --device=/dev/dri --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --user=jenkins -v=/var/jenkins/:/var/jenkins"
+    def image = "rocm/composable_kernel:ck_pytorch"
+    def dockerOpts="--network=host --device=/dev/kfd --device=/dev/dri --group-add video --group-add render --group-add irc --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --user=jenkins -v=/var/jenkins/:/var/jenkins"
     def variant = env.STAGE_NAME
     def retimage
     def video_id = sh(returnStdout: true, script: 'getent group video | cut -d: -f3')
@@ -904,24 +908,7 @@ def run_pytorch_tests(Map conf=[:]){
     withDockerContainer(image: image, args: dockerOpts) {
         timeout(time: 45, unit: 'MINUTES'){
             try{
-                dir("/tmp/pytorch/third_party"){
-                    sh "rm -rf composable_kernel"
-                    sh "git clone https://github.com/ROCm/composable_kernel.git"
-                }
-                dir("/tmp/pytorch/third_party/aiter/3rdparty"){
-                    sh "rm -rf composable_kernel"
-                    sh "git clone https://github.com/ROCm/composable_kernel.git"
-                }
-                dir("/tmp/pytorch/third_party/fbgemm/external"){
-                    sh "rm -rf composable_kernel"
-                    sh "git clone https://github.com/ROCm/composable_kernel.git"
-                }
-                dir("/tmp/pytorch/third_party/flash-attention/csrc"){
-                    sh "rm -rf composable_kernel"
-                    sh "git clone https://github.com/ROCm/composable_kernel.git"
-                }
                 dir("/tmp/pytorch"){
-                    sh "rm -rf build"
                     sh "python3 tools/amd_build/build_amd.py"
                     sh "USE_ROCM_CK_SDPA=1 PYTORCH_ROCM_ARCH=gfx942 python setup.py develop"
                 }
@@ -1083,6 +1070,10 @@ pipeline {
             name: "RUN_PYTORCH_TESTS",
             defaultValue: false,
             description: "Try building PYTORCH with latest CK develop branch (default: OFF)")
+        string(
+            name: 'ck_pytorch_branch',
+            defaultValue: 'develop',
+            description: 'Specify which branch of CK to test with Pytorch (default: develop)')
         booleanParam(
             name: "RUN_AITER_TESTS",
             defaultValue: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -931,7 +931,8 @@ CRON_SETTINGS = BRANCH_NAME == "develop" ? '''0 23 * * * % RUN_FULL_QA=true;DISA
                                               0 19 * * * % BUILD_DOCKER=true;COMPILER_VERSION=amd-staging;BUILD_COMPILER=/llvm-project/build/bin/clang++;USE_SCCACHE=false;NINJA_BUILD_TRACE=true;RUN_ALL_UNIT_TESTS=true
                                               0 17 * * * % BUILD_DOCKER=true;COMPILER_VERSION=amd-mainline;BUILD_COMPILER=/llvm-project/build/bin/clang++;USE_SCCACHE=false;NINJA_BUILD_TRACE=true;RUN_ALL_UNIT_TESTS=true
                                               0 15 * * * % BUILD_INSTANCES_ONLY=true;USE_SCCACHE=false;NINJA_BUILD_TRACE=true
-                                              0 13 * * * % RUN_AITER_TESTS=true;BUILD_LEGACY_OS=true;USE_SCCACHE=false;RUN_PERFORMANCE_TESTS=false''' : ""
+                                              0 13 * * * % RUN_AITER_TESTS=true;BUILD_LEGACY_OS=true;USE_SCCACHE=false;RUN_PERFORMANCE_TESTS=false
+                                              0 11 * * * % RUN_PYTORCH_TESTS=true;RUN_CODEGEN_TESTS=false;USE_SCCACHE=false;RUN_PERFORMANCE_TESTS=false;BUILD_GFX10=false;BUILD_GFX11=false;BUILD_GFX12=false;BUILD_GFX90A=false''' : ""
 
 pipeline {
     agent none


### PR DESCRIPTION
## Proposed changes

These changes will enable a new daily cron job to build pytorch with the latest CK develop branch (also add an option to build pytorch with any other CK branch on demand).
This would allow us to catch any pytorch build issues due to latest CK changes.
Currently, the builds are failing, but it appears that the compiler flags and macros are not getting passed to pytorch correctly. So the fix may come not from the CK side, but from the pytorch side.
Also, the docker image for pytorch-nightly appears to be very large (>70Gb). I'm trying to find ways to reduce it.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x ] I have added inline documentation which enables the maintainers with understanding the motivation
- [x ] I have removed the stale documentation which is no longer relevant after this pull request
- [x ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x ] I have run `clang-format` on all changed files
- [ x] Any dependent changes have been merged

