### PR TITLE
Kabraham/fix block gemm v1 b scale

### DIFF
--- a/include/ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_wmmaops_v1.hpp
+++ b/include/ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_wmmaops_v1.hpp
@@ -300,6 +300,10 @@ struct BlockwiseGemmWmmaops_pipeline_v1<BlockGemmPipelineScheduler::Intrawave,
 
                 block_sync_lds();
                 b_scale_struct.template GlobalLoad<0>((i + 2) % num_loop_per_scale == 0);
+                if constexpr(ck::is_same<BScaleStruct, Empty>::value == false)
+                {
+			block_sync_lds();
+		}
                 a_blockwise_copy.RunWrite(a_block_desc, a_block_buf);
                 b_blockwise_copy.RunWrite(b_block_desc, b_block_buf);
 
@@ -699,6 +703,10 @@ struct BlockwiseGemmWmmaops_pipeline_v1<BlockGemmPipelineScheduler::Interwave,
                 blockwise_gemm_func();
 
                 b_scale_struct.template GlobalLoad<0>((i + 2) % num_loop_per_scale == 0);
+                if constexpr(ck::is_same<BScaleStruct, Empty>::value == false)
+                {
+			block_sync_lds();
+		}
                 a_blockwise_copy.RunWrite(a_block_desc, a_block_buf);
                 b_blockwise_copy.RunWrite(b_block_desc, b_block_buf);
 

--- a/include/ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_wmmaops_v1.hpp
+++ b/include/ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_wmmaops_v1.hpp
@@ -302,8 +302,8 @@ struct BlockwiseGemmWmmaops_pipeline_v1<BlockGemmPipelineScheduler::Intrawave,
                 b_scale_struct.template GlobalLoad<0>((i + 2) % num_loop_per_scale == 0);
                 if constexpr(ck::is_same<BScaleStruct, Empty>::value == false)
                 {
-			block_sync_lds();
-		}
+                    block_sync_lds();
+                }
                 a_blockwise_copy.RunWrite(a_block_desc, a_block_buf);
                 b_blockwise_copy.RunWrite(b_block_desc, b_block_buf);
 
@@ -705,8 +705,8 @@ struct BlockwiseGemmWmmaops_pipeline_v1<BlockGemmPipelineScheduler::Interwave,
                 b_scale_struct.template GlobalLoad<0>((i + 2) % num_loop_per_scale == 0);
                 if constexpr(ck::is_same<BScaleStruct, Empty>::value == false)
                 {
-			block_sync_lds();
-		}
+                    block_sync_lds();
+                }
                 a_blockwise_copy.RunWrite(a_block_desc, a_block_buf);
                 b_blockwise_copy.RunWrite(b_block_desc, b_block_buf);
 


### PR DESCRIPTION
## Proposed changes

Fix an issue with the block gemm pipeline v1 where b_scale tests fail when compiled with clang++22. The issue seems to have been caused by a missing synchronization after loading b_scale struct from global memory


