### PR TITLE
[CK_TILE] Add Bquant to Grouped Gemm

### DIFF
--- a/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.cpp
+++ b/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.cpp
@@ -69,9 +69,9 @@ float grouped_gemm_tileloop(const ck_tile::stream_config& s,
 
         using QuantGemmProblem = typename std::conditional<
             QuantMode == ck_tile::QuantType::BQuantGrouped,
-            ck_tile::GemmBQuantPipelineProblem<ck_tile::fp8_t,
-                                               ck_tile::fp8_t,
-                                               BQDataType, // Qdatatype
+            ck_tile::GemmBQuantPipelineProblem<ADataType,
+                                               BDataType,
+                                               BQDataType,
                                                AccDataType,
                                                GemmShape,
                                                GemmUniversalTraits,

--- a/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.cpp
+++ b/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.cpp
@@ -29,7 +29,7 @@ template <typename GemmConfig,
           typename BQDataType,
           typename AccDataType,
           typename CDataType,
-          ck_tile::QuantType QuantMode>
+          ck_tile::QuantType QuantMode = ck_tile::QuantType::BQuantGrouped>
 float grouped_gemm_tileloop(const ck_tile::stream_config& s,
                             const ck_tile::index_t num_groups,
                             void* kargs_ptr)

--- a/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.cpp
+++ b/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.cpp
@@ -48,8 +48,8 @@ float grouped_gemm_tileloop(const ck_tile::stream_config& s,
     using GemmUniversalTraits = ck_tile::TileGemmQuantTraits<GemmConfig::kPadM,
                                                              GemmConfig::kPadN,
                                                              GemmConfig::kPadK,
-                                                             false,
-                                                             false,
+                                                             false, // PreshuffleQuant
+                                                             false, // PreshuffleB
                                                              ALayout,
                                                              BLayout,
                                                              CLayout,
@@ -67,18 +67,29 @@ float grouped_gemm_tileloop(const ck_tile::stream_config& s,
         constexpr auto memory_operation = memory_operation_.value;
         constexpr bool transpose_c      = false;
 
-        using QuantGemmProblem = ck_tile::GemmRowColTensorQuantPipelineProblem<ADataType,
-                                                                               BDataType,
-                                                                               AccDataType,
-                                                                               AccDataType,
-                                                                               GemmShape,
-                                                                               GemmUniversalTraits,
-                                                                               transpose_c,
-                                                                               BDataType,
-                                                                               scheduler>;
+        using QuantGemmProblem = typename std::conditional<
+            QuantMode == ck_tile::QuantType::BQuantGrouped,
+            ck_tile::GemmBQuantPipelineProblem<ck_tile::fp8_t,
+                                               ck_tile::fp8_t,
+                                               BQDataType, // Qdatatype
+                                               AccDataType,
+                                               GemmShape,
+                                               GemmUniversalTraits,
+                                               128>, // QuantGroupSize
+            ck_tile::GemmRowColTensorQuantPipelineProblem<ADataType,
+                                                          BDataType,
+                                                          AccDataType,
+                                                          AccDataType,
+                                                          GemmShape,
+                                                          GemmUniversalTraits,
+                                                          transpose_c,
+                                                          BDataType,
+                                                          scheduler>>::type;
 
-        using GemmPipeline = typename PipelineTypeTraits<
-            GemmConfig::Pipeline>::template GemmPipeline<QuantGemmProblem>;
+        using GemmPipeline =
+            typename std::conditional<QuantMode == ck_tile::QuantType::BQuantGrouped,
+                                      ck_tile::BQuantGemmPipelineAgBgCrCompV3<QuantGemmProblem>,
+                                      ck_tile::GemmPipelineAgBgCrCompV3<QuantGemmProblem>>::type;
         using GemmEpilogue = ck_tile::CShuffleEpilogue<
             ck_tile::CShuffleEpilogueProblem<ADataType,
                                              BDataType,

--- a/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.hpp
+++ b/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.hpp
@@ -141,7 +141,7 @@ template <typename GemmConfig,
           typename BQDataType,
           typename AccDataType,
           typename CDataType,
-          ck_tile::QuantType QuantMode = ck_tile::QuantType::BQuantGrouped>
+          ck_tile::QuantType QuantMode>
 float grouped_gemm_tileloop(const ck_tile::stream_config& s,
                             const ck_tile::index_t num_groups,
                             void* kargs_ptr);

--- a/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.hpp
+++ b/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.hpp
@@ -11,6 +11,7 @@
 #include "ck_tile/ops/elementwise/unary_element_wise_operation.hpp"
 
 #define CK_TILE_PIPELINE_COMPUTE_V3 1
+#define CK_TILE_PIPELINE_BQUANT_COMPUTE_V3 2
 
 template <typename PrecType, ck_tile::index_t M_Warp_Tile>
 constexpr ck_tile::index_t get_k_warp_tile()
@@ -77,22 +78,9 @@ struct GemmConfigComputeV3_2 : public GemmConfigBase
     static constexpr ck_tile::index_t N_Warp_Tile = 32;
     static constexpr ck_tile::index_t K_Warp_Tile = get_k_warp_tile<PrecType, M_Warp_Tile>();
 
-    static constexpr bool DoubleSmemBuffer     = false;
-    static constexpr ck_tile::index_t Pipeline = CK_TILE_PIPELINE_COMPUTE_V3;
+    static constexpr bool DoubleSmemBuffer = false;
 
     static constexpr int kBlockPerCu = 1;
-};
-
-template <ck_tile::index_t PipelineId>
-struct PipelineTypeTraits;
-
-template <>
-struct PipelineTypeTraits<CK_TILE_PIPELINE_COMPUTE_V3>
-{
-    template <typename PipelineProblem>
-    using GemmPipeline = ck_tile::GemmPipelineAgBgCrCompV3<PipelineProblem>;
-    template <typename PipelineProblem>
-    using UniversalGemmPipeline = ck_tile::BaseGemmPipelineAgBgCrCompV3<PipelineProblem>;
 };
 
 using grouped_gemm_kargs = ck_tile::QuantGroupedGemmHostArgs;
@@ -122,7 +110,7 @@ auto create_args(int argc, char* argv[])
         .insert("repeat", "100", "number of iterations to benchmark the kernel.")
         .insert("group_count", "8", "group count.")
         .insert("kbatch", "1", "kbatch for SplitK")
-        .insert("quant_mode", "tensor", "Choose tensor (default), or rowcol");
+        .insert("quant_mode", "bquant", "Choose bquant (default), tensor, or rowcol");
     ;
 
     bool result = arg_parser.parse(argc, argv);

--- a/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.hpp
+++ b/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.hpp
@@ -141,7 +141,7 @@ template <typename GemmConfig,
           typename BQDataType,
           typename AccDataType,
           typename CDataType,
-          ck_tile::QuantType QuantMode>
+          ck_tile::QuantType QuantMode = ck_tile::QuantType::BQuantGrouped>
 float grouped_gemm_tileloop(const ck_tile::stream_config& s,
                             const ck_tile::index_t num_groups,
                             void* kargs_ptr);

--- a/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.hpp
+++ b/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.hpp
@@ -42,6 +42,14 @@ struct GemmTypeConfig<ck_tile::fp8_t>
     using AccDataType = float;
     using CDataType   = ck_tile::half_t;
 };
+template <>
+struct GemmTypeConfig<ck_tile::bf8_t>
+{
+    using ADataType   = ck_tile::bf8_t;
+    using BDataType   = ck_tile::bf8_t;
+    using AccDataType = float;
+    using CDataType   = ck_tile::half_t;
+};
 
 struct GemmConfigBase
 {

--- a/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.hpp
+++ b/example/ck_tile/17_grouped_gemm/quant_grouped_gemm.hpp
@@ -111,7 +111,6 @@ auto create_args(int argc, char* argv[])
         .insert("group_count", "8", "group count.")
         .insert("kbatch", "1", "kbatch for SplitK")
         .insert("quant_mode", "bquant", "Choose bquant (default), tensor, or rowcol");
-    ;
 
     bool result = arg_parser.parse(argc, argv);
     return std::make_tuple(result, arg_parser);

--- a/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.inc
+++ b/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.inc
@@ -264,7 +264,6 @@ int run_grouped_gemm_example_with_layouts(int argc,
                 throw std::runtime_error("K must be divisible by 128 for BQuantGrouped mode");
             }
         }
-        
 
         stride_As[i] = ck_tile::get_default_stride(M, K, stride_As[i], is_row_major(a_layout));
         stride_Bs[i] = ck_tile::get_default_stride(K, N, stride_Bs[i], is_row_major(b_layout));

--- a/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.inc
+++ b/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.inc
@@ -159,11 +159,12 @@ int run_grouped_gemm_example_with_layouts(int argc,
         return group_count != 0 && ((args.size() == static_cast<size_t>(group_count)) && ...);
     };
 
-    const int group_count = arg_parser.get_int("group_count");
-    const int repeat      = arg_parser.get_int("repeat");
-    const int warmup      = arg_parser.get_int("warmup");
-    const int kbatch      = arg_parser.get_int("kbatch");
-    bool validate         = arg_parser.get_bool("validate");
+    const int group_count                 = arg_parser.get_int("group_count");
+    const int repeat                      = arg_parser.get_int("repeat");
+    const int warmup                      = arg_parser.get_int("warmup");
+    const int kbatch                      = arg_parser.get_int("kbatch");
+    bool validate                         = arg_parser.get_bool("validate");
+    const ck_tile::index_t QuantGroupSize = 128;
 
     if(kbatch > 1 && validate && warmup + repeat > 1)
     {
@@ -172,9 +173,11 @@ int run_grouped_gemm_example_with_layouts(int argc,
         validate = false;
     }
 
-    std::vector<ck_tile::index_t> Ms         = arg_parser.get_int_vec("Ms");
-    std::vector<ck_tile::index_t> Ns         = arg_parser.get_int_vec("Ns");
-    std::vector<ck_tile::index_t> Ks         = arg_parser.get_int_vec("Ks");
+    std::vector<ck_tile::index_t> Ms = arg_parser.get_int_vec("Ms");
+    std::vector<ck_tile::index_t> Ns = arg_parser.get_int_vec("Ns");
+    std::vector<ck_tile::index_t> Ks = arg_parser.get_int_vec("Ks");
+    std::vector<ck_tile::index_t> AQs; // dimension of AQ tensor is calculated from A tensor
+    std::vector<ck_tile::index_t> BQs; // dimension of BQ tensor is calculated from B tensor
     std::vector<ck_tile::index_t> stride_As  = arg_parser.get_int_vec("stride_As");
     std::vector<ck_tile::index_t> stride_Bs  = arg_parser.get_int_vec("stride_Bs");
     std::vector<ck_tile::index_t> stride_Cs  = arg_parser.get_int_vec("stride_Cs");
@@ -252,6 +255,15 @@ int run_grouped_gemm_example_with_layouts(int argc,
             AQK = 1; // Row quantization: tensor shape [M, 1] or [1]
             BQK = 1; // Column quantization: tensor shape [1, N] or [1]
         }
+        else if constexpr(QuantMode == ck_tile::QuantType::BQuantGrouped)
+        {
+            AQK = 0;                  // No A quantization
+            BQK = K / QuantGroupSize; // Group quantization: BQK = K / GroupSize
+            if(K % QuantGroupSize != 0)
+            {
+                throw std::runtime_error("K must be divisible by 128 for BQuantGrouped mode");
+            }
+        }
 
         stride_As[i] = ck_tile::get_default_stride(M, K, stride_As[i], is_row_major(a_layout));
         stride_Bs[i] = ck_tile::get_default_stride(K, N, stride_Bs[i], is_row_major(b_layout));
@@ -288,6 +300,13 @@ int run_grouped_gemm_example_with_layouts(int argc,
                 ck_tile::host_tensor_descriptor(1, 1, stride_AQs[i], is_row_major(aq_layout))));
             bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(
                 ck_tile::host_tensor_descriptor(1, 1, stride_BQs[i], is_row_major(bq_layout))));
