### PR TITLE
Fixing python backward compatibility issue in benchmarking script.

### DIFF
--- a/tile_engine/ops/gemm/gemm_instance_builder.py
+++ b/tile_engine/ops/gemm/gemm_instance_builder.py
@@ -8,6 +8,7 @@ import multiprocessing
 import concurrent.futures
 from pathlib import Path
 import logging
+from typing import Optional
 from validation_utils import is_tile_config_valid, is_trait_combination_valid
 
 logging.basicConfig(level=logging.INFO)
@@ -325,7 +326,7 @@ class GemmKernelBuilder:
         "c": "ck_tile::tensor_layout::gemm::ColumnMajor",
     }
 
-    def _get_abc_layouts(self, layout_code: str | None = None):
+    def _get_abc_layouts(self, layout_code: Optional[str] = None):
         """
         Return (ALayout, BLayout, CLayout) from a 3-letter code like 'rcr', 'ccr', 'crr', 'rrr'.
         If layout_code is None, use self.layout.

--- a/tile_engine/ops/gemm/validation_utils.py
+++ b/tile_engine/ops/gemm/validation_utils.py
@@ -11,6 +11,7 @@ import subprocess
 import re
 from functools import lru_cache
 import logging
+from typing import Tuple, List
 
 # Element size mapping for different data types
 ELEMENT_SIZE_MAP = {
@@ -169,7 +170,7 @@ def validate_dimension_alignment(
     warp_tile_m: int,
     warp_tile_n: int,
     warp_tile_k: int,
-) -> tuple[bool, list[str]]:
+) -> Tuple[bool, List[str]]:
     """Check if tile dimensions are properly aligned with warp dimensions."""
     alignment_issues = []
 
@@ -196,7 +197,7 @@ def validate_lds_capacity(
     a_datatype: str,
     b_datatype: str,
     pipeline: str,
-) -> tuple[bool, str]:
+) -> Tuple[bool, str]:
     """Validate LDS capacity requirements."""
     matrix_a_size = (tile_m * tile_k) * element_size(a_datatype)
     matrix_b_size = (tile_n * tile_k) * element_size(b_datatype)
@@ -224,7 +225,7 @@ def validate_warp_tile_combination(
     b_datatype: str,
     c_datatype: str,
     gpu_name: str = None,
-) -> tuple[bool, str]:
+) -> Tuple[bool, str]:
     """Validate warp tile combination against GPU-specific supported combinations."""
     if gpu_name is None:
         gpu_name = get_gpu_name_by_id(0)


### PR DESCRIPTION
## Proposed changes

Following PR #2747, there was an issue with building on legacy OS like RHEL8 due to python 3.8 backward compatibility issues, this PR fixes these issues.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x ] I have added inline documentation which enables the maintainers with understanding the motivation
- [x ] I have removed the stale documentation which is no longer relevant after this pull request
- [x ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x ] I have run `clang-format` on all changed files
- [x ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

