### PR TITLE
[CK_TILE] FMHA Fix synchronization issue in FWD splitkv combine pipeline

### DIFF
--- a/example/ck_tile/01_fmha/fmha_fwd_runner.hpp
+++ b/example/ck_tile/01_fmha/fmha_fwd_runner.hpp
@@ -1153,7 +1153,7 @@ fwd_result fmha_fwd_run(mode_enum mode,
         }
     };
 
-    const float appendkv_ave_time = [&] {
+    auto run_appendkv = [&](const ck_tile::stream_config& sc) {
 #if CK_TILE_FMHA_FWD_APPENDKV_API
         if(need_append_kvcache)
         {
@@ -1163,18 +1163,19 @@ fwd_result fmha_fwd_run(mode_enum mode,
             fmha_fwd_appendkv_args fwd_appendkv_args;
             init_args(fwd_appendkv_args);
 
-            return fmha_fwd_appendkv(fwd_appendkv_traits, fwd_appendkv_args, stream_config);
+            return fmha_fwd_appendkv(fwd_appendkv_traits, fwd_appendkv_args, sc);
         }
 #endif
         return 0.0f;
-    }();
+    };
+    const float appendkv_ave_time = run_appendkv(stream_config);
     if(appendkv_ave_time < 0.0f)
     {
         std::cout << ", not supported yet" << std::flush << std::endl;
         return fwd_result::no_instance;
     }
 
-    const float fwd_ave_time = [&] {
+    auto run_fwd = [&](const ck_tile::stream_config& sc) {
 #if CK_TILE_FMHA_FWD_PAGEDKV_API
         if(1 == num_splits && use_kvcache)
         {
@@ -1184,8 +1185,7 @@ fwd_result fmha_fwd_run(mode_enum mode,
             fmha_fwd_pagedkv_args fmha_pagedkv_args;
             init_args(fmha_pagedkv_args);
 
-            const float ave_time =
-                fmha_fwd_pagedkv(fmha_pagedkv_traits, fmha_pagedkv_args, stream_config);
+            const float ave_time = fmha_fwd_pagedkv(fmha_pagedkv_traits, fmha_pagedkv_args, sc);
 #if CK_TILE_FMHA_FWD_SPLITKV_API
             // If there is no instance for these args, fallback to fmha_fwd_splitkv
             if(ave_time >= 0.0f)
@@ -1204,7 +1204,7 @@ fwd_result fmha_fwd_run(mode_enum mode,
             fmha_fwd_splitkv_args fmha_splitkv_args;
             init_args(fmha_splitkv_args);
 
-            return fmha_fwd_splitkv(fmha_splitkv_traits, fmha_splitkv_args, stream_config);
+            return fmha_fwd_splitkv(fmha_splitkv_traits, fmha_splitkv_args, sc);
         }
 #endif // CK_TILE_FMHA_FWD_SPLITKV_API
         fmha_fwd_traits fmha_traits;
@@ -1213,8 +1213,9 @@ fwd_result fmha_fwd_run(mode_enum mode,
         fmha_fwd_args fmha_args;
         init_args(fmha_args);
 
-        return fmha_fwd(fmha_traits, fmha_args, stream_config);
-    }();
+        return fmha_fwd(fmha_traits, fmha_args, sc);
+    };
+    const float fwd_ave_time = run_fwd(stream_config);
     if(fwd_ave_time < 0.0f)
     {
         std::cout << ", not supported yet" << std::flush << std::endl;
@@ -1288,6 +1289,17 @@ fwd_result fmha_fwd_run(mode_enum mode,
     }
     else
     {
+#if CK_TILE_FMHA_FWD_APPENDKV_API
+        // When rotary embedding is used, the appendkv kernel modifies the q tensor (multiple times
+        // when time_kernel_ is set). We need to reset the q buffer and rerun all kernels.
+        if(0 < rotary_dim && stream_config.time_kernel_)
+        {
+            const ck_tile::stream_config stream_config2{stream_config.stream_id_, false, 0};
+            q_buf.ToDevice(q_host.data());
+            run_appendkv(stream_config2);
+            run_fwd(stream_config2);
+        }
+#endif
         o_buf.FromDevice(o_host.data());
         lse_buf.FromDevice(lse_host.data());
         randval_buf.FromDevice(randval_host.data());

--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_fwd_splitkv_combine_pipeline.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_fwd_splitkv_combine_pipeline.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #pragma once
 
@@ -223,6 +223,8 @@ struct BlockFmhaFwdSplitKVCombinePipeline
             });
         }
 
+        // sync before rewriting lse_acc_lds
+        block_sync_lds();
         // store the lse scales in shared memory.
         {
             constexpr auto spans = decltype(lse_accum)::get_distributed_spans();


### PR DESCRIPTION
## Proposed changes

Similarly to https://github.com/ROCm/composable_kernel/pull/2876, this is quite a rare bug.
There are tests failures in some CI jobs on gfx950 (`AppendKVR` and `AppendKVRoPE` tests).
Also I encountered it on gfx12 and gfx90a while testing manually.

```
[ RUN      ] TestCkTileFmhaFwd/AppendKV.Test/478
[fp16|batch|bshd-bhsd] b:2, h:3/1, s:264/265, d:256/256, scale_s:0.0625, bias:n, p_drop:0, lse:1, squant:0, mask:t(-1:0), v:r, cache_batch_idx:1, fmha_fwd_appendkv_d256_fp16_b64x64x256x256_vr_psskddv, fmha_fwd_splitkv_d256_fp16_batch_b64x128x32x256x32x256_r4x1x1_r4x1x1_w16x16x16_w16x16x16_qr_vr_pssk_nlogits_nbias_mask_lse_nsquant_npagedkv, fmha_fwd_splitkv_combine_d256_fp16_batch_b32_unused_ps_lse_nsquantLSE Error: Incorrect results!        out[520] != ref[520]: 1 != 9.749868
LSE Error: Incorrect results!        out[521] != ref[521]: 1 != 9.582224
LSE Error: Incorrect results!        out[522] != ref[522]: 1 != 9.720694
LSE Error: Incorrect results!        out[523] != ref[523]: 1 != 9.543851
max err: 8.749868, number of errors: 8, 1.010101% wrong values

[ RUN      ] TestCkTileFmhaFwd/SplitKV.Test/156
[fp16|group|bshd] b:4, h:3/1, s:200/1024, d:96/96, scale_s:0.10, bias:n, p_drop:0.00, lse:1, squant:0, mask:n, v:c, num_splits:3, fmha_fwd_splitkv_d128_fp16_group_b64x128x32x128x32x128_r4x1x1_r4x1x1_w16x16x16_w16x16x16_qr_vc_psskddv_nlogits_nbias_nmask_lse_nsquant_npagedkv, fmha_fwd_splitkv_combine_d128_fp16_group_b32_unused_psdv_lse_nsquant, 0.440 ms, 2.14 TFlops, 5.67 GB/sLSE Error: Incorrect results!        out[352] != ref[352]: 1.431952 != 9.221003
LSE Error: Incorrect results!        out[353] != ref[353]: 1.43195 != 9.513733
LSE Error: Incorrect results!        out[354] != ref[354]: 1.431956 != 9.534992
LSE Error: Incorrect results!        out[355] != ref[355]: 1.431954 != 9.439976
max err: 8.103036, number of errors: 8, 1.333333% wrong values
```

I was able to reproduce it on gfx90a with
```
bin/test_ck_tile_fmha_fwd_fp16 --gtest_repeat=-1 --gtest_shuffle --gtest_throw_on_failure --gtest_filter="TestCkTileFmhaFwd/*KV*"
```
It takes multiple repeats to trigger the bug, I also run 2 processes on the same GPU in parallel to make GPU load less stable.

The cause of the bug: different warps can read and then rewrite the same values of `lse_acc_lds`. Sometimes warps progress at different speeds, one warp can rewrite values that are still being read by another warp.
So the fix is one `block_sync_lds()` call.

----

Another commit is a fix of failed validation with rotary embedding when benchmarking (`time_kernel_`) is used. Since the appendkv kernel modifies the q tensor, after multiple consecutive runs it is incorrect.
So in this case I reset the buffer and rerun the kernels before validation.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