+        }
+        else if constexpr(QuantMode == ck_tile::QuantType::BQuantGrouped)
+        {
+            aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(
+                ck_tile::host_tensor_descriptor(0, AQK, stride_AQs[i], is_row_major(aq_layout))));
+            bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(
+                ck_tile::host_tensor_descriptor(BQK, N, stride_BQs[i], is_row_major(bq_layout))));
         }
 
         std::cout << "gemm[" << i << "]" << " a_m_k: " << a_m_k_tensors[i].mDesc
@@ -394,6 +413,17 @@ int run_grouped_gemm_example_with_layouts(int argc,
                                                                 bq_tensors[i],
                                                                 c_m_n_host_ref);
             }
+            else if constexpr(QuantMode == ck_tile::QuantType::BQuantGrouped)
+            {
+                ck_tile::reference_gemm_quant<ADataType,
+                                              AQDataType,
+                                              BDataType,
+                                              AccDataType,
+                                              CDataType,
+                                              QuantGroupSize,
+                                              false>(
+                    a_m_k_tensors[i], bq_tensors[i], b_k_n_tensors[i], c_m_n_host_ref);
+            }
 
             const float max_accumulated_value =
                 *std::max_element(c_m_n_host_ref.mData.begin(), c_m_n_host_ref.mData.end());
@@ -441,42 +471,6 @@ int run_gemm_example_prec_type(std::string a_layout, std::string b_layout, int a
                                                      QuantMode>(
             argc, argv, Row{}, Row{}, Col{}, Col{}, Row{});
     }
