### PR TITLE
Remove concept from the cshuffle_epilogue.hpp

### DIFF
--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -11,23 +11,6 @@
 #include <optional>
 
 namespace ck_tile {
-
-template <typename T>
-concept HasDataType = requires { typename T::DataType; };
-
-template <typename T>
-struct GetDataType
-{
-    using type = float;
-};
-
-template <typename T>
-    requires HasDataType<T>
-struct GetDataType<T>
-{
-    using type = typename T::DataType; // Use T::ScaleN::DataType
-};
-
 template <typename ADataType_,
           typename BDataType_,
           typename DsDataType_,
@@ -387,6 +370,9 @@ struct CShuffleEpilogue
     // TODO: Check if there would be nicer ways to overload rather than with EmptyScale or nullptr_t
     struct EmptyScale
     {
+        // Include DataType here as EmptyScale will be utilized as a template parameter or in
+        // `operator()`, and DataType ensures EmptyScale adheres to the expected contract.
+        using DataType = float;
     };
 
     template <typename ODramWindow,
@@ -439,8 +425,10 @@ struct CShuffleEpilogue
             !std::is_same<ScaleM, EmptyScale>::value && !std::is_same<ScaleN, EmptyScale>::value;
 
         // Tiles to hold row/col scales when present
-        using SMType = typename GetDataType<remove_cvref_t<ScaleM>>::type;
-        using SNType = typename GetDataType<remove_cvref_t<ScaleN>>::type;
+        using SMType =
+            std::conditional_t<has_scales, remove_cvref_t<typename ScaleM::DataType>, float>;
+        using SNType =
+            std::conditional_t<has_scales, remove_cvref_t<typename ScaleN::DataType>, float>;
 
         auto sm_tile = make_static_distributed_tensor<SMType>(dram_tile_distribution);
         auto sn_tile = make_static_distributed_tensor<SNType>(dram_tile_distribution);


### PR DESCRIPTION
## Proposed changes

C++ concept should not be used in `cshuffle_epilogue.hpp`.  #2839  accidentally introduced a usage of it. 

Remove it in this PR. 

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

