### PR TITLE
[CK_BUILDER] Add missing tf32 type to reflection.

### DIFF
--- a/experimental/builder/include/ck_tile/builder/reflect/instance_traits_util.hpp
+++ b/experimental/builder/include/ck_tile/builder/reflect/instance_traits_util.hpp
@@ -40,6 +40,8 @@ consteval std::string_view type_name()
         return "fp16";
     else if constexpr(std::is_same_v<T, float>)
         return "fp32";
+    else if constexpr(std::is_same_v<T, ck::tf32_t>)
+        return "tf32";
     else if constexpr(std::is_same_v<T, double>)
         return "fp64";
     else if constexpr(std::is_same_v<T, int8_t>)


### PR DESCRIPTION
We need to check all the architectures for build errors. This PR adds a missing tf32 type that came up as a build failure when I compiled for different instinct architectures.
