### PR TITLE
[CK Tile] CShuffle Tile Permute N all warp compatible

### DIFF
--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -433,8 +433,13 @@ struct CShuffleEpilogue
                                    const ScaleM& scale_m = {},
                                    const ScaleN& scale_n = {})
     {
+        static constexpr int RowsPerLane = CWarpTensor::get_thread_buffer_size();
+
+        static_assert(MPerXdl % RowsPerLane == 0,
+                  "CShuffle (permuteN): MPerXdl must be divisible by per-lane row count.");
+        
         constexpr int kM0 = MWave;
-        constexpr int kM2 = 4;
+        constexpr int kM2 = RowsPerLane;
         constexpr int kM1 = MPerXdl / kM2;
 
         constexpr int kN0 = NWave;
@@ -515,32 +520,23 @@ struct CShuffleEpilogue
             // Pack 4 “rows per lane” as you already do
             static_for<0, NRepeat, 1>{}([&](auto n_idx) {
                 // source indices in shuffle_acc: (n_idx * product(Y) + row)
-                const index_t base = n_idx * c_warp_y_lengths.product();
+                const index_t plane = c_warp_y_lengths.product();
 
                 // local lambda to fuse scale (if present) and convert
-                auto emit = [&](index_t out_idx, index_t src_row) {
-                    AccDataType v = shuffle_acc.get_thread_buffer()[base + src_row];
-
-                    if constexpr(has_scalar_scales)
-                    {
+                static_for<0, kM2, 1>{}([&](auto m_lane){
+                    const int src = n_idx * plane + m_lane;        // source row in this N-plane
+                    const int dst = n_idx + m_lane * NRepeat;       // permuted N layout in output
+                    AccDataType v = shuffle_acc.get_thread_buffer()[src];
+                    if constexpr (has_scalar_scales) {
                         v = static_cast<AccDataType>(v * scale_m * scale_n);
+                    } else if constexpr (has_scales && !has_scalar_scales) {
+                        const auto sm = static_cast<float>(sm_tile.get_thread_buffer()[dst]);
+                        const auto sn = static_cast<float>(sn_tile.get_thread_buffer()[dst]);
+                        v = static_cast<AccDataType>(v * sm * sn);
                     }
-                    else if constexpr(has_scales && !has_scalar_scales)
-                    {
-                        // same linear index mapping on the permuted distribution
-                        const auto s_m = static_cast<float>(sm_tile.get_thread_buffer()[out_idx]);
-                        const auto s_n = static_cast<float>(sn_tile.get_thread_buffer()[out_idx]);
-                        v              = static_cast<AccDataType>(v * s_m * s_n);
-                    }
+                    c_out_tensor.get_thread_buffer()[dst] = type_convert<ODataType>(v);
 
-                    c_out_tensor.get_thread_buffer()[out_idx] = type_convert<ODataType>(v);
-                };
-
-                // Your current packing pattern (rows 0..3, spaced by NRepeat)
-                emit(n_idx + 0 * NRepeat, 0);
-                emit(n_idx + 1 * NRepeat, 1);
-                emit(n_idx + 2 * NRepeat, 2);
-                emit(n_idx + 3 * NRepeat, 3);
+                });
             });
 
             // store/update

--- a/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
+++ b/include/ck_tile/ops/epilogue/cshuffle_epilogue.hpp
@@ -436,8 +436,8 @@ struct CShuffleEpilogue
         static constexpr int RowsPerLane = CWarpTensor::get_thread_buffer_size();
 
         static_assert(MPerXdl % RowsPerLane == 0,
-                  "CShuffle (permuteN): MPerXdl must be divisible by per-lane row count.");
-        
+                      "CShuffle (permuteN): MPerXdl must be divisible by per-lane row count.");
+
         constexpr int kM0 = MWave;
         constexpr int kM2 = RowsPerLane;
         constexpr int kM1 = MPerXdl / kM2;
@@ -523,19 +523,21 @@ struct CShuffleEpilogue
                 const index_t plane = c_warp_y_lengths.product();
 
                 // local lambda to fuse scale (if present) and convert
-                static_for<0, kM2, 1>{}([&](auto m_lane){
-                    const int src = n_idx * plane + m_lane;        // source row in this N-plane
-                    const int dst = n_idx + m_lane * NRepeat;       // permuted N layout in output
+                static_for<0, kM2, 1>{}([&](auto m_lane) {
+                    const int src = n_idx * plane + m_lane;   // source row in this N-plane
+                    const int dst = n_idx + m_lane * NRepeat; // permuted N layout in output
                     AccDataType v = shuffle_acc.get_thread_buffer()[src];
-                    if constexpr (has_scalar_scales) {
+                    if constexpr(has_scalar_scales)
+                    {
                         v = static_cast<AccDataType>(v * scale_m * scale_n);
-                    } else if constexpr (has_scales && !has_scalar_scales) {
+                    }
+                    else if constexpr(has_scales && !has_scalar_scales)
+                    {
                         const auto sm = static_cast<float>(sm_tile.get_thread_buffer()[dst]);
                         const auto sn = static_cast<float>(sn_tile.get_thread_buffer()[dst]);
-                        v = static_cast<AccDataType>(v * sm * sn);
+                        v             = static_cast<AccDataType>(v * sm * sn);
                     }
                     c_out_tensor.get_thread_buffer()[dst] = type_convert<ODataType>(v);
-
                 });
             });
 


### PR DESCRIPTION
## Proposed changes

Change the Tile PermuteN CShuffle to let it be compatible with any warp tile combination in epilogue layer.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

