### PR TITLE
Add .cline* files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ tags
 # Editors
 .vscode
 
+# Cline
+.cline*
+
 # build-in-source directory (see exceptions below)
 build*
 


### PR DESCRIPTION
Developers who use cline on the code base need to ignore .cline* directories like .cline_storage and .clinerules. Using a wildcard to ignore any other cline-related directories.
