### PR TITLE
test: temporarily disable flaky test_ck_tile_moe_sorting_2d_buf

### DIFF
--- a/test/ck_tile/moe_sorting/CMakeLists.txt
+++ b/test/ck_tile/moe_sorting/CMakeLists.txt
@@ -12,7 +12,8 @@ if(GPU_TARGETS MATCHES "gfx942|gfx950|gfx90a|gfx11|gfx12")
 
     endfunction(add_moe_sorting_test EXECUTABLE USE_2D_BUF)
 
-    add_moe_sorting_test(test_ck_tile_moe_sorting_2d_buf 1)
+    # Temporarily disable 2d buf test because it fails on gfx11 for unknown reason
+    # add_moe_sorting_test(test_ck_tile_moe_sorting_2d_buf 1)
     add_moe_sorting_test(test_ck_tile_moe_sorting 0)
 
 else()


### PR DESCRIPTION
## Proposed changes

This test fails on CI for unknown reason and causes disruption for other PRs CI runs.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