-    else if(a_layout == "R" && b_layout == "R")
-    {
-        return run_grouped_gemm_example_with_layouts<GemmConfig,
-                                                     ADataType,
-                                                     AQDataType,
-                                                     BDataType,
-                                                     BQDataType,
-                                                     CDataType,
-                                                     AccDataType,
-                                                     QuantMode>(
-            argc, argv, Row{}, Row{}, Row{}, Col{}, Row{});
-    }
-    else if(a_layout == "C" && b_layout == "R")
-    {
-        return run_grouped_gemm_example_with_layouts<GemmConfig,
-                                                     ADataType,
-                                                     AQDataType,
-                                                     BDataType,
-                                                     BQDataType,
-                                                     CDataType,
-                                                     AccDataType,
-                                                     QuantMode>(
-            argc, argv, Row{}, Row{}, Col{}, Col{}, Row{});
-    }
-    else if(a_layout == "C" && b_layout == "C")
-    {
-        return run_grouped_gemm_example_with_layouts<GemmConfig,
-                                                     ADataType,
-                                                     AQDataType,
-                                                     BDataType,
-                                                     BQDataType,
-                                                     CDataType,
-                                                     AccDataType,
-                                                     QuantMode>(
-            argc, argv, Col{}, Col{}, Col{}, Col{}, Row{});
-    }
     else
     {
         throw std::runtime_error("Unsupported data layout configuration for A,B and C tensors!");
@@ -511,6 +505,13 @@ int run_grouped_gemm_example(int argc, char* argv[])
             return run_gemm_example_prec_type<GemmConfig<ck_tile::fp8_t>,
                                               ck_tile::fp8_t,
                                               ck_tile::QuantType::RowColQuant>(
+                a_layout, b_layout, argc, argv);
+        }
+        else if(quant_mode == "bquant")
+        {
+            return run_gemm_example_prec_type<GemmConfig<ck_tile::fp8_t>,
+                                              ck_tile::fp8_t,
+                                              ck_tile::QuantType::BQuantGrouped>(
                 a_layout, b_layout, argc, argv);
         }
         else

--- a/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.inc
+++ b/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.inc
@@ -264,6 +264,7 @@ int run_grouped_gemm_example_with_layouts(int argc,
                 throw std::runtime_error("K must be divisible by 128 for BQuantGrouped mode");
             }
         }
+        
 
         stride_As[i] = ck_tile::get_default_stride(M, K, stride_As[i], is_row_major(a_layout));
         stride_Bs[i] = ck_tile::get_default_stride(K, N, stride_Bs[i], is_row_major(b_layout));

--- a/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.inc
+++ b/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.inc
@@ -520,6 +520,34 @@ int run_grouped_gemm_example(int argc, char* argv[])
             throw std::runtime_error("Unsupported quantization mode!");
         }
     }
+    if(data_type == "bf8")
+    {
+        if(quant_mode == "tensor")
+        {
+            return run_gemm_example_prec_type<GemmConfig<ck_tile::bf8_t>,
+                                              ck_tile::bf8_t,
+                                              ck_tile::QuantType::TensorQuant>(
+                a_layout, b_layout, argc, argv);
+        }
+        else if(quant_mode == "rowcol")
+        {
+            return run_gemm_example_prec_type<GemmConfig<ck_tile::bf8_t>,
+                                              ck_tile::bf8_t,
+                                              ck_tile::QuantType::RowColQuant>(
+                a_layout, b_layout, argc, argv);
+        }
+        else if(quant_mode == "bquant")
+        {
+            return run_gemm_example_prec_type<GemmConfig<ck_tile::bf8_t>,
+                                              ck_tile::bf8_t,
+                                              ck_tile::QuantType::BQuantGrouped>(
+                a_layout, b_layout, argc, argv);
+        }
+        else
+        {
+            throw std::runtime_error("Unsupported quantization mode!");
+        }
+    }
     else
     {
         throw std::runtime_error("Unsupported data type configuration.");

--- a/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.inc
+++ b/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.inc
@@ -43,8 +43,8 @@ template <typename GemmConfig,
           typename BLayout,
           typename BQLayout,
           typename CLayout,
-          ck_tile::QuantType QuantMode,
-          typename CDEElementWise = ck_tile::element_wise::PassThrough>
+          ck_tile::QuantType QuantMode = ck_tile::QuantType::BQuantGrouped,
+          typename CDEElementWise      = ck_tile::element_wise::PassThrough>
 float invoke_gemm(int n_warmup,
                   int n_repeat,
                   int group_count,

--- a/include/ck_tile/ops/gemm_quant/kernel/grouped_gemm_quant_kernel.hpp
+++ b/include/ck_tile/ops/gemm_quant/kernel/grouped_gemm_quant_kernel.hpp
@@ -379,9 +379,16 @@ struct QuantGroupedGemmKernel
         {
             const auto& bq_block_window = gemm_tile_windows.at(Base::I3);
             // Run GEMM pipeline
-            const auto& c_block_tile = GemmPipeline{}.template operator()(
-                a_block_window, b_block_window, bq_block_window, num_loop, smem_ptr_0);
+            const auto& c_block_tile = GemmPipeline{}.template operator()(a_block_window,
+                                                                          b_block_window,
+                                                                          bq_block_window,
+                                                                          num_loop,
+                                                                          has_hot_loop,
+                                                                          tail_num,
+                                                                          smem_ptr_0);
+
             auto& c_block_window = gemm_tile_windows.at(Base::I4);
+
             // Run Epilogue Pipeline
             EpiloguePipeline{}(c_block_window, c_block_tile, c_block_window, smem_ptr_0);
         }

--- a/include/ck_tile/ops/gemm_quant/kernel/grouped_gemm_quant_kernel.hpp
+++ b/include/ck_tile/ops/gemm_quant/kernel/grouped_gemm_quant_kernel.hpp
@@ -396,15 +396,12 @@ struct QuantGroupedGemmKernel
             {
                 const auto& aq_block_window = gemm_tile_windows.at(Base::I1);
                 const auto& bq_block_window = gemm_tile_windows.at(Base::I3);
-                EpiloguePipeline{}
-                    .template operator()<decltype(c_block_window),
-                                         decltype(c_block_tile),
-                                         decltype(c_block_window)>(c_block_window,
-                                                                   c_block_tile,
-                                                                   c_block_window,
-                                                                   smem_ptr_0,
-                                                                   aq_block_window,
-                                                                   bq_block_window);
+                EpiloguePipeline{}(c_block_window,
+                                   c_block_tile,
+                                   c_block_window,
+                                   smem_ptr_0,
+                                   aq_block_window,
+                                   bq_block_window);
             }
             else if constexpr(kQuantType == QuantType::TensorQuant)
             {

--- a/include/ck_tile/ops/gemm_quant/kernel/grouped_gemm_quant_kernel.hpp
+++ b/include/ck_tile/ops/gemm_quant/kernel/grouped_gemm_quant_kernel.hpp
@@ -414,13 +414,6 @@ struct QuantGroupedGemmKernel
                     c_block_window, c_block_tile, c_block_window, smem_ptr_0, aq_scale, bq_scale);
             }
         }
-        else if constexpr(kQuantType == QuantType::TensorQuant)
-        {
-            const AccDataType aq_scale = type_convert<AccDataType>(*aq_ptr);
-            const AccDataType bq_scale = type_convert<AccDataType>(*bq_ptr);
-            EpiloguePipeline{}(
-                c_block_window, c_block_tile, c_block_window, smem_ptr_0, aq_scale, bq_scale);
-        }
     }
 
     // For persistent kernels

--- a/include/ck_tile/ops/gemm_quant/kernel/grouped_gemm_quant_kernel.hpp
+++ b/include/ck_tile/ops/gemm_quant/kernel/grouped_gemm_quant_kernel.hpp
@@ -375,30 +375,44 @@ struct QuantGroupedGemmKernel
         const bool has_hot_loop   = GemmPipeline::BlockHasHotloop(num_loop);
         const TailNumber tail_num = GemmPipeline::GetBlockLoopTailNum(num_loop);
 
