### PR TITLE
[CK_BUILDER] old ck build fixes

### DIFF
--- a/cmake/EnableCompilerWarnings.cmake
+++ b/cmake/EnableCompilerWarnings.cmake
@@ -99,6 +99,9 @@ else()
                 -Wno-unused-lambda-capture
                 -Wno-nvcc-compat
             )
+            if(CK_CXX_STANDARD GREATER_EQUAL 20)
+                list(APPEND CMAKE_COMPILER_WARNINGS -Wno-c++20-compat)
+            endif()
         else()
             if (CMAKE_${COMPILER}_COMPILER_ID MATCHES "GNU" AND ${COMPILER} MATCHES "CXX")
                 # cmake 3.5.2 does not support >=.

--- a/experimental/builder/include/ck_tile/builder/reflect/instance_traits_util.hpp
+++ b/experimental/builder/include/ck_tile/builder/reflect/instance_traits_util.hpp
@@ -60,45 +60,38 @@ consteval std::string_view type_name()
 template <typename T>
 constexpr std::string_view layout_name()
 {
-    // Convolution layouts
-    if constexpr(std::is_same_v<T, ck::tensor_layout::convolution::GNHWC>)
-        return "GNHWC";
-    else if constexpr(std::is_same_v<T, ck::tensor_layout::convolution::GKYXC>)
-        return "GKYXC";
-    else if constexpr(std::is_same_v<T, ck::tensor_layout::convolution::GNHWK>)
-        return "GNHWK";
-    else if constexpr(std::is_same_v<T, ck::tensor_layout::convolution::GKZYXC>)
-        return "GKZYXC";
-    else if constexpr(std::is_same_v<T, ck::tensor_layout::convolution::GNDHWC>)
-        return "GNDHWC";
-    else if constexpr(std::is_same_v<T, ck::tensor_layout::convolution::GNDHWK>)
-        return "GNDHWK";
-    else if constexpr(std::is_same_v<T, ck::tensor_layout::convolution::NHWGC>)
-        return "NHWGC";
-    else if constexpr(std::is_same_v<T, ck::tensor_layout::convolution::KYXGC>)
-        return "KYXGC";
-    else if constexpr(std::is_same_v<T, ck::tensor_layout::convolution::NHWGK>)
-        return "NHWGK";
+    if constexpr(requires {
+                     { T::name } -> std::convertible_to<std::string_view>;
+                 })
+        return T::name;
     else
-        static_assert(false, "unknown_layout");
+        static_assert(false, "layout type is missing name attribute");
 }
 
 // Convert element-wise operation types to string names
 template <typename T>
 constexpr std::string_view elementwise_op_name()
 {
-    if constexpr(std::is_same_v<T, ck::tensor_operation::element_wise::PassThrough>)
+    namespace element_wise = ck::tensor_operation::element_wise;
+
+    if constexpr(std::is_same_v<T, element_wise::PassThrough>)
         return "PassThrough";
-    else if constexpr(std::is_same_v<T, ck::tensor_operation::element_wise::Scale>)
+    else if constexpr(std::is_same_v<T, element_wise::Scale>)
         return "Scale";
-    else if constexpr(std::is_same_v<T, ck::tensor_operation::element_wise::Bilinear>)
+    else if constexpr(std::is_same_v<T, element_wise::Bilinear>)
         return "Bilinear";
-    else if constexpr(std::is_same_v<T, ck::tensor_operation::element_wise::Add>)
+    else if constexpr(std::is_same_v<T, element_wise::Add>)
         return "Add";
-    else if constexpr(std::is_same_v<T, ck::tensor_operation::element_wise::AddRelu>)
+    else if constexpr(std::is_same_v<T, element_wise::AddRelu>)
         return "AddRelu";
-    else if constexpr(std::is_same_v<T, ck::tensor_operation::element_wise::Relu>)
+    else if constexpr(std::is_same_v<T, element_wise::Relu>)
         return "Relu";
+    else if constexpr(std::is_same_v<T, element_wise::BiasNormalizeInInferClamp>)
+        return "BiasNormalizeInInferClamp";
+    else if constexpr(std::is_same_v<T, element_wise::Clamp>)
+        return "Clamp";
+    else if constexpr(std::is_same_v<T, element_wise::AddClamp>)
+        return "AddClamp";
     else
         static_assert(false, "unknown_op");
 }


### PR DESCRIPTION
## Proposed changes

This fixes a few things when building old CK with CK builder enabled:
- Disable C++20-compat warnings when building CK in C++20 mode. This was emitting warnings about the CK-builder C++20 features.
- Add missing layouts to `instance_traits_util.hpp`
  - I've simplified `layout_name` to make use of the existing `::name` attribute. This should already be there for all layouts, see [ck tensor_layout.hpp](https://github.com/ROCm/composable_kernel/blob/develop/include/ck/tensor_operation/gpu/device/tensor_layout.hpp) and [ck_tile tensor_layout.hpp](https://github.com/ROCm/composable_kernel/blob/develop/include/ck_tile/ops/common/tensor_layout.hpp). This reduces some duplication but requires that these names aren't touched. Lmk if this is not good.
  - Added missing element_wise operations to `elementwise_op_name()`. These are the ones required for compiling CK right now, but its probably not an exhaustive list. We should add them when required.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

