### PR TITLE
Revert "[CK_TILE] Enable StoreLSE for fmha_fwd_trload kernel"

### DIFF
--- a/example/ck_tile/01_fmha/codegen/ops/fmha_fwd.py
+++ b/example/ck_tile/01_fmha/codegen/ops/fmha_fwd.py
@@ -608,7 +608,7 @@ class KernelComponentFactory:
                     else:
                         pipelines.append(FmhaFwdPipeline('qr_async', 'row', 't', 'f', 't', 't', logits, bias, lse, dropout, squant, mask, skip, 'f'))
                         pipelines.append(FmhaFwdPipeline('qr_async', 'row', 't', 't', 't', 't', logits, bias, lse, dropout, squant, mask, skip, 'f'))
-                        if (hdim, hdim_v) in [(64, 64), (128, 128)] and logits == "f" and bias == "no" and dropout == "f" and skip == "f":
+                        if (hdim, hdim_v) in [(64, 64), (128, 128)] and logits == "f" and bias == "no" and dropout == "f" and lse == "f" and skip == "f":
                             pipelines.append(FmhaFwdPipeline('qr_async_trload', 'row', 'f', 'f', 'f', 'f', logits, bias, lse, dropout, squant, mask, skip, 't'))
                             pipelines.append(FmhaFwdPipeline('qr_async_trload', 'row', 'f', 'f', 't', 't', logits, bias, lse, dropout, squant, mask, skip, 't'))
                     if receipt == 1 and bias != "bias":


### PR DESCRIPTION
Reverts ROCm/composable_kernel#3023
This PR introduced 2 regressions on gfx950:

[2025-10-16T07:36:38.037Z] The following tests FAILED:
[2025-10-16T07:36:38.037Z] 	348 - test_ck_tile_fmha_fwd_fp16 (Failed)
[2025-10-16T07:36:38.037Z] 	349 - test_ck_tile_fmha_fwd_bf16 (Failed)