### PR TITLE
Fix mha prefill

### DIFF
--- a/include/ck_tile/ops/fmha/kernel/fmha_batch_prefill_kernel.hpp
+++ b/include/ck_tile/ops/fmha/kernel/fmha_batch_prefill_kernel.hpp
@@ -1143,7 +1143,7 @@ struct FmhaBatchPrefillWithPagedKVCacheKernel
                              make_tuple(number<FmhaPipeline::kM0>{}, number<FmhaPipeline::kN1>{}),
                              {i_m0, i_n1});
 
-        EpiloguePipeline{}(o_dram_window, o_acc_tile);
+        EpiloguePipeline{}(o_dram_window, o_acc_tile, nullptr);
     }
 };
 

--- a/script/cmake-ck-dev.sh
+++ b/script/cmake-ck-dev.sh
@@ -28,16 +28,10 @@ if [ $# -ge 1 ]; then
             REST_ARGS=("$@")
             ;;
         *)
-            echo "No GPU targets provided, using default targets: gfx908;gfx90a;gfx942"
-            GPU_TARGETS="gfx908;gfx90a;gfx942"
-            shift 1
             REST_ARGS=("$@")
             ;;
     esac
 else
-    echo "No GPU targets provided, using default targets: gfx908;gfx90a;gfx942"
-    GPU_TARGETS="gfx908;gfx90a;gfx942"
-    shift 1
     REST_ARGS=("$@")
 fi
 


### PR DESCRIPTION
## Proposed changes

Fix the Aiter CI, with Default Epilogue configuration in CK.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

