### PR TITLE
Improve build infrastructure for generating doc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -734,3 +734,11 @@ rocm_create_package(
     LDCONFIG
     HEADER_ONLY
 )
+
+# Add documentation support
+option(BUILD_DOCS "Build documentation" ON)
+
+if(BUILD_DOCS)
+    include(cmake/SetupDocs.cmake)
+    setup_documentation()
+endif()

--- a/cmake/SetupDocs.cmake
+++ b/cmake/SetupDocs.cmake
@@ -1,0 +1,109 @@
+function(setup_documentation)
+    # Find Python executable
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+    
+    # Check for existing virtual environment in ~/python-env
+    set(HOME_VENV "$ENV{HOME}/python-env/venv-1")
+    set(BUILD_VENV "${CMAKE_BINARY_DIR}/python-env")
+    
+    if(EXISTS "${HOME_VENV}/bin/python3")
+        set(PYTHON_VENV "${HOME_VENV}")
+        set(PYTHON_EXECUTABLE "${HOME_VENV}/bin/python3")
+        set(VENV_IS_NEW FALSE)
+        message(STATUS "Using existing Python virtual environment: ${HOME_VENV}")
+    else()
+        set(PYTHON_VENV "${BUILD_VENV}")
+        set(PYTHON_EXECUTABLE "${BUILD_VENV}/bin/python3")
+        set(VENV_IS_NEW TRUE)
+        message(STATUS "Will create Python virtual environment: ${BUILD_VENV}")
+    endif()
+    
+    # Create virtual environment if it doesn't exist
+    if(NOT EXISTS "${PYTHON_EXECUTABLE}")
+        message(STATUS "Creating Python virtual environment...")
+        execute_process(
+            COMMAND ${Python3_EXECUTABLE} -m venv ${PYTHON_VENV}
+            RESULT_VARIABLE VENV_RESULT
+        )
+        if(NOT VENV_RESULT EQUAL 0)
+            message(FATAL_ERROR "Failed to create Python virtual environment")
+        endif()
+        set(VENV_IS_NEW TRUE)
+    endif()
+    
+    # Set requirements file path
+    set(REQUIREMENTS_FILE "${CMAKE_SOURCE_DIR}/docs/sphinx/requirements.txt")
+    
+    # Only install packages if we created a new virtual environment
+    if(VENV_IS_NEW)
+        message(STATUS "Installing Python documentation requirements in new virtual environment...")
+        execute_process(
+            COMMAND ${PYTHON_EXECUTABLE} -m pip install --upgrade pip
+            RESULT_VARIABLE PIP_RESULT
+        )
+        if(NOT PIP_RESULT EQUAL 0)
+            message(FATAL_ERROR "Failed to upgrade pip")
+        endif()
+        
+        execute_process(
+            COMMAND ${PYTHON_EXECUTABLE} -m pip install -r ${REQUIREMENTS_FILE}
+            RESULT_VARIABLE PIP_RESULT
+        )
+        if(NOT PIP_RESULT EQUAL 0)
+            message(FATAL_ERROR "Failed to install Python documentation requirements")
+        endif()
+        
+        message(STATUS "Python documentation requirements installed successfully")
+    endif()
+    
+    # Create dummy target (no build-time package installation needed)
+    add_custom_target(docs_venv
+        COMMENT "Python virtual environment ready"
+    )
+    
+    # Set up Doxygen
+    find_package(Doxygen REQUIRED)
+    
+    set(DOXYGEN_OUTPUT_DIR "${CMAKE_BINARY_DIR}/docs/doxygen")
+    set(DOXYGEN_CONFIG_FILE "${CMAKE_SOURCE_DIR}/docs/doxygen/Doxyfile")
+    
+    add_custom_command(
+        OUTPUT "${DOXYGEN_OUTPUT_DIR}/xml/index.xml"
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${DOXYGEN_OUTPUT_DIR}
+        COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG_FILE}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docs/doxygen
+        DEPENDS ${DOXYGEN_CONFIG_FILE}
+        COMMENT "Building Doxygen XML documentation"
+    )
+    
+    add_custom_target(docs_doxygen
+        DEPENDS "${DOXYGEN_OUTPUT_DIR}/xml/index.xml"
+    )
+    
+    # Set up Sphinx
+    set(SPHINX_OUTPUT_DIR "${CMAKE_BINARY_DIR}/docs/html")
+    set(SPHINX_SOURCE_DIR "${CMAKE_SOURCE_DIR}/docs")
+    
+    # Set number of parallel jobs for Sphinx (default to 8 if not set)
+    if(NOT CMAKE_BUILD_PARALLEL_LEVEL)
+        set(CMAKE_BUILD_PARALLEL_LEVEL 8)
+    endif()
+    
+    add_custom_target(docs
+        COMMAND ${PYTHON_EXECUTABLE} -m sphinx -b html -j ${CMAKE_BUILD_PARALLEL_LEVEL} ${SPHINX_SOURCE_DIR} ${SPHINX_OUTPUT_DIR}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        DEPENDS docs_venv docs_doxygen
+        COMMENT "Building HTML documentation with Sphinx"
+    )
+    
+    # Add clean target for docs
+    add_custom_target(docs_clean
+        COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/docs
+        COMMENT "Cleaning documentation build files"
+    )
+    
+    message(STATUS "Documentation build configured:")
+    message(STATUS "  Build command: cmake --build . --target docs")
+    message(STATUS "  Clean command: cmake --build . --target docs_clean")
+    message(STATUS "  Output directory: ${SPHINX_OUTPUT_DIR}")
+endfunction()


### PR DESCRIPTION
- Add CMake documentation infrastructure with auto Python venv management
- Enable streamlined docs build: cmake --build . --target docs

## Proposed changes

Please describe the motivation behind the pull request, whether it enables a new feature or fixes a bug. If there are associated pull requests or issues, please link them to the pull request.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

