### PR TITLE
Remove default constructor to fix c++17 build issue

### DIFF
--- a/include/ck/tensor_description/multi_index_transform.hpp
+++ b/include/ck/tensor_description/multi_index_transform.hpp
@@ -1586,6 +1586,8 @@ struct ConvBwdDataImplicitGemmOutTransform
     Tuple<index_t, index_t, index_t, index_t>
         low_lengths_magic_divisor_shift_; // XDotSlice_K_, K_, TildeSlice_, WTildeSlice_
 
+    __host__ __device__ ConvBwdDataImplicitGemmOutTransform() = default;
+
     __host__ __device__ constexpr ConvBwdDataImplicitGemmOutTransform(index_t N,
                                                                       index_t Ho,
                                                                       index_t Wo,
@@ -1643,7 +1645,7 @@ struct ConvBwdDataImplicitGemmOutTransform
     template <typename UpIdx>
     __host__ __device__ constexpr auto CalculateLowerIndexN(const UpIdx& idx_up) const
     {
-        index_t NStep, HStep, WStep;
+        index_t NStep{0}, HStep{0}, WStep{0};
         // Merge
         // NStep = M_id / TildeSlice_
         NStep = MagicDivision::DoMagicDivision(idx_up[I1],

--- a/include/ck/tensor_description/multi_index_transform.hpp
+++ b/include/ck/tensor_description/multi_index_transform.hpp
@@ -1586,8 +1586,6 @@ struct ConvBwdDataImplicitGemmOutTransform
     Tuple<index_t, index_t, index_t, index_t>
         low_lengths_magic_divisor_shift_; // XDotSlice_K_, K_, TildeSlice_, WTildeSlice_
 
-    __host__ __device__ constexpr ConvBwdDataImplicitGemmOutTransform() = default;
-
     __host__ __device__ constexpr ConvBwdDataImplicitGemmOutTransform(index_t N,
                                                                       index_t Ho,
                                                                       index_t Wo,


### PR DESCRIPTION
## Proposed changes

Fix the c++17 build issue: "defaulted definition of default constructor is not constexpr"

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

N/A

