### PR TITLE
[CI] Enable ccache w/ namespace for external use

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -105,7 +105,7 @@ jobs:
           echo "CCache Stats:"
           echo "-------------"
           ccache -s -v
-          tail -v -n +1 .ccache/compiler_check_cache/* > build/logs/ccache_compiler_check_cache.log
+          tail -v -n +1 .ccache/compiler_check_cache/* > TheROck/build/logs/ccache_compiler_check_cache.log
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -26,6 +26,9 @@ jobs:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       TEATIME_FORCE_INTERACTIVE: 0
       AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
+      CACHE_DIR: ${{ github.workspace }}/.container-cache
+      # The ccache.conf will be written by setup_ccache.py before this gets used.
+      CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
     steps:
       - name: "Checking out repository for rocm-libraries"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -44,10 +47,20 @@ jobs:
           ref: dc05d637054ad197c84b00e24b6262af0ec797c6 # 10-03-2025 commit
           path: "TheRock"
 
+      - name: Setup ccache
+        run: |
+          ./TheRock/build_tools/setup_ccache.py \
+            --config-preset "github-oss-presubmit" \
+            --dir "$(dirname $CCACHE_CONFIGPATH)" \
+            --local-path "$CACHE_DIR/ccache"
+          echo "namespace = ext_composable_kernel" >> $CCACHE_CONFIGPATH
+          echo "[*] ccache_config contents:"
+          cat $CCACHE_CONFIGPATH
+
       - name: Runner Health Settings
         run: |
           ./TheRock/build_tools/health_status.py
-      
+
       - name: Fetch sources
         run: |
           ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-libraries --no-include-ml-frameworks
@@ -89,6 +102,10 @@ jobs:
           echo "Artifacts:"
           echo "----------"
           du -h -d 1 TheRock/build/artifacts
+          echo "CCache Stats:"
+          echo "-------------"
+          ccache -s -v
+          tail -v -n +1 .ccache/compiler_check_cache/* > build/logs/ccache_compiler_check_cache.log
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -105,7 +105,7 @@ jobs:
           echo "CCache Stats:"
           echo "-------------"
           ccache -s -v
-          tail -v -n +1 .ccache/compiler_check_cache/* > TheROck/build/logs/ccache_compiler_check_cache.log
+          tail -v -n +1 .ccache/compiler_check_cache/* > TheRock/build/logs/ccache_compiler_check_cache.log
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}


### PR DESCRIPTION
Currently, no build cache is being used and is causing each null build to take an exceedingly long time. This will enable caching like [TheRock](https://github.com/ROCm/TheRock/blob/2d9ca43c2140c5d35e4105c811bd23dbd6420c94/.github/workflows/build_portable_linux_artifacts.yml#L69-L74) repo.