### PR TITLE
refactor: use snake_case naming in ck_tile/core components

### DIFF
--- a/include/ck_tile/core/algorithm/static_encoding_pattern.hpp
+++ b/include/ck_tile/core/algorithm/static_encoding_pattern.hpp
@@ -104,7 +104,7 @@ enum struct tile_distribution_pattern
     block_raked,
 };
 
-struct TileDistributionEncodingPattern
+struct tile_distribution_encoding_pattern
 {
 };
 
@@ -126,7 +126,7 @@ template <index_t BlockSize,
           index_t VecSize,
           tile_distribution_pattern DistributionPattern,
           index_t NumWaveGroups = 1>
-struct TileDistributionEncodingPattern2D : public TileDistributionEncodingPattern
+struct tile_distribution_encoding_pattern_2d : public tile_distribution_encoding_pattern
 {
 };
 
@@ -136,12 +136,12 @@ template <index_t BlockSize,
           index_t XPerTile,
           index_t VecSize,
           index_t NumWaveGroups>
-struct TileDistributionEncodingPattern2D<BlockSize,
+struct tile_distribution_encoding_pattern_2d<BlockSize,
                                          YPerTile,
                                          XPerTile,
                                          VecSize,
                                          tile_distribution_pattern::thread_raked,
-                                         NumWaveGroups> : public TileDistributionEncodingPattern
+                                         NumWaveGroups> : public tile_distribution_encoding_pattern
 {
 
     // TODO: make pattern where below condition does not need to hold - GGemmMultiDSplitk!
@@ -165,7 +165,7 @@ struct TileDistributionEncodingPattern2D<BlockSize,
                   "X0 * warp_ys * Y0 must cover whole workgroup!");
     static_assert(Y0 * Y1 * Y2 == YPerTile, "Y0, Y1, Y2 must cover whole YPerTile");
 
-    CK_TILE_HOST_DEVICE static constexpr auto Make2DStaticTileDistribution()
+    CK_TILE_HOST_DEVICE static constexpr auto make_2d_static_tile_distribution()
     {
         if constexpr(NumWaveGroups != 1)
         {
@@ -189,7 +189,7 @@ struct TileDistributionEncodingPattern2D<BlockSize,
         }
     }
 
