### PR TITLE
Excluding Tile engine from build

### DIFF
--- a/tile_engine/ops/gemm/CMakeLists.txt
+++ b/tile_engine/ops/gemm/CMakeLists.txt
@@ -64,6 +64,7 @@ function(create_individual_gemm_target datatype layout trait tile_config config_
 
     # Create the executable
     add_executable(${target_name}
+        EXCLUDE_FROM_ALL
         ${GEMM_SOURCE_DIR}/benchmark_gemm_single.cpp
         ${instance_header}
     )

--- a/tile_engine/ops/gemm_preshuffle/CMakeLists.txt
+++ b/tile_engine/ops/gemm_preshuffle/CMakeLists.txt
@@ -64,6 +64,7 @@ function(create_individual_gemm_preshuffle_target datatype layout trait tile_con
     
     # Create the executable
     add_executable(${target_name} 
+        EXCLUDE_FROM_ALL
         ${GEMM_PRESHUFFLE_SOURCE_DIR}/benchmark_gemm_preshuffle_single.cpp
         ${instance_header}
     )


### PR DESCRIPTION
## Proposed changes

With this PR we exclude CK Tile Engine build from the regular build

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

