### PR TITLE
[CK_TILE][REGRESSION] Correct blockSize in Generic2dBlockShape (c254f…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,21 @@ repos:
         language: script
         types_or: [c++, text]
         verbose: true
+    -   id: ruff-check
+        name: Ruff Linter
+        entry: ruff check --fix
+        language: python
+        types: [python]
+        additional_dependencies: [ruff]
+    -   id: ruff-format
+        name: Ruff Formatter
+        entry: ruff format
+        language: python
+        types: [python]
+        additional_dependencies: [ruff]
+    -   id: run-remod-if-ck-tile-changed
+        name: Run remod.py if ck_tile files changed
+        entry: script/remod_for_ck_tile.sh
+        language: script
+        always_run: true
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,21 +18,3 @@ repos:
         language: script
         types_or: [c++, text]
         verbose: true
-    -   id: ruff-check
-        name: Ruff Linter
-        entry: ruff check --fix
-        language: python
-        types: [python]
-        additional_dependencies: [ruff]
-    -   id: ruff-format
-        name: Ruff Formatter
-        entry: ruff format
-        language: python
-        types: [python]
-        additional_dependencies: [ruff]
-    -   id: run-remod-if-ck-tile-changed
-        name: Run remod.py if ck_tile files changed
-        entry: script/remod_for_ck_tile.sh
-        language: script
-        always_run: true
-        pass_filenames: false

--- a/include/ck_tile/ops/add_rmsnorm2d_rdquant/kernel/add_rmsnorm2d_rdquant_fwd_kernel.hpp
+++ b/include/ck_tile/ops/add_rmsnorm2d_rdquant/kernel/add_rmsnorm2d_rdquant_fwd_kernel.hpp
@@ -95,7 +95,11 @@ struct AddRmsnorm2dRdquantFwd
         return dim3(integer_divide_ceil(hargs.m, Block_M));
     }
 
-    CK_TILE_HOST static constexpr auto BlockSize() { return Problem::BlockShape::BlockSize; }
+    CK_TILE_HOST static constexpr auto BlockSize()
+    {
+        return is_wave32() ? Problem::BlockShape::template GetBlockSize<true>()
+                           : Problem::BlockShape::template GetBlockSize<false>();
+    }
 
     // clang-format off
     template <typename T> struct t2s;

--- a/include/ck_tile/ops/common/generic_2d_block_shape.hpp
+++ b/include/ck_tile/ops/common/generic_2d_block_shape.hpp
@@ -45,47 +45,57 @@ struct Generic2dBlockShape
     static constexpr index_t Block_N          = BlockTile_::at(number<1>{});
     static constexpr index_t ThreadPerBlock_M = ThreadPerBlock_::at(number<0>{});
     static constexpr index_t ThreadPerBlock_N = ThreadPerBlock_::at(number<1>{});
-    static constexpr index_t BlockSize        = ThreadPerBlock_M * ThreadPerBlock_N;
 
     // vector size along seq<M, N>
     static constexpr index_t Vector_M = Vector_::at(number<0>{});
     static constexpr index_t Vector_N = Vector_::at(number<1>{});
 
-    static constexpr bool is_warp_per_row = ThreadPerBlock_N <= get_warp_size();
-    static_assert((ThreadPerBlock_M * ThreadPerBlock_N) % get_warp_size() == 0);
-    static constexpr index_t total_warps = (ThreadPerBlock_M * ThreadPerBlock_N) / get_warp_size();
-
     // num warps along seq<M, N>, within each block
-    static constexpr index_t WarpPerBlock_M = []() {
+    template <bool isHostWave32>
+    static constexpr index_t GetWarpPerBlock_M()
+    {
+        constexpr index_t warp_size    = isHostWave32 ? 32 : get_warp_size();
+        constexpr bool is_warp_per_row = ThreadPerBlock_N <= warp_size;
+        static_assert((ThreadPerBlock_M * ThreadPerBlock_N) % warp_size == 0);
+        constexpr index_t total_warps = (ThreadPerBlock_M * ThreadPerBlock_N) / warp_size;
+
         if constexpr(is_warp_per_row)
         {
-            static_assert(get_warp_size() % ThreadPerBlock_N == 0);
-            return total_warps * (get_warp_size() / ThreadPerBlock_N);
+            static_assert(warp_size % ThreadPerBlock_N == 0);
+            return total_warps * (warp_size / ThreadPerBlock_N);
         }
         else
         {
             // static_assert(ck_tile::get_warp_size() % ThreadPerBlock_M_ == 0);
-            return total_warps / (ThreadPerBlock_N / get_warp_size());
+            return total_warps / (ThreadPerBlock_N / warp_size);
         }
-    }();
+    };
 
     // num of warps along n
