### PR TITLE
Adding new alert failure patterns

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,8 @@ def sendFailureNotifications() {
         [pattern: /docker login failed/, description: "Docker login failed"],
         [pattern: /HTTP request sent .* 404 Not Found/, description: "HTTP request failed with 404"],
         [pattern: /cat: .* No such file or directory/, description: "GPU not found"],
-        [pattern: /GPU not found/, description: "GPU not found"]
+        [pattern: /GPU not found/, description: "GPU not found"],
+        [pattern: /Could not connect to Redis at .* Connection timed out/, description: "Redis connection timed out"]
     ]
     
     // Get the build log.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,14 +12,6 @@ def show_node_info() {
     """
 }
 
-// Error patterns to scan build logs for specific failure types and send detailed notifications.
-def failurePatterns = [
-    [pattern: /login attempt to .* failed with status: 401 Unauthorized/, description: "Docker registry authentication failed"],
-    [pattern: /docker login failed/, description: "Docker login failed"],
-    [pattern: /HTTP request sent .* 404 Not Found/, description: "HTTP request failed with 404"],
-    [pattern: /cat: .* No such file or directory/, description: "GPU not found"],
-]
-
 // Given a pattern, check if the log contains the pattern and return the context.
 def checkForPattern(pattern, log) {
     def lines = log.split('\n')
@@ -42,8 +34,17 @@ def checkForPattern(pattern, log) {
     return [found: false, matchedLine: "", context: ""]
 }
 
-// Scan build logs and send notifications
+// Scan the build logs for failures and send notifications.
 def sendFailureNotifications() {
+    // Error patterns to scan build logs for specific failure types and send detailed notifications.
+    def failurePatterns = [
+        [pattern: /login attempt to .* failed with status: 401 Unauthorized/, description: "Docker registry authentication failed"],
+        [pattern: /docker login failed/, description: "Docker login failed"],
+        [pattern: /HTTP request sent .* 404 Not Found/, description: "HTTP request failed with 404"],
+        [pattern: /cat: .* No such file or directory/, description: "GPU not found"],
+        [pattern: /GPU not found/, description: "GPU not found"]
+    ]
+    
     // Get the build log.
     def buildLog = sh(script: 'wget -q --no-check-certificate -O - ' + BUILD_URL + 'consoleText', returnStdout: true)
     // Check for patterns in the log.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1293,8 +1293,6 @@ pipeline {
                 script {
                     env.SHOULD_RUN_CI = String.valueOf(params.FORCE_CI.toBoolean() || shouldRunCICheck())
                     echo "SHOULD_RUN_CI: ${env.SHOULD_RUN_CI}"
-                    echo "GPU not found"
-                    sh 'false';
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1287,21 +1287,14 @@ pipeline {
         DOCKER_BUILDKIT = "1"
     }
     stages{
-        stage("No GPU found test") {
-            agent{ label rocmnode("nogpu") }
-            steps {
-                script {
-                    echo "GPU not found"
-                    sh 'false';
-                }
-            }
-        }
         stage("Determine CI Execution") {
             agent{ label rocmnode("nogpu") }
             steps {
                 script {
                     env.SHOULD_RUN_CI = String.valueOf(params.FORCE_CI.toBoolean() || shouldRunCICheck())
                     echo "SHOULD_RUN_CI: ${env.SHOULD_RUN_CI}"
+                    echo "GPU not found"
+                    sh 'false';
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1287,6 +1287,15 @@ pipeline {
         DOCKER_BUILDKIT = "1"
     }
     stages{
+        stage("No GPU found test") {
+            agent{ label rocmnode("nogpu") }
+            steps {
+                script {
+                    echo "GPU not found"
+                    sh 'false';
+                }
+            }
+        }
         stage("Determine CI Execution") {
             agent{ label rocmnode("nogpu") }
             steps {


### PR DESCRIPTION
## Proposed changes
- Two new failure patterns have been added to the list: GPU not found and Redis connection time out patterns.
- The logic for sending notifications was recently moved which introduced a bug. I moved failurePatterns variable to live in the failure notifications function scope so that it can access the list of failure patterns.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## How was this tested
The new failure was tested by forcing a stage failure and echoing the error message. The pattern was discovered and the message was sent to the Teams channel.