-        // Run GEMM pipeline
-        const auto& c_block_tile = GemmPipeline{}.template operator()(
-            a_block_window, b_block_window, num_loop, has_hot_loop, tail_num, smem_ptr_0);
-        // Run Epilogue Pipeline
-        auto& c_block_window = gemm_tile_windows.at(Base::I4);
-        if constexpr(kQuantType == QuantType::RowColQuant)
+        if constexpr(kQuantType == QuantType::BQuantGrouped)
         {
-            const auto& aq_block_window = gemm_tile_windows.at(Base::I1);
             const auto& bq_block_window = gemm_tile_windows.at(Base::I3);
-            EpiloguePipeline{}.template
-            operator()<decltype(c_block_window), decltype(c_block_tile), decltype(c_block_window)>(
-                c_block_window,
-                c_block_tile,
-                c_block_window,
-                smem_ptr_0,
-                aq_block_window,
-                bq_block_window);
+            // Run GEMM pipeline
+            const auto& c_block_tile = GemmPipeline{}.template operator()(
+                a_block_window, b_block_window, bq_block_window, num_loop, smem_ptr_0);
+            auto& c_block_window = gemm_tile_windows.at(Base::I4);
+            // Run Epilogue Pipeline
+            EpiloguePipeline{}(c_block_window, c_block_tile, c_block_window, smem_ptr_0);
         }
-        else if constexpr(kQuantType == QuantType::TensorQuant)
+        else
         {
-            const AccDataType aq_scale = type_convert<AccDataType>(*aq_ptr);
-            const AccDataType bq_scale = type_convert<AccDataType>(*bq_ptr);
-            EpiloguePipeline{}(
-                c_block_window, c_block_tile, c_block_window, smem_ptr_0, aq_scale, bq_scale);
+            // Run GEMM pipeline
+            const auto& c_block_tile = GemmPipeline{}.template operator()(
+                a_block_window, b_block_window, num_loop, has_hot_loop, tail_num, smem_ptr_0);
+            // Run Epilogue Pipeline
+            auto& c_block_window = gemm_tile_windows.at(Base::I4);
+            if constexpr(kQuantType == QuantType::RowColQuant)
+            {
+                const auto& aq_block_window = gemm_tile_windows.at(Base::I1);
+                const auto& bq_block_window = gemm_tile_windows.at(Base::I3);
+                EpiloguePipeline{}
+                    .template operator()<decltype(c_block_window),
+                                         decltype(c_block_tile),
+                                         decltype(c_block_window)>(c_block_window,
+                                                                   c_block_tile,
+                                                                   c_block_window,
+                                                                   smem_ptr_0,
+                                                                   aq_block_window,
+                                                                   bq_block_window);
+            }
+            else if constexpr(kQuantType == QuantType::TensorQuant)
+            {
+                const AccDataType aq_scale = type_convert<AccDataType>(*aq_ptr);
+                const AccDataType bq_scale = type_convert<AccDataType>(*bq_ptr);
+                EpiloguePipeline{}(
+                    c_block_window, c_block_tile, c_block_window, smem_ptr_0, aq_scale, bq_scale);
+            }
         }
     }
 

--- a/include/ck_tile/ops/gemm_quant/kernel/grouped_gemm_quant_kernel.hpp
+++ b/include/ck_tile/ops/gemm_quant/kernel/grouped_gemm_quant_kernel.hpp
@@ -414,6 +414,13 @@ struct QuantGroupedGemmKernel
                     c_block_window, c_block_tile, c_block_window, smem_ptr_0, aq_scale, bq_scale);
             }
         }
+        else if constexpr(kQuantType == QuantType::TensorQuant)
+        {
+            const AccDataType aq_scale = type_convert<AccDataType>(*aq_ptr);
+            const AccDataType bq_scale = type_convert<AccDataType>(*bq_ptr);
+            EpiloguePipeline{}(
+                c_block_window, c_block_tile, c_block_window, smem_ptr_0, aq_scale, bq_scale);
+        }
     }
 
     // For persistent kernels

--- a/include/ck_tile/ops/gemm_quant/pipeline/gemm_bquant_pipeline_ag_bg_cr_v3.hpp
+++ b/include/ck_tile/ops/gemm_quant/pipeline/gemm_bquant_pipeline_ag_bg_cr_v3.hpp
@@ -470,6 +470,49 @@ struct BQuantGemmPipelineAgBgCrCompV3 : public BaseBQuantGemmPipelineAgBgCrCompV
             num_loop,
             p_smem);
     }
+
+    /// @brief Runtime pipeline dispatch operator for grouped GEMM kernels.
+    ///
+    /// This operator is used by grouped GEMM kernels where pipeline parameters
+    /// (has_hot_loop, num_loop, tail_number) are calculated on the device side
+    /// at runtime, not on the host side during compilation. This is necessary
+    /// because different GEMM problems in the group may have different K dimensions,
+    /// requiring different pipeline configurations that cannot be determined at
+    /// compile time.
+    ///
+    /// @param a_dram_block_window_tmp Block window for A tensor in DRAM
+    /// @param b_dram_block_window_tmp Block window for B tensor in DRAM
+    /// @param bq_dram_block_window_tmp Block window for BQ (quantization scale) tensor in DRAM
+    /// @param num_loop Number of main loop iterations (calculated on device)
+    /// @param has_hot_loop Whether the pipeline has a hot loop (calculated on device)
+    /// @param tail_number Type of tail handling required (calculated on device)
+    /// @param p_smem Pointer to shared memory
+    /// @return Accumulated result tile in registers
+    template <typename ADramBlockWindowTmp,
+              typename BDramBlockWindowTmp,
+              typename BQDramBlockWindowTmp>
+    CK_TILE_DEVICE auto operator()(const ADramBlockWindowTmp& a_dram_block_window_tmp,
+                                   const BDramBlockWindowTmp& b_dram_block_window_tmp,
+                                   const BQDramBlockWindowTmp& bq_dram_block_window_tmp,
+                                   index_t num_loop,
+                                   bool has_hot_loop,
+                                   TailNumber tail_number,
+                                   void* p_smem) const
+    {
+        const auto RunPipeline = [&](auto has_hot_loop_, auto tail_number_) {
+            constexpr bool hot_loop = has_hot_loop_.value;
+            constexpr auto tail_num = tail_number_.value;
+            return PipelineImpl<Scheduler>{}.template operator()<hot_loop, tail_num>(
+                a_dram_block_window_tmp,
+                [](const ADataType& a) { return a; },
+                b_dram_block_window_tmp,
+                [](const BDataType& b) { return b; },
+                bq_dram_block_window_tmp,
+                num_loop,
+                p_smem);
+        };
+        return Base::TailHandler(RunPipeline, has_hot_loop, tail_number);
+    }
 };
 
 } // namespace ck_tile

--- a/test/ck_tile/grouped_gemm/test_grouped_gemm_util.hpp
+++ b/test/ck_tile/grouped_gemm/test_grouped_gemm_util.hpp
@@ -14,7 +14,7 @@
 #include "ck_tile/ops/elementwise/unary_element_wise_operation.hpp"
 
 template <typename Tuple>