-    CK_TILE_HOST_DEVICE static constexpr auto MakeShuffled2DStaticTileDistribution()
+    CK_TILE_HOST_DEVICE static constexpr auto make_shuffled_2d_static_tile_distribution()
     {
         if constexpr(NumWaveGroups != 1)
         {
@@ -220,12 +220,12 @@ template <index_t BlockSize,
           index_t XPerTile,
           index_t VecSize,
           index_t NumWaveGroups>
-struct TileDistributionEncodingPattern2D<BlockSize,
+struct tile_distribution_encoding_pattern_2d<BlockSize,
                                          YPerTile,
                                          XPerTile,
                                          VecSize,
                                          tile_distribution_pattern::warp_raked,
-                                         NumWaveGroups> : public TileDistributionEncodingPattern
+                                         NumWaveGroups> : public tile_distribution_encoding_pattern
 {
 
     static_assert(XPerTile % VecSize == 0, "XPerTile must be a multiple of VecSize!");
@@ -244,7 +244,7 @@ struct TileDistributionEncodingPattern2D<BlockSize,
     static constexpr index_t Y1 = YPerTile / (Y2 * Y0); // # of iters within wavefront
     static_assert(Y0 * Y1 * Y2 == YPerTile, "Y0, Y1, Y2 must cover whole YPerTile");
 
-    CK_TILE_HOST_DEVICE static constexpr auto Make2DStaticTileDistribution()
+    CK_TILE_HOST_DEVICE static constexpr auto make_2d_static_tile_distribution()
     {
         return make_static_tile_distribution(
             tile_distribution_encoding<sequence<1>,
@@ -255,7 +255,7 @@ struct TileDistributionEncodingPattern2D<BlockSize,
                                        sequence<1, 1>>{}); // -> <Y1, X1>
     }
 
-    CK_TILE_HOST_DEVICE static constexpr auto MakeShuffled2DStaticTileDistribution()
+    CK_TILE_HOST_DEVICE static constexpr auto make_shuffled_2d_static_tile_distribution()
     {
         return make_static_tile_distribution(
             tile_distribution_encoding<sequence<1>,
@@ -273,12 +273,12 @@ template <index_t BlockSize,
           index_t XPerTile,
           index_t VecSize,
           index_t NumWaveGroups>
-struct TileDistributionEncodingPattern2D<BlockSize,
+struct tile_distribution_encoding_pattern_2d<BlockSize,
                                          YPerTile,
                                          XPerTile,
                                          VecSize,
                                          tile_distribution_pattern::block_raked,
-                                         NumWaveGroups> : public TileDistributionEncodingPattern
+                                         NumWaveGroups> : public tile_distribution_encoding_pattern
 {
 
     // TODO: make pattern where below condition does not need to hold - GGemmMultiDSplitk!
@@ -295,7 +295,7 @@ struct TileDistributionEncodingPattern2D<BlockSize,
     static constexpr index_t Y0 = YPerTile / (Y2 * Y1); // # of iters
     static_assert(Y0 * Y1 * Y2 == YPerTile, "Y0, Y1, Y2 must cover whole YPerTile");
 
-    CK_TILE_HOST_DEVICE static constexpr auto Make2DStaticTileDistribution()
+    CK_TILE_HOST_DEVICE static constexpr auto make_2d_static_tile_distribution()
     {
         return make_static_tile_distribution(
             tile_distribution_encoding<sequence<1>,
@@ -306,7 +306,7 @@ struct TileDistributionEncodingPattern2D<BlockSize,
                                        sequence<0, 1>>{}); // -> <Y0, X1>
     }
 
-    CK_TILE_HOST_DEVICE static constexpr auto MakeShuffled2DStaticTileDistribution()
+    CK_TILE_HOST_DEVICE static constexpr auto make_shuffled_2d_static_tile_distribution()
     {
         return make_static_tile_distribution(
             tile_distribution_encoding<sequence<1>,
@@ -336,21 +336,21 @@ template <index_t BlockSize,
           index_t VecSize,
           tile_distribution_pattern DistributionPattern,
           index_t NumWaveGroups>
-CK_TILE_HOST_DEVICE void print(const TileDistributionEncodingPattern2D<BlockSize,
+CK_TILE_HOST_DEVICE void print(const tile_distribution_encoding_pattern_2d<BlockSize,
                                                                        YPerTile,
                                                                        XPerTile,
                                                                        VecSize,
                                                                        DistributionPattern,
                                                                        NumWaveGroups>&)
 {
-    using PatternType = TileDistributionEncodingPattern2D<BlockSize,
+    using PatternType = tile_distribution_encoding_pattern_2d<BlockSize,
                                                           YPerTile,
                                                           XPerTile,
                                                           VecSize,
                                                           DistributionPattern,
                                                           NumWaveGroups>;
 
-    printf("TileDistributionEncodingPattern2D<BlockSize:%d, YPerTile:%d, XPerTile:%d, "
+    printf("tile_distribution_encoding_pattern_2d<BlockSize:%d, YPerTile:%d, XPerTile:%d, "
            "VecSize:%d, %s>: ",
            BlockSize,
            YPerTile,

--- a/include/ck_tile/core/algorithm/static_encoding_pattern.hpp
+++ b/include/ck_tile/core/algorithm/static_encoding_pattern.hpp
@@ -137,11 +137,12 @@ template <index_t BlockSize,
           index_t VecSize,
           index_t NumWaveGroups>
 struct tile_distribution_encoding_pattern_2d<BlockSize,
-                                         YPerTile,
-                                         XPerTile,
-                                         VecSize,
-                                         tile_distribution_pattern::thread_raked,
-                                         NumWaveGroups> : public tile_distribution_encoding_pattern
+                                             YPerTile,
+                                             XPerTile,
+                                             VecSize,
+                                             tile_distribution_pattern::thread_raked,
+                                             NumWaveGroups>
+    : public tile_distribution_encoding_pattern
 {
 
     // TODO: make pattern where below condition does not need to hold - GGemmMultiDSplitk!
@@ -221,11 +222,12 @@ template <index_t BlockSize,
           index_t VecSize,
           index_t NumWaveGroups>
 struct tile_distribution_encoding_pattern_2d<BlockSize,
-                                         YPerTile,
-                                         XPerTile,
-                                         VecSize,
-                                         tile_distribution_pattern::warp_raked,
-                                         NumWaveGroups> : public tile_distribution_encoding_pattern
+                                             YPerTile,
+                                             XPerTile,
+                                             VecSize,
+                                             tile_distribution_pattern::warp_raked,
+                                             NumWaveGroups>
+    : public tile_distribution_encoding_pattern
 {
 
     static_assert(XPerTile % VecSize == 0, "XPerTile must be a multiple of VecSize!");
@@ -274,11 +276,12 @@ template <index_t BlockSize,
           index_t VecSize,
           index_t NumWaveGroups>
 struct tile_distribution_encoding_pattern_2d<BlockSize,
-                                         YPerTile,
-                                         XPerTile,
-                                         VecSize,
-                                         tile_distribution_pattern::block_raked,
-                                         NumWaveGroups> : public tile_distribution_encoding_pattern
+                                             YPerTile,
+                                             XPerTile,
+                                             VecSize,
+                                             tile_distribution_pattern::block_raked,
+                                             NumWaveGroups>
+    : public tile_distribution_encoding_pattern
 {
 
     // TODO: make pattern where below condition does not need to hold - GGemmMultiDSplitk!
@@ -337,18 +340,18 @@ template <index_t BlockSize,
           tile_distribution_pattern DistributionPattern,
           index_t NumWaveGroups>
 CK_TILE_HOST_DEVICE void print(const tile_distribution_encoding_pattern_2d<BlockSize,
-                                                                       YPerTile,
-                                                                       XPerTile,
-                                                                       VecSize,
-                                                                       DistributionPattern,
-                                                                       NumWaveGroups>&)
+                                                                           YPerTile,
+                                                                           XPerTile,
+                                                                           VecSize,
+                                                                           DistributionPattern,
+                                                                           NumWaveGroups>&)
 {
     using PatternType = tile_distribution_encoding_pattern_2d<BlockSize,
-                                                          YPerTile,
-                                                          XPerTile,
-                                                          VecSize,
-                                                          DistributionPattern,
-                                                          NumWaveGroups>;
+                                                              YPerTile,
+                                                              XPerTile,
+                                                              VecSize,
+                                                              DistributionPattern,
+                                                              NumWaveGroups>;
 
     printf("tile_distribution_encoding_pattern_2d<BlockSize:%d, YPerTile:%d, XPerTile:%d, "
            "VecSize:%d, %s>: ",

--- a/include/ck_tile/ops/batched_transpose/pipeline/batched_transpose_common_policy.hpp
+++ b/include/ck_tile/ops/batched_transpose/pipeline/batched_transpose_common_policy.hpp
@@ -22,10 +22,10 @@ struct BatchedTransposeCommonPolicy
         constexpr index_t kVectorSize = Problem::VectorSizeInput;
         static_assert((kLeadDimPerBlock * kVectorSize) % kBlockSize == 0, "");
         using TileEncodingPattern = tile_distribution_encoding_pattern_2d<kBlockSize,
-                                                                      kSecondDimPerBlock,
-                                                                      kLeadDimPerBlock,
-                                                                      kVectorSize,
-                                                                      TileAccessPattern>;
+                                                                          kSecondDimPerBlock,
+                                                                          kLeadDimPerBlock,
+                                                                          kVectorSize,
+                                                                          TileAccessPattern>;
         return TileEncodingPattern::make_2d_static_tile_distribution();
     }
 };

--- a/include/ck_tile/ops/batched_transpose/pipeline/batched_transpose_common_policy.hpp
+++ b/include/ck_tile/ops/batched_transpose/pipeline/batched_transpose_common_policy.hpp
@@ -21,12 +21,12 @@ struct BatchedTransposeCommonPolicy
 
         constexpr index_t kVectorSize = Problem::VectorSizeInput;
         static_assert((kLeadDimPerBlock * kVectorSize) % kBlockSize == 0, "");
-        using TileEncodingPattern = TileDistributionEncodingPattern2D<kBlockSize,
+        using TileEncodingPattern = tile_distribution_encoding_pattern_2d<kBlockSize,
                                                                       kSecondDimPerBlock,
                                                                       kLeadDimPerBlock,
                                                                       kVectorSize,
                                                                       TileAccessPattern>;
-        return TileEncodingPattern::Make2DStaticTileDistribution();
+        return TileEncodingPattern::make_2d_static_tile_distribution();
     }
 };
 

--- a/include/ck_tile/ops/batched_transpose/pipeline/batched_transpose_policy.hpp
+++ b/include/ck_tile/ops/batched_transpose/pipeline/batched_transpose_policy.hpp
@@ -18,12 +18,12 @@ struct BatchedTransposePolicy : public BatchedTransposeCommonPolicy
         constexpr index_t NPerBlock   = Problem::kNPerBlock;
         constexpr index_t VecLoadSize = Problem::VectorSizeOutput;
 
-        using TileEncodingPattern = TileDistributionEncodingPattern2D<BlockSize,
+        using TileEncodingPattern = tile_distribution_encoding_pattern_2d<BlockSize,
                                                                       MPerBlock,
                                                                       NPerBlock,
                                                                       VecLoadSize,
                                                                       TileAccessPattern>;
-        return TileEncodingPattern::MakeShuffled2DStaticTileDistribution();
+        return TileEncodingPattern::make_shuffled_2d_static_tile_distribution();
     }
 };
 } // namespace ck_tile

--- a/include/ck_tile/ops/batched_transpose/pipeline/batched_transpose_policy.hpp
+++ b/include/ck_tile/ops/batched_transpose/pipeline/batched_transpose_policy.hpp
@@ -19,10 +19,10 @@ struct BatchedTransposePolicy : public BatchedTransposeCommonPolicy
         constexpr index_t VecLoadSize = Problem::VectorSizeOutput;
 
         using TileEncodingPattern = tile_distribution_encoding_pattern_2d<BlockSize,
-                                                                      MPerBlock,
-                                                                      NPerBlock,
-                                                                      VecLoadSize,
-                                                                      TileAccessPattern>;
+                                                                          MPerBlock,
+                                                                          NPerBlock,
+                                                                          VecLoadSize,
+                                                                          TileAccessPattern>;
         return TileEncodingPattern::make_shuffled_2d_static_tile_distribution();
     }
 };

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -291,13 +291,14 @@ struct CShuffleEpilogue
                       "Currently, the CShuffle Epilogue only supports the Row Major Output layout");
 
         using TileEncodingPattern =
-        tile_distribution_encoding_pattern_2d<kBlockSize,
-                                              MPerIterationShuffle,
-                                              NPerIterationShuffle,
-                                              GetVectorSizeC(),
-                                              tile_distribution_pattern::thread_raked,
-                                              Problem::kNumWaveGroups>;
-        constexpr auto dram_tile_distribution = TileEncodingPattern::make_2d_static_tile_distribution();
+            tile_distribution_encoding_pattern_2d<kBlockSize,
+                                                  MPerIterationShuffle,
+                                                  NPerIterationShuffle,
+                                                  GetVectorSizeC(),
+                                                  tile_distribution_pattern::thread_raked,
+                                                  Problem::kNumWaveGroups>;
+        constexpr auto dram_tile_distribution =
+            TileEncodingPattern::make_2d_static_tile_distribution();
 
         auto d_dram_windows = generate_tuple(
             [&](auto idx) {

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -291,13 +291,13 @@ struct CShuffleEpilogue
                       "Currently, the CShuffle Epilogue only supports the Row Major Output layout");
 
         using TileEncodingPattern =
-            TileDistributionEncodingPattern2D<kBlockSize,
+        tile_distribution_encoding_pattern_2d<kBlockSize,
                                               MPerIterationShuffle,
                                               NPerIterationShuffle,
                                               GetVectorSizeC(),
                                               tile_distribution_pattern::thread_raked,
                                               Problem::kNumWaveGroups>;
-        constexpr auto dram_tile_distribution = TileEncodingPattern::Make2DStaticTileDistribution();
+        constexpr auto dram_tile_distribution = TileEncodingPattern::make_2d_static_tile_distribution();
 
         auto d_dram_windows = generate_tuple(
             [&](auto idx) {

--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -168,7 +168,7 @@ struct UniversalGemmBasePolicy
         {
             constexpr index_t BlockSize   = Problem::kBlockSize;
             constexpr index_t VecLoadSize = GetVectorSizeB<Problem>();
-            using TileEncodingPattern     = TileDistributionEncodingPattern2D<BlockSize,
+            using TileEncodingPattern     = tile_distribution_encoding_pattern_2d<BlockSize,
                                                                               KPerBlock,
                                                                               NPerBlock,
                                                                               VecLoadSize,
@@ -494,24 +494,24 @@ struct UniversalGemmBasePolicy
         // Tile: MPerBlock X KPerBlock
         if constexpr(std::is_same_v<ALayout, ck_tile::tensor_layout::gemm::RowMajor>)
         {
-            using TileEncodingPattern = TileDistributionEncodingPattern2D<BlockSize,
+            using TileEncodingPattern = tile_distribution_encoding_pattern_2d<BlockSize,
                                                                           MPerBlock,
                                                                           KPerBlock,
                                                                           VecLoadSize,
                                                                           ATileAccessPattern,
                                                                           NumWaveGroups>;
-            return TileEncodingPattern::Make2DStaticTileDistribution();
+            return TileEncodingPattern::make_2d_static_tile_distribution();
         }
         // Tile: KPerBlock X MPerBlock
         else
         {
-            using TileEncodingPattern = TileDistributionEncodingPattern2D<BlockSize,
+            using TileEncodingPattern = tile_distribution_encoding_pattern_2d<BlockSize,
                                                                           KPerBlock,
                                                                           MPerBlock,
                                                                           VecLoadSize,
                                                                           ATileAccessPattern,
                                                                           NumWaveGroups>;
-            return TileEncodingPattern::Make2DStaticTileDistribution();
+            return TileEncodingPattern::make_2d_static_tile_distribution();
         }
     }
 
@@ -530,24 +530,24 @@ struct UniversalGemmBasePolicy
         // Tile: KPerBlock X NPerBlock
         if constexpr(std::is_same_v<BLayout, ck_tile::tensor_layout::gemm::RowMajor>)
         {
-            using TileEncodingPattern = TileDistributionEncodingPattern2D<BlockSize,
+            using TileEncodingPattern = tile_distribution_encoding_pattern_2d<BlockSize,
                                                                           KPerBlock,
                                                                           NPerBlock,
                                                                           VecLoadSize,
                                                                           BTileAccessPattern,
                                                                           NumWaveGroups>;
-            return TileEncodingPattern::Make2DStaticTileDistribution();
+            return TileEncodingPattern::make_2d_static_tile_distribution();
         }
         // Tile: NPerBlock X KPerBlock
         else
         {
-            using TileEncodingPattern = TileDistributionEncodingPattern2D<BlockSize,
+            using TileEncodingPattern = tile_distribution_encoding_pattern_2d<BlockSize,
                                                                           NPerBlock,
                                                                           KPerBlock,
                                                                           VecLoadSize,
                                                                           BTileAccessPattern,
                                                                           NumWaveGroups>;
-            return TileEncodingPattern::Make2DStaticTileDistribution();
+            return TileEncodingPattern::make_2d_static_tile_distribution();
         }
     }
 
@@ -562,13 +562,13 @@ struct UniversalGemmBasePolicy
         constexpr index_t VecLoadSize   = GetVectorSizeA<Problem>();
         constexpr index_t NumWaveGroups = Problem::NumWaveGroups;
 
-        using TileEncodingPattern = TileDistributionEncodingPattern2D<BlockSize,
+        using TileEncodingPattern = tile_distribution_encoding_pattern_2d<BlockSize,
                                                                       KPerBlock,
                                                                       MPerBlock,
                                                                       VecLoadSize,
                                                                       ATileAccessPattern,
                                                                       NumWaveGroups>;
-        return TileEncodingPattern::MakeShuffled2DStaticTileDistribution();
+        return TileEncodingPattern::make_shuffled_2d_static_tile_distribution();
     }
 
     template <typename Problem>
@@ -582,13 +582,13 @@ struct UniversalGemmBasePolicy
         constexpr index_t VecLoadSize   = GetVectorSizeB<Problem>();
         constexpr index_t NumWaveGroups = Problem::NumWaveGroups;
 
-        using TileEncodingPattern = TileDistributionEncodingPattern2D<BlockSize,
+        using TileEncodingPattern = tile_distribution_encoding_pattern_2d<BlockSize,
                                                                       KPerBlock,
                                                                       NPerBlock,
                                                                       VecLoadSize,
                                                                       BTileAccessPattern,
                                                                       NumWaveGroups>;
-        return TileEncodingPattern::MakeShuffled2DStaticTileDistribution();
+        return TileEncodingPattern::make_shuffled_2d_static_tile_distribution();
     }
 
     template <typename Problem>

--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -169,10 +169,10 @@ struct UniversalGemmBasePolicy
             constexpr index_t BlockSize   = Problem::kBlockSize;
             constexpr index_t VecLoadSize = GetVectorSizeB<Problem>();
             using TileEncodingPattern     = tile_distribution_encoding_pattern_2d<BlockSize,
-                                                                              KPerBlock,
-                                                                              NPerBlock,
-                                                                              VecLoadSize,
-                                                                              BTileAccessPattern>;
+                                                                                  KPerBlock,
+                                                                                  NPerBlock,
+                                                                                  VecLoadSize,
+                                                                                  BTileAccessPattern>;
 
             constexpr auto BK0 = number<TileEncodingPattern::X1>{};
             constexpr auto BK1 = number<TileEncodingPattern::Y0>{};
@@ -495,22 +495,22 @@ struct UniversalGemmBasePolicy
         if constexpr(std::is_same_v<ALayout, ck_tile::tensor_layout::gemm::RowMajor>)
         {
             using TileEncodingPattern = tile_distribution_encoding_pattern_2d<BlockSize,
-                                                                          MPerBlock,
-                                                                          KPerBlock,
-                                                                          VecLoadSize,
-                                                                          ATileAccessPattern,
-                                                                          NumWaveGroups>;
+                                                                              MPerBlock,
+                                                                              KPerBlock,
+                                                                              VecLoadSize,
+                                                                              ATileAccessPattern,
+                                                                              NumWaveGroups>;
             return TileEncodingPattern::make_2d_static_tile_distribution();
         }
         // Tile: KPerBlock X MPerBlock
         else
         {
             using TileEncodingPattern = tile_distribution_encoding_pattern_2d<BlockSize,
-                                                                          KPerBlock,
-                                                                          MPerBlock,
-                                                                          VecLoadSize,
-                                                                          ATileAccessPattern,
-                                                                          NumWaveGroups>;
+                                                                              KPerBlock,
+                                                                              MPerBlock,
+                                                                              VecLoadSize,
+                                                                              ATileAccessPattern,
+                                                                              NumWaveGroups>;
             return TileEncodingPattern::make_2d_static_tile_distribution();
         }
     }
@@ -531,22 +531,22 @@ struct UniversalGemmBasePolicy
         if constexpr(std::is_same_v<BLayout, ck_tile::tensor_layout::gemm::RowMajor>)
         {
             using TileEncodingPattern = tile_distribution_encoding_pattern_2d<BlockSize,
-                                                                          KPerBlock,
-                                                                          NPerBlock,
-                                                                          VecLoadSize,
-                                                                          BTileAccessPattern,
-                                                                          NumWaveGroups>;
+                                                                              KPerBlock,
+                                                                              NPerBlock,
+                                                                              VecLoadSize,
+                                                                              BTileAccessPattern,
+                                                                              NumWaveGroups>;
             return TileEncodingPattern::make_2d_static_tile_distribution();
         }
         // Tile: NPerBlock X KPerBlock
         else
         {
             using TileEncodingPattern = tile_distribution_encoding_pattern_2d<BlockSize,
-                                                                          NPerBlock,
-                                                                          KPerBlock,
-                                                                          VecLoadSize,
-                                                                          BTileAccessPattern,
-                                                                          NumWaveGroups>;
+                                                                              NPerBlock,
+                                                                              KPerBlock,
+                                                                              VecLoadSize,
+                                                                              BTileAccessPattern,
+                                                                              NumWaveGroups>;
             return TileEncodingPattern::make_2d_static_tile_distribution();
         }
     }
@@ -563,11 +563,11 @@ struct UniversalGemmBasePolicy
         constexpr index_t NumWaveGroups = Problem::NumWaveGroups;
 
         using TileEncodingPattern = tile_distribution_encoding_pattern_2d<BlockSize,
-                                                                      KPerBlock,
-                                                                      MPerBlock,
-                                                                      VecLoadSize,
-                                                                      ATileAccessPattern,
-                                                                      NumWaveGroups>;
+                                                                          KPerBlock,
+                                                                          MPerBlock,
+                                                                          VecLoadSize,
+                                                                          ATileAccessPattern,
+                                                                          NumWaveGroups>;
         return TileEncodingPattern::make_shuffled_2d_static_tile_distribution();
     }
 
@@ -583,11 +583,11 @@ struct UniversalGemmBasePolicy
         constexpr index_t NumWaveGroups = Problem::NumWaveGroups;
 
         using TileEncodingPattern = tile_distribution_encoding_pattern_2d<BlockSize,
-                                                                      KPerBlock,
-                                                                      NPerBlock,
-                                                                      VecLoadSize,
-                                                                      BTileAccessPattern,
-                                                                      NumWaveGroups>;
+                                                                          KPerBlock,
+                                                                          NPerBlock,
+                                                                          VecLoadSize,
+                                                                          BTileAccessPattern,
+                                                                          NumWaveGroups>;
         return TileEncodingPattern::make_shuffled_2d_static_tile_distribution();
     }
 

--- a/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_policy.hpp
@@ -55,16 +55,15 @@ struct GemmAQuantPipelineAgBgCrDefaultPolicy : public UniversalGemmPipelineAgBgC
         static_assert(std::is_same_v<AQLayout, tensor_layout::gemm::RowMajor>);
         if constexpr(PreshuffleQuant)
         {
-            using TileEncodingPattern =
-                tile_distribution_encoding_pattern_aq<BlockGemmShape,
-                                                  WarpGemm,
-                                                  BlockSize,
-                                                  MPerBlock / WarpGemm::kM,
-                                                  ck_tile::integer_least_multiple(
-                                                      WarpGemm::kM * KPerBlockAQ, get_warp_size()),
-                                                  KPerBlockAQ,
-                                                  VecLoadSize,
-                                                  PreshuffleQuant>;
+            using TileEncodingPattern = tile_distribution_encoding_pattern_aq<
+                BlockGemmShape,
+                WarpGemm,
+                BlockSize,
+                MPerBlock / WarpGemm::kM,
+                ck_tile::integer_least_multiple(WarpGemm::kM * KPerBlockAQ, get_warp_size()),
+                KPerBlockAQ,
+                VecLoadSize,
+                PreshuffleQuant>;
 
             return TileEncodingPattern::make_2d_static_tile_distribution();
         }
@@ -74,23 +73,23 @@ struct GemmAQuantPipelineAgBgCrDefaultPolicy : public UniversalGemmPipelineAgBgC
             {
                 using TileEncodingPatternTransposeC =
                     tile_distribution_encoding_pattern_aq_transposed_c<BlockGemmShape,
-                                                                 WarpGemm,
-                                                                 BlockSize,
-                                                                 MPerBlock,
-                                                                 KPerBlockAQ,
-                                                                 VecLoadSize>;
+                                                                       WarpGemm,
+                                                                       BlockSize,
+                                                                       MPerBlock,
+                                                                       KPerBlockAQ,
+                                                                       VecLoadSize>;
                 return TileEncodingPatternTransposeC::make_2d_static_tile_distribution();
             }
             else
             {
                 using TileEncodingPattern = tile_distribution_encoding_pattern_aq<BlockGemmShape,
-                                                                              WarpGemm,
-                                                                              BlockSize,
-                                                                              MPerBlock,
-                                                                              KPerBlockAQ,
-                                                                              KPerBlockAQ,
-                                                                              VecLoadSize,
-                                                                              PreshuffleQuant>;
+                                                                                  WarpGemm,
+                                                                                  BlockSize,
+                                                                                  MPerBlock,
+                                                                                  KPerBlockAQ,
+                                                                                  KPerBlockAQ,
+                                                                                  VecLoadSize,
+                                                                                  PreshuffleQuant>;
 
                 return TileEncodingPattern::make_2d_static_tile_distribution();
             }

--- a/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_policy.hpp
@@ -56,7 +56,7 @@ struct GemmAQuantPipelineAgBgCrDefaultPolicy : public UniversalGemmPipelineAgBgC
         if constexpr(PreshuffleQuant)
         {
             using TileEncodingPattern =
-                TileDistributionEncodingPatternAQ<BlockGemmShape,
+                tile_distribution_encoding_pattern_aq<BlockGemmShape,
                                                   WarpGemm,
                                                   BlockSize,
                                                   MPerBlock / WarpGemm::kM,
@@ -66,24 +66,24 @@ struct GemmAQuantPipelineAgBgCrDefaultPolicy : public UniversalGemmPipelineAgBgC
                                                   VecLoadSize,
                                                   PreshuffleQuant>;
 
-            return TileEncodingPattern::Make2DStaticTileDistribution();
+            return TileEncodingPattern::make_2d_static_tile_distribution();
         }
         else
         {
             if constexpr(Problem::TransposeC)
             {
                 using TileEncodingPatternTransposeC =
-                    TileDistributionEncodingPatternAQTransposedC<BlockGemmShape,
+                    tile_distribution_encoding_pattern_aq_transposed_c<BlockGemmShape,
                                                                  WarpGemm,
                                                                  BlockSize,
                                                                  MPerBlock,
                                                                  KPerBlockAQ,
                                                                  VecLoadSize>;
-                return TileEncodingPatternTransposeC::Make2DStaticTileDistribution();
+                return TileEncodingPatternTransposeC::make_2d_static_tile_distribution();
             }
             else
             {
-                using TileEncodingPattern = TileDistributionEncodingPatternAQ<BlockGemmShape,
+                using TileEncodingPattern = tile_distribution_encoding_pattern_aq<BlockGemmShape,
                                                                               WarpGemm,
                                                                               BlockSize,
                                                                               MPerBlock,
@@ -92,7 +92,7 @@ struct GemmAQuantPipelineAgBgCrDefaultPolicy : public UniversalGemmPipelineAgBgC
                                                                               VecLoadSize,
                                                                               PreshuffleQuant>;
 
-                return TileEncodingPattern::Make2DStaticTileDistribution();
+                return TileEncodingPattern::make_2d_static_tile_distribution();
             }
         }
     }

--- a/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_v3.hpp
+++ b/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_v3.hpp
@@ -330,7 +330,7 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
             if constexpr(is_a_col_major)
             {
                 auto a_shuffle_tmp = make_static_distributed_tensor<ADataType>(
-                    Policy::template MakeShuffled2DStaticTileDistribution<Problem>());
+                    Policy::template make_shuffled_2d_static_tile_distribution<Problem>());
                 transpose_tile2d(a_shuffle_tmp, a_block_tile);
                 Base::LocalPrefill(a_copy_lds_window, a_shuffle_tmp, a_element_func);
             }
