### PR TITLE
Fix race conditions in ck_tile remod

### DIFF
--- a/example/ck_tile/remod.py
+++ b/example/ck_tile/remod.py
@@ -10,15 +10,16 @@ for p in sorted(Path("./").rglob("*")):
 
 
 # formatting
+format_procs = []
 for x in all_files:
-    subprocess.Popen(
-        f"python -m dos2unix {str(x)} {str(x)}",
-        shell=True,
-        stdout=open(os.devnull, "wb"),
+    dos2unix = f"python -m dos2unix {str(x)} {str(x)}"
+    clang_format = f"clang-format -style=file -i {str(x)}"
+    # One process to avoid race conditions.
+    cmd = f"{dos2unix} && {clang_format}"
+    format_procs.append(
+        subprocess.Popen(cmd, shell=True, stdout=open(os.devnull, "wb"))
     )
-    cmd = f"clang-format -style=file -i {str(x)}"
-    # for xp in x.parents:
-    # print(get_file_base(x))
-    subprocess.Popen(cmd, shell=True)
 
-# print(all_files)
+# Wait for formatting to complete.
+for p in format_procs:
+    p.wait()

--- a/include/ck_tile/remod.py
+++ b/include/ck_tile/remod.py
@@ -85,18 +85,19 @@ class submodule_t:
 
 submodule = submodule_t()
 # formatting
+format_procs = []
 for x in all_files:
-    subprocess.Popen(
-        f"python -m dos2unix {str(x)} {str(x)}",
-        shell=True,
-        stdout=open(os.devnull, "wb"),
+    dos2unix = f"python -m dos2unix {str(x)} {str(x)}"
+    clang_format = f"clang-format -style=file -i {str(x)}"
+    # One process to avoid race conditions.
+    cmd = f"{dos2unix} && {clang_format}"
+    format_procs.append(
+        subprocess.Popen(cmd, shell=True, stdout=open(os.devnull, "wb"))
     )
-    cmd = f"clang-format -style=file -i {str(x)}"
-    # for xp in x.parents:
-    # print(get_file_base(x))
-    subprocess.Popen(cmd, shell=True)
     submodule.push(x)
 
-submodule.gen()
+# Wait for formatting to complete before generating headers.
+for p in format_procs:
+    p.wait()
 
-# print(all_files)
+submodule.gen()


### PR DESCRIPTION
## Proposed changes

Fixes a race condition in the remod script run by pre-commit that occasionally leads to truncated files.
See [failed](https://github.com/ROCm/composable_kernel/actions/runs/18646706251/job/53155425942) and [successful](https://github.com/ROCm/composable_kernel/actions/runs/18646706251/job/53155611989) runs for the same commit as an example.

The fix consists of two parts:
1. Making sure that `dos2unix` is run before `clang-format` for a given file.
2. Waiting for all subprocesses to finish before generating headers (`include`) or exiting (`examples`).

Thanks @DDEle for bringing this to my attention!

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