-class TestCkTileGroupedGemmQuant : public ::testing::Test
+class TestCkTileGroupedGemm : public ::testing::Test
 {
     protected:
     using ALayout     = std::tuple_element_t<0, Tuple>;

--- a/test/ck_tile/grouped_gemm/test_grouped_gemm_util.hpp
+++ b/test/ck_tile/grouped_gemm/test_grouped_gemm_util.hpp
@@ -14,7 +14,7 @@
 #include "ck_tile/ops/elementwise/unary_element_wise_operation.hpp"
 
 template <typename Tuple>
-class TestCkTileGroupedGemm : public ::testing::Test
+class TestCkTileGroupedGemmQuant : public ::testing::Test
 {
     protected:
     using ALayout     = std::tuple_element_t<0, Tuple>;

--- a/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_quant.cpp
+++ b/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_quant.cpp
@@ -32,12 +32,10 @@ using KernelTypes = ::testing::Types<
     std::tuple<    Col,     Col,     Row,       BF8,        F32,       BF8,        F32,         F32,       F16, RowColQuant>,
     std::tuple<    Row,     Row,     Row,       BF8,        F32,       BF8,        F32,         F32,       F16, RowColQuant>,
     std::tuple<    Col,     Row,     Row,       BF8,        F32,       BF8,        F32,         F32,       F16, RowColQuant>,
-
     std::tuple<    Row,     Col,     Row,       FP8,        F32,       FP8,        F32,         F32,       F16, TensorQuant>,
     std::tuple<    Col,     Col,     Row,       FP8,        F32,       FP8,        F32,         F32,       F16, TensorQuant>,
     std::tuple<    Row,     Row,     Row,       FP8,        F32,       FP8,        F32,         F32,       F16, TensorQuant>,
     std::tuple<    Col,     Row,     Row,       FP8,        F32,       FP8,        F32,         F32,       F16, TensorQuant>,
-
     std::tuple<    Row,     Col,     Row,       BF8,        F32,       BF8,        F32,         F32,       F16, TensorQuant>,
     std::tuple<    Col,     Col,     Row,       BF8,        F32,       BF8,        F32,         F32,       F16, TensorQuant>,
     std::tuple<    Row,     Row,     Row,       BF8,        F32,       BF8,        F32,         F32,       F16, TensorQuant>,

--- a/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_quant.cpp
+++ b/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_quant.cpp
@@ -18,6 +18,7 @@ using True        = ck_tile::bool_constant<true>;
 using False       = ck_tile::bool_constant<false>;
 using RowColQuant = std::integral_constant<ck_tile::QuantType, ck_tile::QuantType::RowColQuant>;
 using TensorQuant = std::integral_constant<ck_tile::QuantType, ck_tile::QuantType::TensorQuant>;
+using BQuant      = std::integral_constant<ck_tile::QuantType, ck_tile::QuantType::BQuantGrouped>;
 
 // clang-format off
 using KernelTypes = ::testing::Types<
@@ -40,7 +41,9 @@ using KernelTypes = ::testing::Types<
     std::tuple<    Row,     Col,     Row,       BF8,        F32,       BF8,        F32,         F32,       F16, TensorQuant>,
     std::tuple<    Col,     Col,     Row,       BF8,        F32,       BF8,        F32,         F32,       F16, TensorQuant>,
     std::tuple<    Row,     Row,     Row,       BF8,        F32,       BF8,        F32,         F32,       F16, TensorQuant>,
-    std::tuple<    Col,     Row,     Row,       BF8,        F32,       BF8,        F32,         F32,       F16, TensorQuant>
+    std::tuple<    Col,     Row,     Row,       BF8,        F32,       BF8,        F32,         F32,       F16, TensorQuant>,
+    std::tuple<    Row,     Col,     Row,       FP8,        F32,       FP8,        F32,         F32,       F16, BQuant>,
+    std::tuple<    Row,     Col,     Row,       BF8,        F32,       BF8,        F32,         F32,       F16, BQuant>
     >;
 // clang-format on
 

--- a/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_quant_ut_cases.inc
+++ b/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_quant_ut_cases.inc
@@ -26,3 +26,32 @@ TYPED_TEST(TestCkTileGroupedGemmQuant, Basic)
 
     this->Run(Ms, Ns, Ks, stride_As, stride_Bs, stride_Cs, stride_AQs, stride_BQs, group_count);
 }
+
+// No Hot Loop Test Case, this is to test the correctness of the kernel when there is no hot loop
+// Using 256x256x128 to match the test kernel's tile size (M_Tile=256, N_Tile=256, K_Tile=128)
+TYPED_TEST(TestCkTileGroupedGemmQuant, SmallUniform) //
+{
+    const int group_count = 2;
+    std::vector<int> Ms;
+    std::vector<int> Ns;
+    std::vector<int> Ks;
+    std::vector<int> stride_As;
+    std::vector<int> stride_Bs;
+    std::vector<int> stride_Cs;
+    std::vector<int> stride_AQs;
+    std::vector<int> stride_BQs;
+    for(int i = 0; i < group_count; i++)
+    {
+        Ms.push_back(256);
+        Ns.push_back(256);
+        Ks.push_back(256);
+
+        stride_As.push_back(0);
+        stride_Bs.push_back(0);
+        stride_Cs.push_back(0);
+        stride_AQs.push_back(0);
+        stride_BQs.push_back(0);
+    }
+
+    this->Run(Ms, Ns, Ks, stride_As, stride_Bs, stride_Cs, stride_AQs, stride_BQs, group_count);
+}

--- a/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
+++ b/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
@@ -218,7 +218,7 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
     {
         ck_tile::index_t AQK, BQK;
         using namespace ck_tile::literals;
-        
+
         std::vector<ck_tile::HostTensor<ADataType>> a_m_k_tensors;
         std::vector<ck_tile::HostTensor<BDataType>> b_k_n_tensors;
         std::vector<ck_tile::HostTensor<CDataType>> c_m_n_tensors;

--- a/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
+++ b/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
@@ -107,7 +107,15 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
             constexpr bool transpose_c      = false;
             // We create the GEMM pipeline without specifying hotloop or tailnumber.
             // These are automatically run inside the kernel based on the given input data.
-            using QuantGemmProblem =
+            using QuantGemmProblem = typename std::conditional<
+                QuantType == ck_tile::QuantType::BQuantGrouped,
+                ck_tile::GemmBQuantPipelineProblem<ADataType,
+                                                   BDataType,
+                                                   BQDataType,
+                                                   AccDataType,
+                                                   GemmShape,
+                                                   GemmUniversalTraits,
+                                                   128>, // QuantGroupSize
                 ck_tile::GemmRowColTensorQuantPipelineProblem<ADataType,
                                                               BDataType,
                                                               AccDataType,
@@ -116,9 +124,13 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
                                                               GemmUniversalTraits,
                                                               transpose_c,
                                                               BDataType,
-                                                              scheduler>;
+                                                              scheduler>>::type;
 
-            using GemmPipeline = ck_tile::GemmPipelineAgBgCrCompV3<QuantGemmProblem>;
+            using GemmPipeline = typename std::conditional<
+                QuantType == ck_tile::QuantType::BQuantGrouped,
+                ck_tile::BQuantGemmPipelineAgBgCrCompV3<QuantGemmProblem>,
+                ck_tile::GemmPipelineAgBgCrCompV3<QuantGemmProblem>>::type;
+
             using GemmEpilogue = ck_tile::CShuffleEpilogue<
                 ck_tile::CShuffleEpilogueProblem<ADataType,
                                                  BDataType,
@@ -244,6 +256,15 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
                 AQK = 1; // Row quantization: tensor shape [M, 1] or [1]
                 BQK = 1; // Column quantization: tensor shape [1, N] or [1]
             }
+            else if constexpr(QuantType == ck_tile::QuantType::BQuantGrouped)
+            {
+                AQK = 0;       // No A quantization
+                BQK = K / 128; // Group quantization: BQK = K / GroupSize
+                if(K % 128 != 0)
+                {
+                    throw std::runtime_error("K must be divisible by 128 for BQuantGrouped mode");
+                }
+            }
 
             stride_As[i] = ck_tile::get_default_stride(M, K, stride_As[i], is_row_major(ALayout{}));
             stride_Bs[i] = ck_tile::get_default_stride(K, N, stride_Bs[i], is_row_major(BLayout{}));
@@ -259,6 +280,12 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
             {
                 stride_AQs[i] = 1; // Tensor quantization: tensor shape [1]
                 stride_AQs[i] = 1; // Tensor quantization: tensor shape [1]
+            }
+            else if constexpr(QuantType == ck_tile::QuantType::BQuantGrouped)
+            {
+                stride_AQs[i] = 0; // No A quantization
+                stride_BQs[i] =
+                    ck_tile::get_default_stride(BQK, N, stride_BQs[i], is_row_major(BQLayout()));
             }
 
             a_m_k_tensors.push_back(ck_tile::HostTensor<ADataType>(
@@ -284,6 +311,15 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
                 bq_tensors.push_back(
                     ck_tile::HostTensor<BQDataType>(ck_tile::host_tensor_descriptor(
                         1, 1, stride_BQs[i], is_row_major(BQLayout()))));
+            }
+            else if constexpr(QuantType == ck_tile::QuantType::BQuantGrouped)
+            {
+                aq_tensors.push_back(
+                    ck_tile::HostTensor<AQDataType>(ck_tile::host_tensor_descriptor(
+                        0, AQK, stride_AQs[i], is_row_major(AQLayout{}))));
+                bq_tensors.push_back(
+                    ck_tile::HostTensor<BQDataType>(ck_tile::host_tensor_descriptor(
+                        BQK, N, stride_BQs[i], is_row_major(BQLayout()))));
             }
 
             std::cout << "gemm[" << i << "]" << " a_m_k: " << a_m_k_tensors[i].mDesc
@@ -418,6 +454,17 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
                                                                 b_k_n_tensors[i],
                                                                 bq_tensors[i],
                                                                 c_m_n_host_ref);
+            }
+            else if constexpr(QuantType == ck_tile::QuantType::BQuantGrouped)
+            {
+                ck_tile::reference_gemm_quant<ADataType,
+                                              AQDataType,
+                                              BDataType,
+                                              AccDataType,
+                                              CDataType,
+                                              128,
+                                              false>(
+                    a_m_k_tensors[i], bq_tensors[i], b_k_n_tensors[i], c_m_n_host_ref);
             }
 
             const float max_accumulated_value =

