### PR TITLE
[CK_TILE] Fix building CK Tile grouped conv fwd bias clamp example

### DIFF
--- a/example/ck_tile/20_grouped_convolution/grouped_convolution_forward_bias_clamp.cpp
+++ b/example/ck_tile/20_grouped_convolution/grouped_convolution_forward_bias_clamp.cpp
@@ -51,8 +51,8 @@ int run_grouped_conv_fwd_bias_clamp_example(int argc, char* argv[])
 int main(int argc, char* argv[])
 {
 #if CK_TILE_USE_WMMA
-    return !run_grouped_conv_fwd_bias_clamp_example<GemmConfigComputeV3_WMMA>(argc, argv);
+    return !run_grouped_conv_fwd_bias_clamp_example<ConvConfigComputeV3_WMMA>(argc, argv);
 #else
-    return !run_grouped_conv_fwd_bias_clamp_example<GemmConfigComputeV3>(argc, argv);
+    return !run_grouped_conv_fwd_bias_clamp_example<ConvConfigComputeV3>(argc, argv);
 #endif
 }


### PR DESCRIPTION
## Proposed changes

Fix building CK Tile grouped forward convolution bias-clamp example. Building this example is currently broken due to refactoring done in PR #2986. 