### PR TITLE
add the check of granularity for atomic add in CK GEMM

### DIFF
--- a/include/ck/tensor_operation/gpu/device/impl/device_gemm_multiple_d_xdl_cshuffle_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_gemm_multiple_d_xdl_cshuffle_v3.hpp
@@ -682,6 +682,10 @@ struct DeviceGemmMultiD_Xdl_CShuffle_V3 : public DeviceGemmMultipleDSplitK<ALayo
                 return GridwiseGemm64::CheckValidity(arg);
             }
         }
+        if(CDEShuffleBlockTransferScalarPerVectors{}[Number<0>{}] <= 1 && (arg.KBatch > 1))
+        {
+            return false;
+        }
         else
         {
             if constexpr(NXdlPerWave32 > 0)

--- a/test/ck_tile/gemm/test_gemm_pipeline_ut_cases.inc
+++ b/test/ck_tile/gemm/test_gemm_pipeline_ut_cases.inc
@@ -11,7 +11,7 @@ TYPED_TEST(TEST_SUITE_NAME, SmallM)
     std::vector<int> Ms{1, 2, 3, 4, 5, 6};
     constexpr int N = 1024;
     std::vector<int> Ks;
-    for (auto K_count: {2, 3, 4, 10, 11}) 
+    for(auto K_count : {2, 3, 4, 10, 11})
     {
         Ks.push_back(K_count * TestFixture::K_Tile);
     }
@@ -36,10 +36,10 @@ TYPED_TEST(TEST_SUITE_NAME, SmallM)
 TYPED_TEST(TEST_SUITE_NAME, MidLargeM)
 {
     std::vector<int> Ms{127, 255, 312, 799, 1573};
-    constexpr int N           = 1024;
+    constexpr int N = 1024;
 
     std::vector<int> Ks;
-    for (auto K_count: {2, 3, 4, 10, 11}) 
+    for(auto K_count : {2, 3, 4, 10, 11})
     {
         Ks.push_back(K_count * TestFixture::K_Tile);
     }
@@ -51,7 +51,7 @@ TYPED_TEST(TEST_SUITE_NAME, MidLargeM)
 
     for(int M : Ms)
     {
-        for (int K: Ks)
+        for(int K : Ks)
         {
             if constexpr(std::is_same_v<typename TestFixture::ALayout,
                                         ck_tile::tensor_layout::gemm::ColumnMajor>)


### PR DESCRIPTION
## Proposed changes

Update the PR https://github.com/ROCm/composable_kernel/pull/1737 to add the atomic add feasibility check of CK GEMM.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