--- a/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
+++ b/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
@@ -379,7 +379,7 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
         }
         else
         {
-            throw std::runtime_error("Non-persistent kernel not implemented yet");
+            GTEST_FAIL() << "Non-persistent kernel not implemented yet";
         }
 
         // Copy results back to host for validation

--- a/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
+++ b/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
@@ -279,7 +279,7 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
             else if constexpr(QuantType == ck_tile::QuantType::TensorQuant)
             {
                 stride_AQs[i] = 1; // Tensor quantization: tensor shape [1]
-                stride_AQs[i] = 1; // Tensor quantization: tensor shape [1]
+                stride_BQs[i] = 1; // Tensor quantization: tensor shape [1]
             }
             else if constexpr(QuantType == ck_tile::QuantType::BQuantGrouped)
             {

--- a/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
+++ b/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
@@ -17,22 +17,22 @@ template <typename Tuple>
 class TestCkTileGroupedGemmQuant : public ::testing::Test
 {
     protected:
-    using ALayout                    = std::tuple_element_t<0, Tuple>;
-    using BLayout                    = std::tuple_element_t<1, Tuple>;
-    using CLayout                    = std::tuple_element_t<2, Tuple>;
-    using ADataType                  = std::tuple_element_t<3, Tuple>;
-    using AQDataType                 = std::tuple_element_t<4, Tuple>;
-    using BDataType                  = std::tuple_element_t<5, Tuple>;
-    using BQDataType                 = std::tuple_element_t<6, Tuple>;
-    using AccDataType                = std::tuple_element_t<7, Tuple>;
-    using CDataType                  = std::tuple_element_t<8, Tuple>;
-    static constexpr auto QuantType  = std::tuple_element_t<9, Tuple>::value;
-    using DsLayout                   = ck_tile::tuple<>;
-    using DsDataType                 = ck_tile::tuple<>;
-    using Row                        = ck_tile::tensor_layout::gemm::RowMajor;
-    using Col                        = ck_tile::tensor_layout::gemm::ColumnMajor;
-    using AQLayout                   = Row;
-    using BQLayout                   = Col;
+    using ALayout                   = std::tuple_element_t<0, Tuple>;
+    using BLayout                   = std::tuple_element_t<1, Tuple>;
+    using CLayout                   = std::tuple_element_t<2, Tuple>;
+    using ADataType                 = std::tuple_element_t<3, Tuple>;
+    using AQDataType                = std::tuple_element_t<4, Tuple>;
+    using BDataType                 = std::tuple_element_t<5, Tuple>;
+    using BQDataType                = std::tuple_element_t<6, Tuple>;
+    using AccDataType               = std::tuple_element_t<7, Tuple>;
+    using CDataType                 = std::tuple_element_t<8, Tuple>;
+    static constexpr auto QuantType = std::tuple_element_t<9, Tuple>::value;
+    using DsLayout    = ck_tile::tuple<>;
+    using DsDataType  = ck_tile::tuple<>;
+    using Row   = ck_tile::tensor_layout::gemm::RowMajor;
+    using Col   = ck_tile::tensor_layout::gemm::ColumnMajor;
+    using AQLayout = Row;
+    using BQLayout = Col;
     static constexpr bool Persistent = true;
 
     struct GroupedGemKernelParam_Mfma
@@ -59,8 +59,8 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
     std::size_t get_workspace_size(const std::vector<grouped_gemm_kargs>& gemm_descs)
     {
         return gemm_descs.size() * sizeof(ck_tile::QuantGemmTransKernelArg);
-    }
-
+    }   
+    
     template <typename GroupedGemKernelParam, typename ALayout, typename BLayout, typename CLayout>
     void invoke_grouped_gemm_persistent(const ck_tile::stream_config& s,
                                         const ck_tile::index_t num_groups,
@@ -170,7 +170,7 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
     static constexpr inline auto is_row_major(Layout layout_)
     {
         return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                     ck_tile::tensor_layout::gemm::RowMajor>>{};
+                                                    ck_tile::tensor_layout::gemm::RowMajor>>{};
     }
 
     auto calculate_rtol_atol(const ck_tile::index_t K,
@@ -206,7 +206,7 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
     {
         ck_tile::index_t AQK, BQK;
         using namespace ck_tile::literals;
-
+        
         std::vector<ck_tile::HostTensor<ADataType>> a_m_k_tensors;
         std::vector<ck_tile::HostTensor<BDataType>> b_k_n_tensors;
         std::vector<ck_tile::HostTensor<CDataType>> c_m_n_tensors;
@@ -278,12 +278,10 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
             }
             else if constexpr(QuantType == ck_tile::QuantType::TensorQuant)
             {
-                aq_tensors.push_back(
-                    ck_tile::HostTensor<AQDataType>(ck_tile::host_tensor_descriptor(
-                        1, 1, stride_AQs[i], is_row_major(AQLayout{}))));
-                bq_tensors.push_back(
-                    ck_tile::HostTensor<BQDataType>(ck_tile::host_tensor_descriptor(
-                        1, 1, stride_BQs[i], is_row_major(BQLayout()))));
+                aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(
+                    ck_tile::host_tensor_descriptor(1, 1, stride_AQs[i], is_row_major(AQLayout{}))));
+                bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(
+                    ck_tile::host_tensor_descriptor(1, 1, stride_BQs[i], is_row_major(BQLayout()))));
             }
 
             std::cout << "gemm[" << i << "]" << " a_m_k: " << a_m_k_tensors[i].mDesc
@@ -345,7 +343,7 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
         {
             // Generate kernel arguments
             std::vector<ck_tile::QuantGemmTransKernelArg> kargs;
-            void* kargs_ptr = gemm_workspace.GetDeviceBuffer();
+            void* kargs_ptr   = gemm_workspace.GetDeviceBuffer();
             assert(gemm_descs[0].k_batch == 1);
             for(const auto& arg : gemm_descs)
             {
@@ -379,7 +377,7 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
         }
         else
         {
-            GTEST_FAIL() << "Non-persistent kernel not implemented yet";
+            throw std::runtime_error("Non-persistent kernel not implemented yet");
         }
 
         // Copy results back to host for validation
@@ -397,11 +395,11 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
             if constexpr(QuantType == ck_tile::QuantType::RowColQuant)
             {
                 ck_tile::reference_gemm_rowcol_quant<ADataType,
-                                                     AQDataType,
-                                                     BDataType,
-                                                     BQDataType,
-                                                     AccDataType,
-                                                     CDataType>(a_m_k_tensors[i],
+                                                    AQDataType,
+                                                    BDataType,
+                                                    BQDataType,
+                                                    AccDataType,
+                                                    CDataType>(a_m_k_tensors[i],
                                                                 aq_tensors[i],
                                                                 b_k_n_tensors[i],
                                                                 bq_tensors[i],
@@ -410,11 +408,11 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
             else if constexpr(QuantType == ck_tile::QuantType::TensorQuant)
             {
                 ck_tile::reference_gemm_tensor_quant<ADataType,
-                                                     AQDataType,
-                                                     BDataType,
-                                                     BQDataType,
-                                                     AccDataType,
-                                                     CDataType>(a_m_k_tensors[i],
+                                                    AQDataType,
+                                                    BDataType,
+                                                    BQDataType,
+                                                    AccDataType,
+                                                    CDataType>(a_m_k_tensors[i],
                                                                 aq_tensors[i],
                                                                 b_k_n_tensors[i],
                                                                 bq_tensors[i],
@@ -423,19 +421,20 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
 
             const float max_accumulated_value =
                 *std::max_element(c_m_n_host_ref.mData.begin(), c_m_n_host_ref.mData.end());
-            const auto rtol_atol = calculate_rtol_atol(Ks[i], 1, max_accumulated_value);
+            const auto rtol_atol =
+                calculate_rtol_atol(Ks[i], 1, max_accumulated_value);
             pass &= ck_tile::check_err(c_m_n_tensors[i],
-                                       c_m_n_host_ref,
-                                       "Error: Incorrect results!",
-                                       rtol_atol.at(ck_tile::number<0>{}),
-                                       rtol_atol.at(ck_tile::number<1>{}));
+                                    c_m_n_host_ref,
+                                    "Error: Incorrect results!",
+                                    rtol_atol.at(ck_tile::number<0>{}),
+                                    rtol_atol.at(ck_tile::number<1>{}));
             std::cout << "gemm[" << i
-                      << "] Relative error threshold: " << rtol_atol.at(ck_tile::number<0>{})
-                      << " Absolute error threshold: " << rtol_atol.at(ck_tile::number<1>{})
-                      << std::endl;
+                    << "] Relative error threshold: " << rtol_atol.at(ck_tile::number<0>{})
+                    << " Absolute error threshold: " << rtol_atol.at(ck_tile::number<1>{})
+                    << std::endl;
         }
         std::cout << "The CPU verification result is:" << (pass ? "correct" : "fail") << std::endl;
-
+        
         EXPECT_TRUE(pass);
     }
 };

--- a/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
+++ b/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
@@ -206,6 +206,7 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
     {
         ck_tile::index_t AQK, BQK;
         using namespace ck_tile::literals;
+        
         std::vector<ck_tile::HostTensor<ADataType>> a_m_k_tensors;
         std::vector<ck_tile::HostTensor<BDataType>> b_k_n_tensors;
         std::vector<ck_tile::HostTensor<CDataType>> c_m_n_tensors;

--- a/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
+++ b/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
@@ -206,7 +206,6 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
     {
         ck_tile::index_t AQK, BQK;
         using namespace ck_tile::literals;
-
         std::vector<ck_tile::HostTensor<ADataType>> a_m_k_tensors;
         std::vector<ck_tile::HostTensor<BDataType>> b_k_n_tensors;
         std::vector<ck_tile::HostTensor<CDataType>> c_m_n_tensors;

--- a/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
+++ b/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
@@ -373,7 +373,6 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
                                     kargs.size() * sizeof(ck_tile::QuantGemmTransKernelArg),
                                     hipMemcpyHostToDevice,
                                     stream.stream_id_));
-
             invoke_grouped_gemm_persistent<GroupedGemKernelParam_Mfma, ALayout, BLayout, CLayout>(
                 stream, group_count, kargs_ptr);
         }

--- a/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
+++ b/test/ck_tile/grouped_gemm_quant/test_grouped_gemm_util_quant.hpp
@@ -17,22 +17,22 @@ template <typename Tuple>
 class TestCkTileGroupedGemmQuant : public ::testing::Test
 {
     protected:
-    using ALayout                   = std::tuple_element_t<0, Tuple>;
-    using BLayout                   = std::tuple_element_t<1, Tuple>;
-    using CLayout                   = std::tuple_element_t<2, Tuple>;
-    using ADataType                 = std::tuple_element_t<3, Tuple>;
-    using AQDataType                = std::tuple_element_t<4, Tuple>;
-    using BDataType                 = std::tuple_element_t<5, Tuple>;
-    using BQDataType                = std::tuple_element_t<6, Tuple>;
-    using AccDataType               = std::tuple_element_t<7, Tuple>;
-    using CDataType                 = std::tuple_element_t<8, Tuple>;
-    static constexpr auto QuantType = std::tuple_element_t<9, Tuple>::value;
-    using DsLayout    = ck_tile::tuple<>;
-    using DsDataType  = ck_tile::tuple<>;
-    using Row   = ck_tile::tensor_layout::gemm::RowMajor;
-    using Col   = ck_tile::tensor_layout::gemm::ColumnMajor;
-    using AQLayout = Row;
-    using BQLayout = Col;
+    using ALayout                    = std::tuple_element_t<0, Tuple>;
+    using BLayout                    = std::tuple_element_t<1, Tuple>;
+    using CLayout                    = std::tuple_element_t<2, Tuple>;
+    using ADataType                  = std::tuple_element_t<3, Tuple>;
+    using AQDataType                 = std::tuple_element_t<4, Tuple>;
+    using BDataType                  = std::tuple_element_t<5, Tuple>;
+    using BQDataType                 = std::tuple_element_t<6, Tuple>;
+    using AccDataType                = std::tuple_element_t<7, Tuple>;
+    using CDataType                  = std::tuple_element_t<8, Tuple>;
+    static constexpr auto QuantType  = std::tuple_element_t<9, Tuple>::value;
+    using DsLayout                   = ck_tile::tuple<>;
+    using DsDataType                 = ck_tile::tuple<>;
+    using Row                        = ck_tile::tensor_layout::gemm::RowMajor;
+    using Col                        = ck_tile::tensor_layout::gemm::ColumnMajor;
+    using AQLayout                   = Row;
+    using BQLayout                   = Col;
     static constexpr bool Persistent = true;
 
     struct GroupedGemKernelParam_Mfma
@@ -59,8 +59,8 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
     std::size_t get_workspace_size(const std::vector<grouped_gemm_kargs>& gemm_descs)
     {
         return gemm_descs.size() * sizeof(ck_tile::QuantGemmTransKernelArg);
-    }   
-    
+    }
+
     template <typename GroupedGemKernelParam, typename ALayout, typename BLayout, typename CLayout>
     void invoke_grouped_gemm_persistent(const ck_tile::stream_config& s,
                                         const ck_tile::index_t num_groups,
@@ -170,7 +170,7 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
     static constexpr inline auto is_row_major(Layout layout_)
     {
         return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                    ck_tile::tensor_layout::gemm::RowMajor>>{};
+                                                     ck_tile::tensor_layout::gemm::RowMajor>>{};
     }
 
     auto calculate_rtol_atol(const ck_tile::index_t K,
@@ -206,7 +206,7 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
     {
         ck_tile::index_t AQK, BQK;
         using namespace ck_tile::literals;
-        
+
         std::vector<ck_tile::HostTensor<ADataType>> a_m_k_tensors;
         std::vector<ck_tile::HostTensor<BDataType>> b_k_n_tensors;
         std::vector<ck_tile::HostTensor<CDataType>> c_m_n_tensors;
@@ -278,10 +278,12 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
             }
             else if constexpr(QuantType == ck_tile::QuantType::TensorQuant)
             {
-                aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(
-                    ck_tile::host_tensor_descriptor(1, 1, stride_AQs[i], is_row_major(AQLayout{}))));
-                bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(
-                    ck_tile::host_tensor_descriptor(1, 1, stride_BQs[i], is_row_major(BQLayout()))));
+                aq_tensors.push_back(
+                    ck_tile::HostTensor<AQDataType>(ck_tile::host_tensor_descriptor(
+                        1, 1, stride_AQs[i], is_row_major(AQLayout{}))));
+                bq_tensors.push_back(
+                    ck_tile::HostTensor<BQDataType>(ck_tile::host_tensor_descriptor(
+                        1, 1, stride_BQs[i], is_row_major(BQLayout()))));
             }
 
             std::cout << "gemm[" << i << "]" << " a_m_k: " << a_m_k_tensors[i].mDesc
@@ -343,7 +345,7 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
         {
             // Generate kernel arguments
             std::vector<ck_tile::QuantGemmTransKernelArg> kargs;
-            void* kargs_ptr   = gemm_workspace.GetDeviceBuffer();
+            void* kargs_ptr = gemm_workspace.GetDeviceBuffer();
             assert(gemm_descs[0].k_batch == 1);
             for(const auto& arg : gemm_descs)
             {
@@ -395,11 +397,11 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
             if constexpr(QuantType == ck_tile::QuantType::RowColQuant)
             {
                 ck_tile::reference_gemm_rowcol_quant<ADataType,
-                                                    AQDataType,
-                                                    BDataType,
-                                                    BQDataType,
-                                                    AccDataType,
-                                                    CDataType>(a_m_k_tensors[i],
+                                                     AQDataType,
+                                                     BDataType,
+                                                     BQDataType,
+                                                     AccDataType,
+                                                     CDataType>(a_m_k_tensors[i],
                                                                 aq_tensors[i],
                                                                 b_k_n_tensors[i],
                                                                 bq_tensors[i],
@@ -408,11 +410,11 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
             else if constexpr(QuantType == ck_tile::QuantType::TensorQuant)
             {
                 ck_tile::reference_gemm_tensor_quant<ADataType,
-                                                    AQDataType,
-                                                    BDataType,
-                                                    BQDataType,
-                                                    AccDataType,
-                                                    CDataType>(a_m_k_tensors[i],
+                                                     AQDataType,
+                                                     BDataType,
+                                                     BQDataType,
+                                                     AccDataType,
+                                                     CDataType>(a_m_k_tensors[i],
                                                                 aq_tensors[i],
                                                                 b_k_n_tensors[i],
                                                                 bq_tensors[i],
@@ -421,20 +423,19 @@ class TestCkTileGroupedGemmQuant : public ::testing::Test
 
             const float max_accumulated_value =
                 *std::max_element(c_m_n_host_ref.mData.begin(), c_m_n_host_ref.mData.end());
-            const auto rtol_atol =
-                calculate_rtol_atol(Ks[i], 1, max_accumulated_value);
+            const auto rtol_atol = calculate_rtol_atol(Ks[i], 1, max_accumulated_value);
             pass &= ck_tile::check_err(c_m_n_tensors[i],
-                                    c_m_n_host_ref,
-                                    "Error: Incorrect results!",
-                                    rtol_atol.at(ck_tile::number<0>{}),
-                                    rtol_atol.at(ck_tile::number<1>{}));
+                                       c_m_n_host_ref,
+                                       "Error: Incorrect results!",
+                                       rtol_atol.at(ck_tile::number<0>{}),
+                                       rtol_atol.at(ck_tile::number<1>{}));
             std::cout << "gemm[" << i
-                    << "] Relative error threshold: " << rtol_atol.at(ck_tile::number<0>{})
-                    << " Absolute error threshold: " << rtol_atol.at(ck_tile::number<1>{})
-                    << std::endl;
+                      << "] Relative error threshold: " << rtol_atol.at(ck_tile::number<0>{})
+                      << " Absolute error threshold: " << rtol_atol.at(ck_tile::number<1>{})
+                      << std::endl;
         }
         std::cout << "The CPU verification result is:" << (pass ? "correct" : "fail") << std::endl;
-        
+
         EXPECT_TRUE(pass);
     }
 };


### PR DESCRIPTION
## Proposed changes

This PR integrates quant_mode=bqaunt into grouped_gemm. Unit tests are added.

PR also depends on #3007 

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged #3007 must be merged first.

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

