### PR TITLE
set number of cpu threads in CI to min(nproc,64)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,9 +33,6 @@ def nthreads() {
     def nproc = sh(returnStdout: true, script: 'nproc')
     echo "Number of cores: ${nproc}"
     def n = nproc.toInteger()
-    if (n > 32){
-        n /= 2
-    }
     if (n > 64){
         n = 64
     }


### PR DESCRIPTION
## Proposed changes

Change the formula for the number of CPU threads to be used for building CK in CI from 
n = min(nproc/2, 64)
to 
n = min(nproc, 64)

This should allow us to run a bit faster on some of the older systems, while still avoiding running out of RAM.
Also recent addition of VMs with a weird number of CPU nproc = 43 caused some jobs to fail.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x ] I have added inline documentation which enables the maintainers with understanding the motivation
- [x ] I have removed the stale documentation which is no longer relevant after this pull request
- [ x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ x] I have run `clang-format` on all changed files
- [x ] Any dependent changes have been merged

