### PR TITLE
Fix reinterpret_cast UB build issue

### DIFF
--- a/test/mx_mfma_op/mx_mfma_op.hpp
+++ b/test/mx_mfma_op/mx_mfma_op.hpp
@@ -789,12 +789,12 @@ struct store_C_col_major<CType, CFragT, 32, 32>
             CScalarFragT chunks[vectorSize(CFragT{}) / VW];
         } fragC{cFrag}; // Initialize with input fragment
 
-        *(reinterpret_cast<CScalarFragT*>(output + startOffset))                = fragC.chunks[0];
-        *(reinterpret_cast<CScalarFragT*>(output + startOffset + kMajorOffset)) = fragC.chunks[1];
-        *(reinterpret_cast<CScalarFragT*>(output + startOffset + 2 * kMajorOffset)) =
-            fragC.chunks[2];
-        *(reinterpret_cast<CScalarFragT*>(output + startOffset + 3 * kMajorOffset)) =
-            fragC.chunks[3];
+        CScalarFragT* fragPtr;
+        for(uint32_t idx = 0; idx < vectorSize(CFragT{}) / VW; ++idx)
+        {
+            fragPtr  = reinterpret_cast<CScalarFragT*>(output + startOffset + idx * kMajorOffset);
+            *fragPtr = fragC.chunks[idx];
+        }
     }
 };
 


### PR DESCRIPTION
## Proposed changes

Rearrange pointers to fix the reinterpret_cast issue.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

N/A

