### PR TITLE
[CK][host] limit the rotating count to prevent oom

### DIFF
--- a/include/ck/host_utility/flush_cache.hpp
+++ b/include/ck/host_utility/flush_cache.hpp
@@ -28,12 +28,12 @@ struct RotatingMemWrapperMultiABD
 
     RotatingMemWrapperMultiABD() = delete;
     RotatingMemWrapperMultiABD(Argument& arg_,
-                               std::size_t rotating_count_,
+                               std::size_t rotating_count_hint,
                                std::array<std::size_t, NumAs> size_as_,
                                std::array<std::size_t, NumBs> size_bs_,
                                std::array<std::size_t, NumDs> size_ds_)
         : arg(arg_),
-          rotating_count(rotating_count_),
+          rotating_count(rotating_count_hint),
           size_as(size_as_),
           size_bs(size_bs_),
           size_ds(size_ds_)
@@ -41,6 +41,14 @@ struct RotatingMemWrapperMultiABD
         p_as_grids.push_back(arg.p_as_grid);
         p_bs_grids.push_back(arg.p_bs_grid);
         p_ds_grids.push_back(arg.p_ds_grid);
+
+        // limit the rotating count to prevent oom
+        const uint64_t footprint = std::accumulate(size_as.begin(), size_as.end(), 0UL) +
+                                   std::accumulate(size_bs.begin(), size_bs.end(), 0UL) +
+                                   std::accumulate(size_ds.begin(), size_ds.end(), 0UL);
+        const uint64_t max_rotating_count = (1ULL << 31) / footprint;
+        rotating_count                    = std::min(rotating_count, max_rotating_count);
+
         for(size_t i = 1; i < rotating_count; i++)
         {
             {
@@ -171,12 +179,12 @@ struct RotatingMemWrapperMultiD
 
     RotatingMemWrapperMultiD() = delete;
     RotatingMemWrapperMultiD(Argument& arg_,
-                             std::size_t rotating_count_,
+                             std::size_t rotating_count_hint,
                              std::size_t size_a_,
                              std::size_t size_b_,
                              std::array<std::size_t, NumDs> size_ds_)
         : arg(arg_),
-          rotating_count(rotating_count_),
+          rotating_count(rotating_count_hint),
           size_a(size_a_),
           size_b(size_b_),
           size_ds(size_ds_)
@@ -184,6 +192,13 @@ struct RotatingMemWrapperMultiD
         p_a_grids.push_back(arg.p_a_grid);
         p_b_grids.push_back(arg.p_b_grid);
         p_ds_grids.push_back(arg.p_ds_grid);
+
+        // limit the rotating count to prevent oom
+        const uint64_t footprint =
+            std::accumulate(size_ds.begin(), size_ds.end(), 0UL) + (size_a + size_b);
+        const uint64_t max_rotating_count = (1ULL << 31) / footprint;
+        rotating_count                    = std::min(rotating_count, max_rotating_count);
+
         for(size_t i = 1; i < rotating_count; i++)
         {
             {
@@ -286,13 +301,19 @@ struct RotatingMemWrapper
 
     RotatingMemWrapper() = delete;
     RotatingMemWrapper(Argument& arg_,
-                       std::size_t rotating_count_,
+                       std::size_t rotating_count_hint,
                        std::size_t size_a_,
                        std::size_t size_b_)
-        : arg(arg_), rotating_count(rotating_count_), size_a(size_a_), size_b(size_b_)
+        : arg(arg_), rotating_count(rotating_count_hint), size_a(size_a_), size_b(size_b_)
     {
         p_a_grids.push_back(arg.p_a_grid);
         p_b_grids.push_back(arg.p_b_grid);
+
+        // limit the rotating count to prevent oom
+        const uint64_t footprint          = (size_a + size_b);
+        const uint64_t max_rotating_count = (1ULL << 31) / footprint;
+        rotating_count                    = std::min(rotating_count, max_rotating_count);
+
         for(size_t i = 1; i < rotating_count; i++)
         {
             {

--- a/include/ck/host_utility/flush_cache.hpp
+++ b/include/ck/host_utility/flush_cache.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <hip/hip_runtime.h>
+#include <numeric>
 #include <set>
 #include <vector>
 


### PR DESCRIPTION
## Proposed changes

Follow-up to #3087 

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