@@ -342,7 +342,7 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
             if constexpr(is_b_row_major)
             {
                 auto b_shuffle_tmp = make_static_distributed_tensor<BDataType>(
-                    Policy::template MakeShuffled2DStaticTileDistribution<Problem>());
+                    Policy::template make_shuffled_2d_static_tile_distribution<Problem>());
                 transpose_tile2d(b_shuffle_tmp, b_block_tile);
                 Base::LocalPrefill(b_copy_lds_window, b_shuffle_tmp, b_element_func);
             }

--- a/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_bquant_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_bquant_pipeline_ag_bg_cr_policy.hpp
@@ -52,14 +52,14 @@ struct GemmBQuantPipelineAgBgCrDefaultPolicy : public UniversalGemmPipelineAgBgC
                                                            Problem::TransposeC>;
 
         static_assert(std::is_same_v<BQLayout, tensor_layout::gemm::ColumnMajor>);
-        using TileEncodingPattern = TileDistributionEncodingPatternBQ<BlockGemmShape,
+        using TileEncodingPattern = tile_distribution_encoding_pattern_bq<BlockGemmShape,
                                                                       WarpGemm,
                                                                       BlockSize,
                                                                       NPerBlock,
                                                                       KPerBlockBQ,
                                                                       VecLoadSize>;
 