-    static constexpr index_t WarpPerBlock_N = []() {
+    template <bool isHostWave32>
+    static constexpr index_t GetWarpPerBlock_N()
+    {
+        constexpr index_t warp_size    = isHostWave32 ? 32 : get_warp_size();
+        constexpr bool is_warp_per_row = ThreadPerBlock_N <= warp_size;
         if constexpr(is_warp_per_row)
         {
-            static_assert(get_warp_size() % ThreadPerBlock_N == 0);
+            static_assert(warp_size % ThreadPerBlock_N == 0);
             return 1;
         }
         else
         {
-            static_assert(ThreadPerBlock_N % get_warp_size() == 0);
-            return ThreadPerBlock_N / get_warp_size();
+            static_assert(ThreadPerBlock_N % warp_size == 0);
+            return ThreadPerBlock_N / warp_size;
         }
-    }();
+    }
+
+    static constexpr index_t WarpPerBlock_M = GetWarpPerBlock_M<false>();
+    static constexpr index_t WarpPerBlock_N = GetWarpPerBlock_N<false>();
 
     // warp size
-    static constexpr index_t Warp_M = ThreadPerBlock_M / WarpPerBlock_M * Vector_M;
-    static constexpr index_t Warp_N = ThreadPerBlock_N / WarpPerBlock_N * Vector_N;
+    static constexpr index_t BlockSize = WarpPerBlock_M * WarpPerBlock_N * get_warp_size();
+    static constexpr index_t Warp_M    = ThreadPerBlock_M / WarpPerBlock_M * Vector_M;
+    static constexpr index_t Warp_N    = ThreadPerBlock_N / WarpPerBlock_N * Vector_N;
     static_assert(Warp_M % Vector_M == 0);
     static_assert(Warp_N % Vector_N == 0);
     static_assert(Block_M % (WarpPerBlock_M * Warp_M) == 0);
@@ -98,6 +108,13 @@ struct Generic2dBlockShape
     // num of threads along seq<M, N>, within each warp
     static constexpr index_t ThreadPerWarp_M = Warp_M / Vector_M;
     static constexpr index_t ThreadPerWarp_N = Warp_N / Vector_N;
+
+    template <bool isHostWave32>
+    static constexpr index_t GetBlockSize()
+    {
+        constexpr index_t warp_size = isHostWave32 ? 32 : get_warp_size();
+        return GetWarpPerBlock_M<isHostWave32>() * GetWarpPerBlock_N<isHostWave32>() * warp_size;
+    }
 };
 
 } // namespace ck_tile

--- a/include/ck_tile/ops/layernorm2d/kernel/layernorm2d_fwd_kernel.hpp
+++ b/include/ck_tile/ops/layernorm2d/kernel/layernorm2d_fwd_kernel.hpp
@@ -134,7 +134,11 @@ struct Layernorm2dFwd
         return dim3(integer_divide_ceil(hargs.m, Block_M));
     }
 
-    CK_TILE_HOST static constexpr auto BlockSize() { return Problem::BlockShape::BlockSize; }
+    CK_TILE_HOST static constexpr auto BlockSize()
+    {
+        return is_wave32() ? Problem::BlockShape::template GetBlockSize<true>()
+                           : Problem::BlockShape::template GetBlockSize<false>();
+    }
 
     // clang-format off
     template <typename T> struct t2s;

--- a/include/ck_tile/ops/rmsnorm2d/kernel/rmsnorm2d_fwd_kernel.hpp
+++ b/include/ck_tile/ops/rmsnorm2d/kernel/rmsnorm2d_fwd_kernel.hpp
@@ -124,7 +124,11 @@ struct Rmsnorm2dFwd
         return dim3(integer_divide_ceil(hargs.m, Block_M));
     }
 
-    CK_TILE_HOST static constexpr auto BlockSize() { return Problem::BlockShape::BlockSize; }
+    CK_TILE_HOST static constexpr auto BlockSize()
+    {
+        return is_wave32() ? Problem::BlockShape::template GetBlockSize<true>()
+                           : Problem::BlockShape::template GetBlockSize<false>();
+    }
 
     // clang-format off
     template <typename T> struct t2s;

