### PR TITLE
Fix GCC 7 CTAD compilation error in test_fmha_bwd.cpp

### DIFF
--- a/test/ck_tile/fmha/test_fmha_bwd.cpp
+++ b/test/ck_tile/fmha/test_fmha_bwd.cpp
@@ -29,7 +29,7 @@ struct TestConfigs<FmhaBwdFp32>
         std::array{std::tuple{32, -1}, std::tuple{64, -1}, std::tuple{128, -1}};
 };
 static auto HDimValues     = ValuesIn(TestConfigs<DataTypeConfig>::HDimValues);
-const auto ModeValues      = ValuesIn(std::vector{mode_enum::batch, mode_enum::group});
+const auto ModeValues      = ValuesIn(std::vector<mode_enum>{mode_enum::batch, mode_enum::group});
 constexpr auto init_method = "uf";
 
 // Random seed used for initializing input tensors. 0 for non-deterministic seed


### PR DESCRIPTION
Fixes compilation error on SLES15 with GCC 7 for gfx942 builds:

error: 'vector' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]

Changes:

- Explicitly specify template argument for `std::vector<mode_enum>` instead of relying on C++17 CTAD
- Maintains compatibility with both older (GCC 7) and newer compilers