### PR TITLE
Fix building test_fmha_bwd_fp32 on SLES15

### DIFF
--- a/test/ck_tile/fmha/test_fmha_bwd_fp32.cpp
+++ b/test/ck_tile/fmha/test_fmha_bwd_fp32.cpp
@@ -15,6 +15,6 @@ const auto HDimValues = Values(std::tuple{32, -1}, std::tuple{64, -1}, std::tupl
 
 const auto ModeValues = Values(mode_enum::batch, mode_enum::group);
 
-constexpr std::string init_method = "uf";
+const std::string init_method = "uf";
 
 #include "test_fmha_bwd.inc"


### PR DESCRIPTION
## Proposed changes

Fixes
```
test/ck_tile/fmha/test_fmha_bwd_fp32.cpp:18:23: error: constexpr variable cannot have non-literal type 'const std::string' (aka 'const basic_string<char>')
    18 | constexpr std::string init_method = "uf";
       |                       ^
 /usr/lib64/gcc/x86_64-suse-linux/7/../../../../include/c++/7/bits/basic_string.h:77:11: note: 'basic_string<char>' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
    77 |     class basic_string
```
(I missed that this error was fixed in other files and didn't change the new test)

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