--- a/include/ck_tile/ops/smoothquant/kernel/moe_smoothquant_kernel.hpp
+++ b/include/ck_tile/ops/smoothquant/kernel/moe_smoothquant_kernel.hpp
@@ -93,7 +93,11 @@ struct MoeSmoothquant
         return dim3(hargs.topk, integer_divide_ceil(hargs.tokens, Block_M), 1);
     }
 
-    CK_TILE_HOST static constexpr auto BlockSize() { return Problem::BlockShape::BlockSize; }
+    CK_TILE_HOST static constexpr auto BlockSize()
+    {
+        return is_wave32() ? Problem::BlockShape::template GetBlockSize<true>()
+                           : Problem::BlockShape::template GetBlockSize<false>();
+    }
 
     // clang-format off
     template <typename T> struct t2s;

--- a/include/ck_tile/ops/smoothquant/kernel/smoothquant_kernel.hpp
+++ b/include/ck_tile/ops/smoothquant/kernel/smoothquant_kernel.hpp
@@ -82,7 +82,11 @@ struct Smoothquant
         return dim3(integer_divide_ceil(hargs.m, Block_M));
     }
 
-    CK_TILE_HOST static constexpr auto BlockSize() { return Problem::BlockShape::BlockSize; }
+    CK_TILE_HOST static constexpr auto BlockSize()
+    {
+        return is_wave32() ? Problem::BlockShape::template GetBlockSize<true>()
+                           : Problem::BlockShape::template GetBlockSize<false>();
+    }
 
     // clang-format off
     template <typename T> struct t2s;

--- a/test/ck_tile/add_rmsnorm2d_rdquant/instances/add_rmsnorm2d_rdquant_fwd_instance_common.hpp
+++ b/test/ck_tile/add_rmsnorm2d_rdquant/instances/add_rmsnorm2d_rdquant_fwd_instance_common.hpp
@@ -58,7 +58,7 @@ float add_rmsnorm2d_rdquant_fwd_(const S& s, A a)
     using Kernel = ck_tile::AddRmsnorm2dRdquantFwd<Pipeline>;
 
     const dim3 grids                       = Kernel::GridSize(a);
-    constexpr dim3 blocks                  = Kernel::BlockSize();
+    const dim3 blocks                      = Kernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = 1;
 
     auto kargs = Kernel::MakeKargs(a);

--- a/test/ck_tile/moe_smoothquant/instances/moe_smoothquant_instance_common.hpp
+++ b/test/ck_tile/moe_smoothquant/instances/moe_smoothquant_instance_common.hpp
@@ -53,7 +53,7 @@ float moe_smoothquant_(const S& s, A a)
     using Kernel = ck_tile::MoeSmoothquant<Pipeline>;
 
     const dim3 grids                       = Kernel::GridSize(a);
-    constexpr dim3 blocks                  = Kernel::BlockSize();
+    const dim3 blocks                      = Kernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = 1;
 
     auto kargs = Kernel::MakeKargs(a);

--- a/test/ck_tile/rmsnorm2d/generate.py
+++ b/test/ck_tile/rmsnorm2d/generate.py
@@ -201,7 +201,7 @@ float rmsnorm2d_fwd_(const S& s, A a)
     using Kernel = ck_tile::Rmsnorm2dFwd<Pipeline, Epilogue>;
 
     const dim3 grids                       = Kernel::GridSize(a);
-    constexpr dim3 blocks                  = Kernel::BlockSize();
+    const dim3 blocks                      = Kernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = 1;
 
     auto kargs = Kernel::MakeKargs(a);

--- a/test/ck_tile/smoothquant/instances/smoothquant_instance_common.hpp
+++ b/test/ck_tile/smoothquant/instances/smoothquant_instance_common.hpp
@@ -49,7 +49,7 @@ float smoothquant_(const S& s, A a)
     using Kernel = ck_tile::Smoothquant<Pipeline>;
 
     const dim3 grids                       = Kernel::GridSize(a);
-    constexpr dim3 blocks                  = Kernel::BlockSize();
+    const dim3 blocks                      = Kernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = 1;
 
     auto kargs = Kernel::MakeKargs(a);


### PR DESCRIPTION
…3d7b4ccc )

WarpPerBlock_M * WarpPerBlock_N are not equal with ThreadPerBlock_M * ThreadPerBlock_N /warpSize. we should calculate BlockSize from WarpPerBlock_M * WarpPerBlock_N

To compatible with wave32, function GetBlockSize is added to calculate correct size in host side.

## Proposed changes

Please describe the motivation behind the pull request, whether it enables a new feature or fixes a bug. If there are associated pull requests or issues, please link them to the pull request.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

