### PR TITLE
fix build on legacy systems without cpp20 compiler

### DIFF
--- a/test/ck_tile/batched_gemm/test_batched_gemm_ut_cases.inc
+++ b/test/ck_tile/batched_gemm/test_batched_gemm_ut_cases.inc
@@ -31,7 +31,7 @@ TYPED_TEST(TestCkTileBatchedGemm, Basic)
 
     if(ck_tile::get_device_name() != "gfx950")
     {
-        gemmParams.emplace_back(256, 256, 128, 2);
+        gemmParams.push_back({256, 256, 128, 2});
     }
 
     for(auto& params : gemmParams)


### PR DESCRIPTION
## Proposed changes

```
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/new_allocator.h:191:23: error: no matching constructor for initialization of 'GemmParams'
  191 |         { ::new((void *)__p) _Up(std::forward<_Args>(__args)...); }
      |                              ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/alloc_traits.h:538:8: note: in instantiation of function template specialization 'std::__new_allocator<GemmParams>::construct<GemmParams, int, int, int, int>' requested here
  538 |           __a.construct(__p, std::forward<_Args>(__args)...);
      |               ^
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/vector.tcc:117:21: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<GemmParams>>::construct<GemmParams, int, int, int, int>' requested here
  117 |             _Alloc_traits::construct(this->_M_impl, this->_M_impl._M_finish,
      |                            ^
/composable_kernel/test/ck_tile/batched_gemm/test_batched_gemm_ut_cases.inc:34:20: note: in instantiation of function template specialization 'std::vector<GemmParams>::emplace_back<int, int, int, int>' requested here
   34 |         gemmParams.emplace_back(256, 256, 128, 2);
```

## Testing (and repro on develop)

```
# ../script/cmake-ck-dev.sh .. gfx950 -G Ninja -D CK_CXX_STANDARD=17
# ninja test_ck_tile_batched_gemm
```

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

