### PR TITLE
[CK_TILE] FMHA Reduce build time by disabling instances that are not tested

### DIFF
--- a/example/ck_tile/01_fmha/CMakeLists.txt
+++ b/example/ck_tile/01_fmha/CMakeLists.txt
@@ -26,7 +26,7 @@ endforeach()
 
 # "fwd" is a must-have api for the fmha_fwd example, add it if not specified
 if(NOT "fwd" IN_LIST FMHA_FWD_ENABLE_APIS)
-  list(APPEND FMHA_FWD_ENABLE_APIS "fwd")
+  list(PREPEND FMHA_FWD_ENABLE_APIS "fwd")
 endif()
 
 file(GLOB_RECURSE CODE_GEN_SCRIPTS CONFIGURE_DEPENDS
@@ -50,6 +50,15 @@ set(FMHA_BWD_CODE_GEN_COMMON_ARGS
   --optdim 32,64,128,256
   # --filter fmha_bwd_dot...@fmha_bwd_convert...@fmha_bwd...
 )
+
+# Reduce building time by disabling instances that are not currently used in the gtests
+# TODO: Consider to use a special receipt for testing only, or even two receipts: a small subset of
+# instances for quick CI runs and a larger subset for scheduled runs (the tests skip tests when
+# there is no corresponding instance for parameters).
+if(BUILD_TESTING)
+  # Filters are in the order of FMHA_FWD_KNOWN_APIS: fwd,fwd_splitkv_combine@fwd_splitkv,fwd_appendkv,pagedkv_prefill
+  list(APPEND FMHA_FWD_CODE_GEN_COMMON_ARGS --filter *_nlogits*_nskip*,*@*_nlogits*_nbias*,*,*_nlogits*_nskip*_pagedkv)
+endif()
 
 # generate a list of kernels, but not actually emit files at config sta
 execute_process(

--- a/test/ck_tile/fmha/test_fmha_fwd.inc
+++ b/test/ck_tile/fmha/test_fmha_fwd.inc
@@ -401,7 +401,7 @@ TEST_P(PagedKV, Test)
                                                0,               // scale_s
                                                0,               // logits_soft_cap
                                                is_v_rowmajor,   // is_v_rowmajor
-                                               def_lse,         // lse
+                                               false,           // lse
                                                page_block_size, // page_block_size
                                                false,           // use_cache_batch_idx
                                                "n",             // bias_str


### PR DESCRIPTION
## Proposed changes

#2744 adds gtests for FMHA and enables building all instances by default. But only a part of the generated instances are launched by the tests.

This change reduces the number of fwd instances from 4106 to 1498 by filtering the combinations that are not tested. It is impossible to filter all unused instances due to limitations of the filter wildcards.

I consider this PR as a temporary solution. Perhaps, adding a special receipt that will be requested by CI is a better solution?

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

