### PR TITLE
[TheRock CI] Updating SHA for build image and TheRock SHA

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:044b113562629f4bd2ec5d2e64b32eee11562d48fb1a75d7493daec9dd8d8292
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:2f3ebd0beb04c449fdb36933e54bdc69483b914fb9005594d3fc9444c206b54b
       options: -v /runner/config:/home/awsconfig/
     env:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: dc05d637054ad197c84b00e24b6262af0ec797c6 # 10-03-2025 commit
+          ref: c2921b151b8285a1d29942aceb33cfe0fea77ac9 # 10-15-2025 commit
           path: "TheRock"
 
       - name: Setup ccache


### PR DESCRIPTION
Seeing errors such as 

```
2025-10-15T14:54:27.6580750Z Submodule path 'compiler/amd-llvm': checked out 'a7d47b26ca0ec0b3e9e4da83825cace5d761f4bc'
2025-10-15T14:54:27.7437094Z Submodule path 'compiler/hipify': checked out 'f5d07c5006d720dedf4a0560200a856c4c192898'
2025-10-15T14:54:27.8521571Z Submodule path 'compiler/spirv-llvm-translator': checked out '37f7ea5856785732839305e6a92af19ff2ea4958'
2025-10-15T14:54:27.8622710Z Submodule path 'profiler/rocprof-trace-decoder/binaries': checked out 'e2609d6e2ce1ab6fba6f7e095fc614ccd8b772ae'
2025-10-15T14:54:28.9760993Z Submodule path 'rocm-systems': checked out '55feeefcff7374906eb7c0daf365d8e5a7652982'
2025-10-15T14:54:28.9947823Z `dvc` not found, skipping large file pull on Linux.
2025-10-15T14:54:28.9950151Z ++ Exec [/__w/composable_kernel/composable_kernel/TheRock]$ git update-index --no-skip-worktree -- base/amdsmi base/half comm-libs/rccl comm-libs/rccl-tests base/rocm-cmake profiler/rocprof-trace-decoder/binaries compiler/hipify compiler/amd-llvm compiler/spirv-llvm-translator rocm-systems
```

The new image will have `dvc`

Resolves DB_SYNC tests