### PR TITLE
Fix multiple test failures with staging compiler.

### DIFF
--- a/codegen/test/rtc/include/rtc/kernel.hpp
+++ b/codegen/test/rtc/include/rtc/kernel.hpp
@@ -52,7 +52,7 @@ struct kernel
     template <class... Ts>
     auto launch(hipStream_t stream, std::size_t global, std::size_t local, Ts... zs) const
     {
-        return [=](auto&&... xs) {
+        return [=, this](auto&&... xs) {
             launch(stream, global, local, std::vector<kernel_argument>{xs...}, zs...);
         };
     }

--- a/include/ck/utility/synchronization.hpp
+++ b/include/ck/utility/synchronization.hpp
@@ -25,7 +25,7 @@ __device__ void block_sync_lds()
     // s_waitcnt lgkmcnt(0) \n \
     // s_barrier \
     // " ::);
-    __builtin_amdgcn_s_waitcnt(0xc07f);
+    __builtin_amdgcn_s_waitcnt(0xfc07);
     __builtin_amdgcn_s_barrier();
 #endif
 #else

--- a/include/ck/utility/synchronization.hpp
+++ b/include/ck/utility/synchronization.hpp
@@ -16,16 +16,23 @@ __device__ void llvm_amdgcn_s_wait_dscnt(short cnt) __asm("llvm.amdgcn.s.wait.ds
 __device__ void block_sync_lds()
 {
 #if CK_EXPERIMENTAL_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM
-#ifdef __gfx12__
+#if defined(__gfx12__)
     llvm_amdgcn_s_wait_dscnt(0);
     asm volatile("s_barrier_signal -1\n\t"
                  "s_barrier_wait -1");
-#else
+#elif defined(__gfx11__)
     // asm volatile("\
     // s_waitcnt lgkmcnt(0) \n \
     // s_barrier \
     // " ::);
     __builtin_amdgcn_s_waitcnt(0xfc07);
+    __builtin_amdgcn_s_barrier();
+#else
+    // asm volatile("\
+    // s_waitcnt lgkmcnt(0) \n \
+    // s_barrier \
+    // " ::);
+    __builtin_amdgcn_s_waitcnt(0xc07f);
     __builtin_amdgcn_s_barrier();
 #endif
 #else


### PR DESCRIPTION
## Proposed changes

It appears that the staging compiler revealed an issue with synchronization barriers on gfx11:

For gfx9, __builtin_amdgcn_s_waitcnt(0xc07f) is  s_waitcnt lgkmcnt(0). ( SIMM16[11:8] = LGKMcnt)

However for gfx11, if 0xc07f is intereted as SIMM16 field of s_waitcnt, it is not lgkmcnt(0).

 From sp3 site, in gfx11, here is the SIMM16 field’s mapping . 

[S_WAITCNT](https://atlvsp3r2.amd.com/sp3help/sp3help.php?asic=GFX11&style=Default&opcode=S_WAITCNT&width=146)  Wait On Dependency Counters    ENC_SOPP op:0x9
Flags:        [OPF_IB_INTERNAL](https://atlvsp3r2.amd.com/sp3help/sp3help.php?asic=GFX11&style=Default&flag=OPF_IB_INTERNAL&width=146), [OPF_WAIT](https://atlvsp3r2.amd.com/sp3help/sp3help.php?asic=GFX11&style=Default&flag=OPF_WAIT&width=146)
Func. Group:  FG_WAVE_CONTROL FSG_NOT_ASSIGNED
   [ENC_SOPP](https://atlvsp3r2.amd.com/sp3help/sp3help.php?asic=GFX11&style=Default&encoding=ENC_SOPP&width=146) default------size--type------------format----------instfield-------flags----------------------------------------op:0x9-------------
    | S0 simm16          [16] [OPR_WAITCNT](https://atlvsp3r2.amd.com/sp3help/sp3help.php?asic=GFX11&style=Default&type=OPR_WAITCNT&width=146)     [FMT_NUM_B16](https://atlvsp3r2.amd.com/sp3help/sp3help.php?asic=GFX11&style=Default&format=FMT_NUM_B16&width=146)     simm16               in                                      
 Wait for the counts of outstanding local data share, vector memory and export instructions to be at or below the specified levels.
    The SIMM16 argument is encoded as:
     EXP= SIMM16[2:0]
        Export wait count. 0x7 means do not wait on EXPCNT.
     LGKM = SIMM16[9:4]
        LGKM wait count. 0x3f means do not wait on LGKMCNT.
     VM = SIMM16[15:10]
        VM wait count. 0x3f means do not wait on VMCNT.

So, in gfx11, 0xc07f will have value 7 at lgkmcnt if I interpret 0xc07f as the SIMM16 field of S_WAITCNT as-is.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged