### PR TITLE
use branch develop to test hipTensor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1039,8 +1039,8 @@ pipeline {
             description: "Use the CK build to verify hipTensor build and tests (default: OFF)")
         string(
             name: 'hipTensor_branch',
-            defaultValue: 'mainline',
-            description: 'Specify which branch of hipTensor to use (default: mainline)')
+            defaultValue: 'develop',
+            description: 'Specify which branch of hipTensor to use (default: develop)')
         booleanParam(
             name: "USE_SCCACHE",
             defaultValue: true,


### PR DESCRIPTION
## Proposed changes

The hipTensor repo no longer has a branch "mainline", which broke our daily tests. Need to switch to branch "develop". Made sure the tests are now passing:

[2025-10-15T20:37:03.282Z] Test project /home/jenkins/workspace/IBS_composable_kernel_lwpck-3977/hipTensor-develop/build
[2025-10-15T20:37:03.282Z]       Start  1: logger_test
[2025-10-15T20:37:04.730Z]  1/54 Test  #1: logger_test ................................   Passed    1.17 sec
[2025-10-15T20:37:04.730Z]       Start  2: yaml_test
[2025-10-15T20:37:05.640Z]  2/54 Test  #2: yaml_test ..................................   Passed    1.18 sec
[2025-10-15T20:37:05.640Z]       Start  3: elementwise_op_test
[2025-10-15T20:37:07.089Z]  3/54 Test  #3: elementwise_op_test ........................   Passed    1.46 sec
[2025-10-15T20:37:07.089Z]       Start  4: util_test
[2025-10-15T20:37:08.538Z]  4/54 Test  #4: util_test ..................................   Passed    1.15 sec
[2025-10-15T20:37:08.538Z]       Start  5: hiptensor_options_test
[2025-10-15T20:37:09.448Z]  5/54 Test  #5: hiptensor_options_test .....................   Passed    1.18 sec
[2025-10-15T20:37:09.448Z]       Start  6: bilinear_contraction_test_m1n1k1
[2025-10-15T20:37:26.697Z]  6/54 Test  #6: bilinear_contraction_test_m1n1k1 ...........   Passed   14.68 sec
[2025-10-15T20:37:26.697Z]       Start  7: bilinear_contraction_test_m2n2k2
[2025-10-15T20:37:38.712Z]  7/54 Test  #7: bilinear_contraction_test_m2n2k2 ...........   Passed   13.45 sec
[2025-10-15T20:37:38.712Z]       Start  8: bilinear_contraction_test_m3n3k3
[2025-10-15T20:37:53.124Z]  8/54 Test  #8: bilinear_contraction_test_m3n3k3 ...........   Passed   13.97 sec
[2025-10-15T20:37:53.124Z]       Start  9: bilinear_contraction_test_m4n4k4
[2025-10-15T20:38:07.534Z]  9/54 Test  #9: bilinear_contraction_test_m4n4k4 ...........   Passed   14.35 sec
[2025-10-15T20:38:07.534Z]       Start 10: bilinear_contraction_test_m5n5k5
[2025-10-15T20:38:22.315Z] 10/54 Test #10: bilinear_contraction_test_m5n5k5 ...........   Passed   15.68 sec
[2025-10-15T20:38:22.315Z]       Start 11: bilinear_contraction_test_m6n6k6
[2025-10-15T20:38:46.953Z] 11/54 Test #11: bilinear_contraction_test_m6n6k6 ...........   Passed   25.21 sec
[2025-10-15T20:38:46.953Z]       Start 12: complex_bilinear_contraction_test_m1n1k1
[2025-10-15T20:38:55.250Z] 12/54 Test #12: complex_bilinear_contraction_test_m1n1k1 ...   Passed    7.16 sec
[2025-10-15T20:38:55.250Z]       Start 13: complex_bilinear_contraction_test_m2n2k2
[2025-10-15T20:39:00.790Z] 13/54 Test #13: complex_bilinear_contraction_test_m2n2k2 ...   Passed    6.48 sec
[2025-10-15T20:39:00.790Z]       Start 14: complex_bilinear_contraction_test_m3n3k3
[2025-10-15T20:39:07.583Z] 14/54 Test #14: complex_bilinear_contraction_test_m3n3k3 ...   Passed    6.80 sec
[2025-10-15T20:39:07.583Z]       Start 15: complex_bilinear_contraction_test_m4n4k4
[2025-10-15T20:39:14.374Z] 15/54 Test #15: complex_bilinear_contraction_test_m4n4k4 ...   Passed    7.25 sec
[2025-10-15T20:39:14.374Z]       Start 16: complex_bilinear_contraction_test_m5n5k5
[2025-10-15T20:39:24.340Z] 16/54 Test #16: complex_bilinear_contraction_test_m5n5k5 ...   Passed    8.37 sec
[2025-10-15T20:39:24.340Z]       Start 17: complex_bilinear_contraction_test_m6n6k6
[2025-10-15T20:39:41.565Z] 17/54 Test #17: complex_bilinear_contraction_test_m6n6k6 ...   Passed   17.96 sec
[2025-10-15T20:39:41.565Z]       Start 18: scale_contraction_test_m1n1k1
[2025-10-15T20:39:55.959Z] 18/54 Test #18: scale_contraction_test_m1n1k1 ..............   Passed   14.19 sec
[2025-10-15T20:39:55.959Z]       Start 19: scale_contraction_test_m2n2k2
[2025-10-15T20:40:10.365Z] 19/54 Test #19: scale_contraction_test_m2n2k2 ..............   Passed   13.56 sec
[2025-10-15T20:40:10.365Z]       Start 20: scale_contraction_test_m3n3k3
[2025-10-15T20:40:22.361Z] 20/54 Test #20: scale_contraction_test_m3n3k3 ..............   Passed   13.76 sec
[2025-10-15T20:40:22.361Z]       Start 21: scale_contraction_test_m4n4k4
[2025-10-15T20:40:36.749Z] 21/54 Test #21: scale_contraction_test_m4n4k4 ..............   Passed   14.26 sec
[2025-10-15T20:40:36.749Z]       Start 22: scale_contraction_test_m5n5k5
[2025-10-15T20:40:53.982Z] 22/54 Test #22: scale_contraction_test_m5n5k5 ..............   Passed   15.64 sec
[2025-10-15T20:40:53.982Z]       Start 23: scale_contraction_test_m6n6k6
[2025-10-15T20:41:18.605Z] 23/54 Test #23: scale_contraction_test_m6n6k6 ..............   Passed   24.88 sec
[2025-10-15T20:41:18.605Z]       Start 24: complex_scale_contraction_test_m1n1k1
[2025-10-15T20:41:25.395Z] 24/54 Test #24: complex_scale_contraction_test_m1n1k1 ......   Passed    7.27 sec
[2025-10-15T20:41:25.395Z]       Start 25: complex_scale_contraction_test_m2n2k2
[2025-10-15T20:41:30.939Z] 25/54 Test #25: complex_scale_contraction_test_m2n2k2 ......   Passed    6.49 sec
[2025-10-15T20:41:30.939Z]       Start 26: complex_scale_contraction_test_m3n3k3
[2025-10-15T20:41:37.726Z] 26/54 Test #26: complex_scale_contraction_test_m3n3k3 ......   Passed    6.61 sec
[2025-10-15T20:41:37.726Z]       Start 27: complex_scale_contraction_test_m4n4k4
[2025-10-15T20:41:44.656Z] 27/54 Test #27: complex_scale_contraction_test_m4n4k4 ......   Passed    7.02 sec
[2025-10-15T20:41:44.656Z]       Start 28: complex_scale_contraction_test_m5n5k5
[2025-10-15T20:41:52.963Z] 28/54 Test #28: complex_scale_contraction_test_m5n5k5 ......   Passed    8.30 sec
[2025-10-15T20:41:52.963Z]       Start 29: complex_scale_contraction_test_m6n6k6
[2025-10-15T20:42:04.907Z] 29/54 Test #29: complex_scale_contraction_test_m6n6k6 ......   Passed   11.83 sec
[2025-10-15T20:42:04.907Z]       Start 30: contraction_mode_test
[2025-10-15T20:42:06.350Z] 30/54 Test #30: contraction_mode_test ......................   Passed    1.80 sec
[2025-10-15T20:42:06.350Z]       Start 31: plan_cache_test
[2025-10-15T20:43:31.874Z] 31/54 Test #31: plan_cache_test ............................   Passed   79.52 sec
[2025-10-15T20:43:31.874Z]       Start 32: elementwise_cpu_test
[2025-10-15T20:43:31.874Z] 32/54 Test #32: elementwise_cpu_test .......................   Passed    1.13 sec
[2025-10-15T20:43:31.874Z]       Start 33: rank2_elementwise_permute_test
[2025-10-15T20:43:31.874Z] 33/54 Test #33: rank2_elementwise_permute_test .............   Passed    1.55 sec
[2025-10-15T20:43:31.874Z]       Start 34: rank2_elementwise_binary_op_test
[2025-10-15T20:43:31.874Z] 34/54 Test #34: rank2_elementwise_binary_op_test ...........   Passed    1.52 sec
[2025-10-15T20:43:31.875Z]       Start 35: rank2_elementwise_trinary_op_test
[2025-10-15T20:43:31.875Z] 35/54 Test #35: rank2_elementwise_trinary_op_test ..........   Passed    1.57 sec
[2025-10-15T20:43:31.875Z]       Start 36: rank3_elementwise_permute_test
[2025-10-15T20:43:33.927Z] 36/54 Test #36: rank3_elementwise_permute_test .............   Passed    1.73 sec
[2025-10-15T20:43:33.927Z]       Start 37: rank3_elementwise_binary_op_test
[2025-10-15T20:43:35.376Z] 37/54 Test #37: rank3_elementwise_binary_op_test ...........   Passed    1.55 sec
[2025-10-15T20:43:35.376Z]       Start 38: rank3_elementwise_trinary_op_test
[2025-10-15T20:43:36.822Z] 38/54 Test #38: rank3_elementwise_trinary_op_test ..........   Passed    1.63 sec
[2025-10-15T20:43:36.822Z]       Start 39: rank4_elementwise_permute_test
[2025-10-15T20:43:39.574Z] 39/54 Test #39: rank4_elementwise_permute_test .............   Passed    2.59 sec
[2025-10-15T20:43:39.574Z]       Start 40: rank4_elementwise_binary_op_test
[2025-10-15T20:43:41.630Z] 40/54 Test #40: rank4_elementwise_binary_op_test ...........   Passed    2.34 sec
[2025-10-15T20:43:41.630Z]       Start 41: rank4_elementwise_trinary_op_test
[2025-10-15T20:43:44.383Z] 41/54 Test #41: rank4_elementwise_trinary_op_test ..........   Passed    2.59 sec
[2025-10-15T20:43:44.383Z]       Start 42: rank5_elementwise_permute_test
[2025-10-15T20:43:54.372Z] 42/54 Test #42: rank5_elementwise_permute_test .............   Passed    9.20 sec
[2025-10-15T20:43:54.372Z]       Start 43: rank5_elementwise_binary_op_test
[2025-10-15T20:44:02.663Z] 43/54 Test #43: rank5_elementwise_binary_op_test ...........   Passed    9.12 sec
[2025-10-15T20:44:02.663Z]       Start 44: rank5_elementwise_trinary_op_test
[2025-10-15T20:44:14.687Z] 44/54 Test #44: rank5_elementwise_trinary_op_test ..........   Passed   12.03 sec
[2025-10-15T20:44:14.687Z]       Start 45: rank6_elementwise_permute_test
[2025-10-15T20:45:04.766Z] 45/54 Test #45: rank6_elementwise_permute_test .............   Passed   48.37 sec
[2025-10-15T20:45:04.767Z]       Start 46: rank6_elementwise_binary_op_test
[2025-10-15T20:45:54.854Z] 46/54 Test #46: rank6_elementwise_binary_op_test ...........   Passed   50.11 sec
[2025-10-15T20:45:54.854Z]       Start 47: rank6_elementwise_trinary_op_test
[2025-10-15T20:47:06.299Z] 47/54 Test #47: rank6_elementwise_trinary_op_test ..........   Passed   66.57 sec
[2025-10-15T20:47:06.299Z]       Start 48: reduction_cpu_impl_test
[2025-10-15T20:47:06.299Z] 48/54 Test #48: reduction_cpu_impl_test ....................   Passed    1.17 sec
[2025-10-15T20:47:06.299Z]       Start 49: rank1_reduction_test
[2025-10-15T20:47:06.299Z] 49/54 Test #49: rank1_reduction_test .......................   Passed    1.48 sec
[2025-10-15T20:47:06.299Z]       Start 50: rank2_reduction_test
[2025-10-15T20:47:06.299Z] 50/54 Test #50: rank2_reduction_test .......................   Passed    2.27 sec
[2025-10-15T20:47:06.299Z]       Start 51: rank3_reduction_test
[2025-10-15T20:47:09.078Z] 51/54 Test #51: rank3_reduction_test .......................   Passed    4.23 sec
[2025-10-15T20:47:09.078Z]       Start 52: rank4_reduction_test
[2025-10-15T20:47:17.358Z] 52/54 Test #52: rank4_reduction_test .......................   Passed    7.94 sec
[2025-10-15T20:47:17.358Z]       Start 53: rank5_reduction_test
[2025-10-15T20:47:34.686Z] 53/54 Test #53: rank5_reduction_test .......................   Passed   15.20 sec
[2025-10-15T20:47:34.686Z]       Start 54: rank6_reduction_test
[2025-10-15T20:48:04.103Z] 54/54 Test #54: rank6_reduction_test .......................   Passed   28.28 sec
[2025-10-15T20:48:04.103Z] 
[2025-10-15T20:48:04.103Z] 100% tests passed, 0 tests failed out of 54
[2025-10-15T20:48:04.103Z] 
[2025-10-15T20:48:04.103Z] Total Test time (real) = 657.05 sec

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged