### PR TITLE
[Python] Tweak version for the installed python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -36,4 +36,4 @@ ck4inductor = "python/ck4inductor"
 "ck4inductor.library" = ["src/tensor_operation_instance/gpu/gemm_universal/**/*.hpp", "src/tensor_operation_instance/gpu/gemm_universal_batched/**/*.hpp", "include/ck/library/tensor_operation_instance/gpu/grouped_conv_fwd/**/*.hpp"]
 
 [tool.setuptools.dynamic]
-version = { attr = "setuptools_scm.get_version" }
+version = { attr = "ck4inductor.__version__" }

--- a/python/ck4inductor/__init__.py
+++ b/python/ck4inductor/__init__.py
@@ -1,0 +1,19 @@
+def __version__():
+    import subprocess
+
+    # needs to be manually updated
+    rocm_version = "7.0.1"
+    hash_width = 6
+    try:
+        hash = subprocess.check_output("git rev-parse HEAD", shell=True, text=True)[
+            :hash_width
+        ]
+    except:
+        hash = "0" * hash_width
+    try:
+        change_count = subprocess.check_output(
+            f"git rev-list rocm-{rocm_version}..HEAD --count", shell=True, text=True
+        ).strip()
+    except:
+        change_count = "0"
+    return f"{rocm_version}.dev{change_count}+g{hash}"


### PR DESCRIPTION
## Proposed changes
Remove install dependency on setuptools-scm and compute the package version with a similar logic.
This removes problems associated with setuptools-scm and its transitive dependencies, and makes installation slightly faster.
Also it exposes version attribute in python code.
Probably it doesn't cover all corner cases, so leave a sane default for the broken ones.
ROCm version string will need to be updated manually after branch cuts.

## Testing

`pip install git+https://github.com/rocm/composable_kernel@tenpercent/tweak_version`

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

