### PR TITLE
Add option to build ckProfiler packages for individual architectures.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1047,7 +1047,7 @@ def run_pytorch_tests(Map conf=[:]){
 //launch develop branch daily jobs
 CRON_SETTINGS = BRANCH_NAME == "develop" ? '''0 23 * * * % RUN_FULL_QA=true;RUN_CK_TILE_FMHA_TESTS=true;RUN_PERFORMANCE_TESTS=true;FORCE_CI=true
                                               0 22 * * * % RUN_FULL_QA=true;DISABLE_DL_KERNELS=true;RUN_TILE_ENGINE_GEMM_TESTS=true;RUN_PERFORMANCE_TESTS=true;RUN_ALL_UNIT_TESTS=true;FORCE_CI=true
-                                              0 21 * * * % RUN_GROUPED_CONV_LARGE_CASES_TESTS=true;hipTensor_test=true;BUILD_GFX908=true;BUILD_GFX942=true;BUILD_GFX950=true;RUN_PERFORMANCE_TESTS=true;RUN_ALL_UNIT_TESTS=true;FORCE_CI=true
+                                              0 21 * * * % RUN_GROUPED_CONV_LARGE_CASES_TESTS=true;hipTensor_test=true;BUILD_GFX908=true;BUILD_GFX942=true;BUILD_GFX950=true;RUN_PERFORMANCE_TESTS=true;RUN_ALL_UNIT_TESTS=true;FORCE_CI=true;BUILD_PACKAGES=true
                                               0 19 * * * % BUILD_DOCKER=true;COMPILER_VERSION=amd-staging;BUILD_COMPILER=/llvm-project/build/bin/clang++;USE_SCCACHE=false;NINJA_BUILD_TRACE=true;RUN_ALL_UNIT_TESTS=true;FORCE_CI=true
                                               0 17 * * * % BUILD_DOCKER=true;COMPILER_VERSION=amd-mainline;BUILD_COMPILER=/llvm-project/build/bin/clang++;USE_SCCACHE=false;NINJA_BUILD_TRACE=true;RUN_ALL_UNIT_TESTS=true;FORCE_CI=true
                                               0 15 * * * % BUILD_INSTANCES_ONLY=true;USE_SCCACHE=false;NINJA_BUILD_TRACE=true;FORCE_CI=true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -321,12 +321,6 @@ def cmake_build(Map conf=[:]){
     //cmake_env can overwrite default CXX variables.
     def cmake_envs = "CXX=${compiler} CXXFLAGS='-Werror' " + conf.get("cmake_ex_env","")
 
-    def package_build = (conf.get("package_build","") == "true")
-
-    if (package_build == true) {
-        config_targets = "package"
-    }
-
     if(conf.get("build_install","") == "true")
     {
         config_targets = 'install ' + config_targets
@@ -476,10 +470,10 @@ def cmake_build(Map conf=[:]){
                     }
                     if(params.BUILD_PACKAGES){
                         echo "Build ckProfiler packages"
-                    sh 'ninja -j64 package'
-                    def arch_name = check_arch_name()
-                    sh "mv composablekernel-ckprofiler_*.deb composablekernel-ckprofiler_1.2.0_amd64_${arch_name}.deb"
-                    stash includes: "composablekernel-**.deb", name: "packages"
+                        sh 'ninja -j64 package'
+                        def arch_name = check_arch_name()
+                        sh "mv composablekernel-ckprofiler_*.deb composablekernel-ckprofiler_1.2.0_amd64_${arch_name}.deb"
+                        stash includes: "composablekernel-**.deb", name: "packages"
                     }
                 }
                 if(params.BUILD_INSTANCES_ONLY){
@@ -499,15 +493,18 @@ def cmake_build(Map conf=[:]){
                     else{
                         sh "ninja check"
                     }
+                    if(params.BUILD_PACKAGES){
+                        echo "Build ckProfiler packages"
+                        sh 'ninja -j64 package'
+                        def arch_name = check_arch_name()
+                        sh "mv composablekernel-ckprofiler_*.deb composablekernel-ckprofiler_1.2.0_amd64_${arch_name}.deb"
+                        stash includes: "composablekernel-**.deb", name: "packages"
+                    }
                 }
             }
         }
     }
 
-    // Only archive from develop
-    if (package_build == true && env.BRANCH_NAME == "develop") {
-        archiveArtifacts artifacts: "build/*.deb", allowEmptyArchive: true, fingerprint: true
-    }
     //check the node gpu architecture
     def arch = check_arch()
     if (params.RUN_CK_TILE_FMHA_TESTS){
@@ -845,7 +842,7 @@ def process_results(Map conf=[:]){
                             echo "could not locate the FMHA performance logs for gfx90a: ${err.getMessage()}."
                         }
                     }
-                    if (params.BUILD_INSTANCES_ONLY){
+                    if (params.BUILD_INSTANCES_ONLY || params.BUILD_PACKAGES){
                         // unstash deb packages
                         unstash "packages"
                         sh "sshpass -p ${env.ck_deb_pw} scp -o StrictHostKeyChecking=no composablekernel-*.deb ${env.ck_deb_user}@${env.ck_deb_ip}:/var/www/html/composable_kernel/"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -473,7 +473,7 @@ def cmake_build(Map conf=[:]){
                         sh 'ninja -j64 package'
                         def arch_name = check_arch_name()
                         sh "mv composablekernel-ckprofiler_*.deb composablekernel-ckprofiler_1.2.0_amd64_${arch_name}.deb"
-                        stash includes: "composablekernel-**.deb", name: "packages"
+                        stash includes: "composablekernel-ckprofiler**.deb", name: "profiler_package_${arch_name}"
                     }
                 }
                 if(params.BUILD_INSTANCES_ONLY){
@@ -481,7 +481,7 @@ def cmake_build(Map conf=[:]){
                     echo "Build library package"
                     sh 'ninja -j64 package'
                     sh 'mv composablekernel-dev_*.deb composablekernel-dev_all_targets_1.2.0_amd64.deb'
-                    stash includes: "composablekernel-dev**.deb", name: "packages"
+                    stash includes: "composablekernel-dev**.deb", name: "lib_package"
                 }
             }
             else{
@@ -498,7 +498,7 @@ def cmake_build(Map conf=[:]){
                         sh 'ninja -j64 package'
                         def arch_name = check_arch_name()
                         sh "mv composablekernel-ckprofiler_*.deb composablekernel-ckprofiler_1.2.0_amd64_${arch_name}.deb"
-                        stash includes: "composablekernel-**.deb", name: "packages"
+                        stash includes: "composablekernel-ckprofiler**.deb", name: "profiler_package_${arch_name}"
                     }
                 }
             }
@@ -842,10 +842,43 @@ def process_results(Map conf=[:]){
                             echo "could not locate the FMHA performance logs for gfx90a: ${err.getMessage()}."
                         }
                     }
-                    if (params.BUILD_INSTANCES_ONLY || params.BUILD_PACKAGES){
+                    if (params.BUILD_INSTANCES_ONLY){
                         // unstash deb packages
-                        unstash "packages"
+                        try{
+                            unstash "lib_package"
+                        }
+                        catch(Exception err){
+                            echo "could not locate lib_package."
+                        }
                         sh "sshpass -p ${env.ck_deb_pw} scp -o StrictHostKeyChecking=no composablekernel-*.deb ${env.ck_deb_user}@${env.ck_deb_ip}:/var/www/html/composable_kernel/"
+                    }
+                    if (params.BUILD_PACKAGES){
+                        // unstash deb packages
+                        try{
+                            unstash "profiler_package_gfx90a"
+                        }
+                        catch(Exception err){
+                            echo "could not locate profiler_package_gfx90a."
+                        }
+                        try{
+                            unstash "profiler_package_gfx942"
+                        }
+                        catch(Exception err){
+                            echo "could not locate profiler_package_gfx942."
+                        }
+                        try{
+                            unstash "profiler_package_gfx950"
+                        }
+                        catch(Exception err){
+                            echo "could not locate profiler_package_gfx950."
+                        }
+                        try{
+                            unstash "profiler_package_gfx12"
+                        }
+                        catch(Exception err){
+                            echo "could not locate profiler_package_gfx12."
+                        }
+                        sh "sshpass -p ${env.ck_deb_pw} scp -o StrictHostKeyChecking=no composablekernel-ckprofiler*.deb ${env.ck_deb_user}@${env.ck_deb_ip}:/var/www/html/composable_kernel/"
                     }
                     else{
                         // unstash perf files to master

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,6 +186,33 @@ def check_arch(){
     return arch_type
 }
 
+def check_arch_name(){
+    def arch_name = ""
+    sh 'rocminfo | tee rocminfo.log'
+    if ( runShell('grep -n "gfx90a" rocminfo.log') ){
+        arch_name = "gfx90a"
+    }
+    else if ( runShell('grep -n "gfx942" rocminfo.log') ) {
+        arch_name = "gfx942"
+    }
+    else if ( runShell('grep -n "gfx10" rocminfo.log') ) {
+        arch_name = "gfx10"
+    }
+    else if ( runShell('grep -n "gfx11" rocminfo.log') ) {
+        arch_name = "gfx11"
+    }
+    else if ( runShell('grep -n "gfx12" rocminfo.log') ) {
+        arch_name = "gfx12"
+    }
+    else if ( runShell('grep -n "gfx908" rocminfo.log') ) {
+        arch_name = "gfx908"
+    }
+    else if ( runShell('grep -n "gfx950" rocminfo.log') ) {
+        arch_name = "gfx950"
+    }
+    return arch_name
+}
+
 def getDockerImage(Map conf=[:]){
     env.DOCKER_BUILDKIT=1
     def prefixpath = conf.get("prefixpath", "/opt/rocm")
@@ -447,15 +474,20 @@ def cmake_build(Map conf=[:]){
                     else{
                         sh "ninja check"
                     }
+                    if(params.BUILD_PACKAGES){
+                        echo "Build ckProfiler packages"
+                    sh 'ninja -j64 package'
+                    def arch_name = check_arch_name()
+                    sh "mv composablekernel-ckprofiler_*.deb composablekernel-ckprofiler_1.2.0_amd64_${arch_name}.deb"
+                    stash includes: "composablekernel-**.deb", name: "packages"
+                    }
                 }
                 if(params.BUILD_INSTANCES_ONLY){
                     // build deb packages
-                    echo "Build packages"
+                    echo "Build library package"
                     sh 'ninja -j64 package'
-                    archiveArtifacts artifacts: 'composablekernel-dev*.deb'
                     sh 'mv composablekernel-dev_*.deb composablekernel-dev_all_targets_1.2.0_amd64.deb'
-                    sh 'mv composablekernel-ckprofiler_*.deb composablekernel-ckprofiler_1.2.0_amd64.deb'
-                    stash includes: "composablekernel-**.deb", name: "packages"
+                    stash includes: "composablekernel-dev**.deb", name: "packages"
                 }
             }
             else{
@@ -1077,6 +1109,10 @@ pipeline {
             name: "BUILD_INSTANCES_ONLY",
             defaultValue: false,
             description: "Test building instances for various architectures simultaneously (default: OFF)")
+        booleanParam(
+            name: "BUILD_PACKAGES",
+            defaultValue: false,
+            description: "Build packages for the libraries and/or ckProfiler (default: OFF)")
         booleanParam(
             name: "BUILD_GFX908",
             defaultValue: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1859,7 +1859,7 @@ pipeline {
                 stage("Process results"){
                     when {
                         beforeAgent true
-                        expression { (params.RUN_PERFORMANCE_TESTS.toBoolean() || params.BUILD_INSTANCES_ONLY.toBoolean() || params.RUN_CK_TILE_FMHA_TESTS.toBoolean()) && !params.BUILD_LEGACY_OS.toBoolean() }
+                        expression { (params.RUN_PERFORMANCE_TESTS.toBoolean() || params.BUILD_INSTANCES_ONLY.toBoolean() || params.RUN_CK_TILE_FMHA_TESTS.toBoolean()|| params.BUILD_PACKAGES.toBoolean()) && !params.BUILD_LEGACY_OS.toBoolean() }
                     }
                     agent { label 'mici' }
                     steps{


### PR DESCRIPTION
## Proposed changes

This will allow generating deb packages for ckProfiler for individual targets and generate them daily during one of the cron jobs.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x ] I have added inline documentation which enables the maintainers with understanding the motivation
- [x ] I have removed the stale documentation which is no longer relevant after this pull request
- [x ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x ] I have run `clang-format` on all changed files
- [ x] Any dependent changes have been merged