-        return TileEncodingPattern::Make2DStaticTileDistribution();
+        return TileEncodingPattern::make_2d_static_tile_distribution();
     }
 
     template <typename Problem>

--- a/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_bquant_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_bquant_pipeline_ag_bg_cr_policy.hpp
@@ -53,11 +53,11 @@ struct GemmBQuantPipelineAgBgCrDefaultPolicy : public UniversalGemmPipelineAgBgC
 
         static_assert(std::is_same_v<BQLayout, tensor_layout::gemm::ColumnMajor>);
         using TileEncodingPattern = tile_distribution_encoding_pattern_bq<BlockGemmShape,
-                                                                      WarpGemm,
-                                                                      BlockSize,
-                                                                      NPerBlock,
-                                                                      KPerBlockBQ,
-                                                                      VecLoadSize>;
+                                                                          WarpGemm,
+                                                                          BlockSize,
+                                                                          NPerBlock,
+                                                                          KPerBlockBQ,
+                                                                          VecLoadSize>;
 
         return TileEncodingPattern::make_2d_static_tile_distribution();
     }

--- a/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_bquant_pipeline_ag_bg_cr_v3.hpp
+++ b/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_bquant_pipeline_ag_bg_cr_v3.hpp
@@ -326,7 +326,7 @@ struct BQuantGemmPipelineAgBgCrCompV3 : public BaseBQuantGemmPipelineAgBgCrCompV
             if constexpr(is_a_col_major)
             {
                 auto a_shuffle_tmp = make_static_distributed_tensor<ADataType>(
-                    Policy::template MakeShuffled2DStaticTileDistribution<Problem>());
+                    Policy::template make_shuffled_2d_static_tile_distribution<Problem>());
                 transpose_tile2d(a_shuffle_tmp, a_block_tile);
                 Base::LocalPrefill(a_copy_lds_window, a_shuffle_tmp, a_element_func);
             }
