### PR TITLE
[CK_TILE] Fix noreturn compiler error on gfx950

### DIFF
--- a/test/ck_tile/permute/alternative_impl/matrix_core_swizzle.hpp
+++ b/test/ck_tile/permute/alternative_impl/matrix_core_swizzle.hpp
@@ -13,119 +13,90 @@ struct matrix_core_swizzle_traits
 
 using matrix_core_swizzle_args = matrix_core_swizzle_host_args;
 
-// host API
-template <typename DataType> // only supported with fp16 data type
-float matrix_core_swizzle(matrix_core_swizzle_traits,
-                          matrix_core_swizzle_args,
-                          const ck_tile::stream_config&);
-
-template <>
-float matrix_core_swizzle<ck_tile::half_t>(matrix_core_swizzle_traits t,
-                                           matrix_core_swizzle_args a,
-                                           const ck_tile::stream_config& s)
+template <typename DataType>
+void matrix_core_swizzle(matrix_core_swizzle_traits t,
+                         matrix_core_swizzle_args a,
+                         const ck_tile::stream_config& s)
 {
-    if(t.inst.compare("32x32x8") == 0)
+    if constexpr(!std::is_same_v<DataType, ck_tile::half_t>)
     {
-        constexpr int BLOCK_SIZE             = 256;
-        constexpr int NPerBlock              = 256;
-        constexpr int KPerBlock              = 128;
-        constexpr matrix_core_inst_enum Inst = matrix_core_inst_enum::MFMA_32x32x8_F16;
-        if(t.permute.compare("0,1,4,2,5,3,6") == 0)
+        throw std::runtime_error("matrix_core_swizzle is only supported for fp16");
+    }
+    else
+    {
+        if(t.inst.compare("32x32x8") == 0)
         {
-            constexpr matrix_core_permute_style pstyle =
-                matrix_core_permute_style::permute_b_n0_k0_n1_k1_n2_k2;
-            using Kernel =
-                matrix_core_swizzle_kernel<BLOCK_SIZE, NPerBlock, KPerBlock, pstyle, Inst>;
+            constexpr int BLOCK_SIZE             = 256;
+            constexpr int NPerBlock              = 256;
+            constexpr int KPerBlock              = 128;
+            constexpr matrix_core_inst_enum Inst = matrix_core_inst_enum::MFMA_32x32x8_F16;
+            if(t.permute.compare("0,1,4,2,5,3,6") == 0)
+            {
+                constexpr matrix_core_permute_style pstyle =
+                    matrix_core_permute_style::permute_b_n0_k0_n1_k1_n2_k2;
+                using Kernel =
+                    matrix_core_swizzle_kernel<BLOCK_SIZE, NPerBlock, KPerBlock, pstyle, Inst>;
 
-            auto k         = Kernel(a);
-            float ave_time = ck_tile::launch_kernel(s, k);
+                auto k = Kernel(a);
+                ck_tile::launch_kernel(s, k);
+            }
+            else if(t.permute.compare("0,1,2,4,5,3,6") == 0)
+            {
+                constexpr matrix_core_permute_style pstyle =
+                    matrix_core_permute_style::permute_b_n0_n1_k0_k1_n2_k2;
+                using Kernel =
+                    matrix_core_swizzle_kernel<BLOCK_SIZE, NPerBlock, KPerBlock, pstyle, Inst>;
 
-            return ave_time;
+                auto k = Kernel(a);
+                ck_tile::launch_kernel(s, k);
+            }
+            else if(t.permute.compare("0,1,3,4,2,5") == 0)
+            {
+                constexpr matrix_core_permute_style pstyle =
+                    matrix_core_permute_style::b_nr_kr_kw_nw_kv;
+                using Kernel =
+                    matrix_core_swizzle_kernel<BLOCK_SIZE, NPerBlock, KPerBlock, pstyle, Inst>;
+
+                auto k = Kernel(a);
+                ck_tile::launch_kernel(s, k);
+            }
         }
-        else if(t.permute.compare("0,1,2,4,5,3,6") == 0)
+        else if(t.inst.compare("16x16x16") == 0)
         {
-            constexpr matrix_core_permute_style pstyle =
-                matrix_core_permute_style::permute_b_n0_n1_k0_k1_n2_k2;
-            using Kernel =
-                matrix_core_swizzle_kernel<BLOCK_SIZE, NPerBlock, KPerBlock, pstyle, Inst>;
+            constexpr int BLOCK_SIZE             = 256;
+            constexpr int NPerBlock              = 256;
+            constexpr int KPerBlock              = 128;
+            constexpr matrix_core_inst_enum Inst = matrix_core_inst_enum::MFMA_16x16x16_F16;
+            if(t.permute.compare("0,1,4,2,5,3,6") == 0)
+            {
+                constexpr matrix_core_permute_style pstyle =
+                    matrix_core_permute_style::permute_b_n0_k0_n1_k1_n2_k2;
+                using Kernel =
+                    matrix_core_swizzle_kernel<BLOCK_SIZE, NPerBlock, KPerBlock, pstyle, Inst>;
 
-            auto k         = Kernel(a);
-            float ave_time = ck_tile::launch_kernel(s, k);
+                auto k = Kernel(a);
+                ck_tile::launch_kernel(s, k);
+            }
+            else if(t.permute.compare("0,1,2,4,5,3,6") == 0)
+            {
+                constexpr matrix_core_permute_style pstyle =
+                    matrix_core_permute_style::permute_b_n0_n1_k0_k1_n2_k2;
+                using Kernel =
+                    matrix_core_swizzle_kernel<BLOCK_SIZE, NPerBlock, KPerBlock, pstyle, Inst>;
 
-            return ave_time;
-        }
-        else if(t.permute.compare("0,1,3,4,2,5") == 0)
-        {
-            constexpr matrix_core_permute_style pstyle =
-                matrix_core_permute_style::b_nr_kr_kw_nw_kv;
-            using Kernel =
-                matrix_core_swizzle_kernel<BLOCK_SIZE, NPerBlock, KPerBlock, pstyle, Inst>;
+                auto k = Kernel(a);
+                ck_tile::launch_kernel(s, k);
+            }
+            else if(t.permute.compare("0,1,3,4,2,5") == 0)
+            {
+                constexpr matrix_core_permute_style pstyle =
+                    matrix_core_permute_style::b_nr_kr_kw_nw_kv;
+                using Kernel =
+                    matrix_core_swizzle_kernel<BLOCK_SIZE, NPerBlock, KPerBlock, pstyle, Inst>;
 
-            auto k         = Kernel(a);
-            float ave_time = ck_tile::launch_kernel(s, k);
-
-            return ave_time;
+                auto k = Kernel(a);
+                ck_tile::launch_kernel(s, k);
+            }
         }
     }
-    else if(t.inst.compare("16x16x16") == 0)
-    {
-        constexpr int BLOCK_SIZE             = 256;
-        constexpr int NPerBlock              = 256;
-        constexpr int KPerBlock              = 128;
-        constexpr matrix_core_inst_enum Inst = matrix_core_inst_enum::MFMA_16x16x16_F16;
-        if(t.permute.compare("0,1,4,2,5,3,6") == 0)
-        {
-            constexpr matrix_core_permute_style pstyle =
-                matrix_core_permute_style::permute_b_n0_k0_n1_k1_n2_k2;
-            using Kernel =
-                matrix_core_swizzle_kernel<BLOCK_SIZE, NPerBlock, KPerBlock, pstyle, Inst>;
-
-            auto k         = Kernel(a);
-            float ave_time = ck_tile::launch_kernel(s, k);
-
-            return ave_time;
-        }
-        else if(t.permute.compare("0,1,2,4,5,3,6") == 0)
-        {
-            constexpr matrix_core_permute_style pstyle =
-                matrix_core_permute_style::permute_b_n0_n1_k0_k1_n2_k2;
-            using Kernel =
-                matrix_core_swizzle_kernel<BLOCK_SIZE, NPerBlock, KPerBlock, pstyle, Inst>;
-
-            auto k         = Kernel(a);
-            float ave_time = ck_tile::launch_kernel(s, k);
-
-            return ave_time;
-        }
-        else if(t.permute.compare("0,1,3,4,2,5") == 0)
-        {
-            constexpr matrix_core_permute_style pstyle =
-                matrix_core_permute_style::b_nr_kr_kw_nw_kv;
-            using Kernel =
-                matrix_core_swizzle_kernel<BLOCK_SIZE, NPerBlock, KPerBlock, pstyle, Inst>;
-
-            auto k         = Kernel(a);
-            float ave_time = ck_tile::launch_kernel(s, k);
-
-            return ave_time;
-        }
-    }
-
-    return -1;
-}
-
-template <>
-float matrix_core_swizzle<ck_tile::fp8_t>(matrix_core_swizzle_traits,
-                                          matrix_core_swizzle_args,
-                                          const ck_tile::stream_config&)
-{
-    throw std::runtime_error("Not supported for fp8");
-}
-
-template <>
-float matrix_core_swizzle<float>(matrix_core_swizzle_traits,
-                                 matrix_core_swizzle_args,
-                                 const ck_tile::stream_config&)
-{
-    throw std::runtime_error("Not supported for fp32");
 }


### PR DESCRIPTION
## Proposed changes

In CK Tile, test_ck_tile_permute fails to compile on gfx950 due to a new compilation error: 
- `error: function could be declared with attribute 'noreturn' [-Werror,-Wmissing-noreturn]`

The problematic function was `matrix_core_swizzle` since for fp8 and float datatypes, the template specializations only throw a runtime error.

This change refactors the code to resolve this issue. Specifically, I removed the template specializations and do a compile time check inside `matrix_core_swizzle` for datatypes instead. Additionally, the return value (originally float) was not used in the tests, so the function is now marked as `void`.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged
