### PR TITLE
[TheRock CI] Updating group ID from 992 to 110 for container runs

### DIFF
--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -29,7 +29,7 @@ jobs:
         --group-add video
         --device /dev/kfd
         --device /dev/dri
-        --group-add 992
+        --group-add 110
         --env-file /etc/podinfo/gha-gpu-isolation-settings
     strategy:
       fail-fast: false


### PR DESCRIPTION
test run here: https://github.com/ROCm/TheRock/actions/runs/18412567584

the groupid 992 was specific to the older clusters, while groupid 110 is for the newer clusters to access GPUs. it's the groupid that owns /dev/kfd

for the future, I will be working with OSSCI to make this value not needed