@@ -338,7 +338,7 @@ struct BQuantGemmPipelineAgBgCrCompV3 : public BaseBQuantGemmPipelineAgBgCrCompV
             if constexpr(is_b_row_major)
             {
                 auto b_shuffle_tmp = make_static_distributed_tensor<BDataType>(
-                    Policy::template MakeShuffled2DStaticTileDistribution<Problem>());
+                    Policy::template make_shuffled_2d_static_tile_distribution<Problem>());
                 transpose_tile2d(b_shuffle_tmp, b_block_tile);
                 Base::LocalPrefill(b_copy_lds_window, b_shuffle_tmp, b_element_func);
             }

--- a/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_group_quant_utils.hpp
+++ b/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_group_quant_utils.hpp
@@ -119,7 +119,8 @@ template <typename BlockGemmShape,
           index_t YPerTile,
           index_t XPerTile,
           index_t VecSize>
-struct tile_distribution_encoding_pattern_aq_transposed_c : public tile_distribution_encoding_pattern
+struct tile_distribution_encoding_pattern_aq_transposed_c
+    : public tile_distribution_encoding_pattern
 {
     // TODO: make pattern where below condition does not need to hold - GGemmMultiDSplitk!
     static_assert(XPerTile % VecSize == 0, "XPerTile must be a multiple of VecSize!");

--- a/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_group_quant_utils.hpp
+++ b/include/ck_tile/ops/gemm_group_quant/pipeline/gemm_group_quant_utils.hpp
@@ -53,7 +53,7 @@ template <typename BlockGemmShape,
           index_t KPerBlockAQ,
           index_t VecSize,
           bool PreshuffleQuant>
-struct TileDistributionEncodingPatternAQ : public TileDistributionEncodingPattern
+struct tile_distribution_encoding_pattern_aq : public tile_distribution_encoding_pattern
 {
     static_assert(XPerTile % VecSize == 0, "XPerTile must be a multiple of VecSize!");
     static constexpr index_t warp_size = get_warp_size();
@@ -70,7 +70,7 @@ struct TileDistributionEncodingPatternAQ : public TileDistributionEncodingPatter
     // KWarps > 1 isn't supported
     static_assert(KWarps == 1);
 
-    CK_TILE_HOST_DEVICE static constexpr auto Make2DStaticTileDistribution()
+    CK_TILE_HOST_DEVICE static constexpr auto make_2d_static_tile_distribution()
     {
         if constexpr(PreshuffleQuant)
         {
@@ -119,7 +119,7 @@ template <typename BlockGemmShape,
           index_t YPerTile,
           index_t XPerTile,
           index_t VecSize>
-struct TileDistributionEncodingPatternAQTransposedC : public TileDistributionEncodingPattern
+struct tile_distribution_encoding_pattern_aq_transposed_c : public tile_distribution_encoding_pattern
 {
     // TODO: make pattern where below condition does not need to hold - GGemmMultiDSplitk!
     static_assert(XPerTile % VecSize == 0, "XPerTile must be a multiple of VecSize!");
@@ -152,7 +152,7 @@ struct TileDistributionEncodingPatternAQTransposedC : public TileDistributionEnc
 
     static_assert(Y0 * Y1 * Y2 == YPerTile, "Y0, Y1, Y2 must cover the blocktile along Y.");
 
-    CK_TILE_HOST_DEVICE static constexpr auto Make2DStaticTileDistribution()
+    CK_TILE_HOST_DEVICE static constexpr auto make_2d_static_tile_distribution()
     {
         return make_static_tile_distribution(
             tile_distribution_encoding<sequence<NWarps, XR>,
@@ -171,7 +171,7 @@ template <typename BlockGemmShape,
           index_t YPerTile,
           index_t XPerTile,
           index_t VecSize>
-struct TileDistributionEncodingPatternBQ : public TileDistributionEncodingPattern
+struct tile_distribution_encoding_pattern_bq : public tile_distribution_encoding_pattern
 {
     // TODO: make pattern where below condition does not need to hold - GGemmMultiDSplitk!
     static_assert(XPerTile % VecSize == 0, "XPerTile must be a multiple of VecSize!");
@@ -204,7 +204,7 @@ struct TileDistributionEncodingPatternBQ : public TileDistributionEncodingPatter
 
     static_assert(Y0 * Y1 * Y2 == YPerTile, "Y0, Y1, Y2 must cover the blocktile along Y.");
 
-    CK_TILE_HOST_DEVICE static constexpr auto Make2DStaticTileDistribution()
+    CK_TILE_HOST_DEVICE static constexpr auto make_2d_static_tile_distribution()
     {
         return make_static_tile_distribution(
             tile_distribution_encoding<sequence<MWarps, XR>,

--- a/test/ck_tile/utility/print/test_print_static_encoding_pattern.cpp
+++ b/test/ck_tile/utility/print/test_print_static_encoding_pattern.cpp
@@ -32,7 +32,11 @@ TEST_F(PrintStaticEncodingPatternTest, PrintThreadRakedPattern)
 {
     // Test printing thread raked pattern
     using PatternType =
-        tile_distribution_encoding_pattern_2d<64, 8, 16, 4, tile_distribution_pattern::thread_raked>;
+        tile_distribution_encoding_pattern_2d<64,
+                                              8,
+                                              16,
+                                              4,
+                                              tile_distribution_pattern::thread_raked>;
     PatternType pattern;
 
     std::string output = CapturePrintOutput(pattern);
@@ -52,7 +56,11 @@ TEST_F(PrintStaticEncodingPatternTest, PrintWarpRakedPattern)
 {
     // Test printing warp raked pattern
     using PatternType =
-        tile_distribution_encoding_pattern_2d<128, 16, 32, 8, tile_distribution_pattern::warp_raked>;
+        tile_distribution_encoding_pattern_2d<128,
+                                              16,
+                                              32,
+                                              8,
+                                              tile_distribution_pattern::warp_raked>;
     PatternType pattern;
 
     std::string output = CapturePrintOutput(pattern);
@@ -72,7 +80,11 @@ TEST_F(PrintStaticEncodingPatternTest, PrintBlockRakedPattern)
 {
     // Test printing block raked pattern
     using PatternType =
-        tile_distribution_encoding_pattern_2d<256, 32, 64, 16, tile_distribution_pattern::block_raked>;
+        tile_distribution_encoding_pattern_2d<256,
+                                              32,
+                                              64,
+                                              16,
+                                              tile_distribution_pattern::block_raked>;
     PatternType pattern;
 
     std::string output = CapturePrintOutput(pattern);

--- a/test/ck_tile/utility/print/test_print_static_encoding_pattern.cpp
+++ b/test/ck_tile/utility/print/test_print_static_encoding_pattern.cpp
@@ -32,13 +32,13 @@ TEST_F(PrintStaticEncodingPatternTest, PrintThreadRakedPattern)
 {
     // Test printing thread raked pattern
     using PatternType =
-        TileDistributionEncodingPattern2D<64, 8, 16, 4, tile_distribution_pattern::thread_raked>;
+        tile_distribution_encoding_pattern_2d<64, 8, 16, 4, tile_distribution_pattern::thread_raked>;
     PatternType pattern;
 
     std::string output = CapturePrintOutput(pattern);
 
     // Verify the output contains expected information
-    EXPECT_TRUE(output.find("TileDistributionEncodingPattern2D") != std::string::npos);
+    EXPECT_TRUE(output.find("tile_distribution_encoding_pattern_2d") != std::string::npos);
     EXPECT_TRUE(output.find("BlockSize:64") != std::string::npos);
     EXPECT_TRUE(output.find("YPerTile:8") != std::string::npos);
     EXPECT_TRUE(output.find("XPerTile:16") != std::string::npos);
@@ -52,13 +52,13 @@ TEST_F(PrintStaticEncodingPatternTest, PrintWarpRakedPattern)
 {
     // Test printing warp raked pattern
     using PatternType =
-        TileDistributionEncodingPattern2D<128, 16, 32, 8, tile_distribution_pattern::warp_raked>;
+        tile_distribution_encoding_pattern_2d<128, 16, 32, 8, tile_distribution_pattern::warp_raked>;
     PatternType pattern;
 
     std::string output = CapturePrintOutput(pattern);
 
     // Verify the output contains expected information
-    EXPECT_TRUE(output.find("TileDistributionEncodingPattern2D") != std::string::npos);
+    EXPECT_TRUE(output.find("tile_distribution_encoding_pattern_2d") != std::string::npos);
     EXPECT_TRUE(output.find("BlockSize:128") != std::string::npos);
     EXPECT_TRUE(output.find("YPerTile:16") != std::string::npos);
     EXPECT_TRUE(output.find("XPerTile:32") != std::string::npos);
@@ -72,13 +72,13 @@ TEST_F(PrintStaticEncodingPatternTest, PrintBlockRakedPattern)
 {
     // Test printing block raked pattern
     using PatternType =
-        TileDistributionEncodingPattern2D<256, 32, 64, 16, tile_distribution_pattern::block_raked>;
+        tile_distribution_encoding_pattern_2d<256, 32, 64, 16, tile_distribution_pattern::block_raked>;
     PatternType pattern;
 
     std::string output = CapturePrintOutput(pattern);
 
     // Verify the output contains expected information
-    EXPECT_TRUE(output.find("TileDistributionEncodingPattern2D") != std::string::npos);
+    EXPECT_TRUE(output.find("tile_distribution_encoding_pattern_2d") != std::string::npos);
     EXPECT_TRUE(output.find("BlockSize:256") != std::string::npos);
     EXPECT_TRUE(output.find("YPerTile:32") != std::string::npos);
     EXPECT_TRUE(output.find("XPerTile:64") != std::string::npos);


### PR DESCRIPTION
## Proposed changes

Use snake_case naming for all structs and functions in ck_tile/core. for example TileDistributionEncodingPattern2D >> tile_distribution_encoding_pattern_2d

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged



