### PR TITLE
re-enable batched transpose test on gfx942

### DIFF
--- a/test/ck_tile/batched_transpose/CMakeLists.txt
+++ b/test/ck_tile/batched_transpose/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(GPU_TARGETS MATCHES "gfx94|gfx95|gfx11|gfx12")
+if(GPU_TARGETS MATCHES "gfx9")
     add_gtest_executable(test_ck_tile_batched_transpose test_batched_transpose.cpp)
     set_property(TARGET test_ck_tile_batched_transpose PROPERTY CXX_STANDARD 20)
 else()

--- a/test/ck_tile/batched_transpose/CMakeLists.txt
+++ b/test/ck_tile/batched_transpose/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(GPU_TARGETS MATCHES "gfx950")
+if(GPU_TARGETS MATCHES "gfx94|gfx95")
     add_gtest_executable(test_ck_tile_batched_transpose test_batched_transpose.cpp)
     set_property(TARGET test_ck_tile_batched_transpose PROPERTY CXX_STANDARD 20)
 else()

--- a/test/ck_tile/batched_transpose/CMakeLists.txt
+++ b/test/ck_tile/batched_transpose/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(GPU_TARGETS MATCHES "gfx94|gfx95")
+if(GPU_TARGETS MATCHES "gfx94|gfx95|gfx11|gfx12")
     add_gtest_executable(test_ck_tile_batched_transpose test_batched_transpose.cpp)
     set_property(TARGET test_ck_tile_batched_transpose PROPERTY CXX_STANDARD 20)
 else()


### PR DESCRIPTION
## Proposed changes

It seems to be accidentally disabled in #2821 - but we need it tested as part of gemm pipelines on gfx942

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

