### PR TITLE
[CK_TILE] FMHA Fix synchronization issue in FWD QR pipeline with dropout

### DIFF
--- a/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -578,6 +578,9 @@ struct BlockFmhaPipelineQRKSVS
 
             if constexpr(kHasDropout)
             {
+                // K and dropout use the same address in LDS, finish loading from k_lds_window by
+                // gemm_0 to reuse LDS.
+                block_sync_lds();
                 dropout.template Run<decltype(gemm_0), SMPLComputeDataType, RandValOutputDataType>(
                     smem_ptr, seqlen_k_start + i_total_loops * kN0, p_compute, randval_dram_window);
             }


### PR DESCRIPTION
## Proposed changes

The fix is for rare failures for gfx12, for example:
```
[fp16|batch|bshd] b:3, h:2/1, s:200/520, d:32/32, scale_s:0.176777, bias:e, p_drop:0.2, lse:1, squant:0, mask:t(128:30), v:r, fmha_fwd_d32_fp16_batch_b64x64x16x32x32x32_r4x1x1_r4x1x1_w16x16x16_w16x16x16_qr_vr_psskddv_nlogits_bias_mask_lse_dropout_nskip_nsquant_ntrload, 0.980 ms, 0.02 TFlops, 0.36 GB/sOUT Error: Incorrect results!        out[5120] != ref[5120]: 0.5283203 != 0.5258789
OUT Error: Incorrect results!        out[5121] != ref[5121]: 0.5029297 != 0.5048828
OUT Error: Incorrect results!        out[5122] != ref[5122]: 0.4931641 != 0.5019531
OUT Error: Incorrect results!        out[5123] != ref[5123]: 0.4858398 != 0.4885254
OUT Error: Incorrect results!        out[5124] != ref[5124]: 0.5078125 != 0.5112305
OUT Error: Incorrect results!        out[5125] != ref[5125]: 0.5024414 != 0.5083008
OUT Error: Incorrect results!        out[5126] != ref[5126]: 0.4829102 != 0.4768066
max err: 0.008789062, number of errors: 366, 2.859375% wrong values
OUT mismatch found at batch: 1
	seqlen_q: 200
	seqlen_k: 520
	seqstart_q (logical): [0, 200, 400, 600]
	seqstart_q (physical): [0, -1, -2, -3]
	seqstart_k (logical): [0, 520, 1040, 1560]
	seqstart_k (physical): [0, -1, -2, -3]
	query_offset used: 0
	key_offset used: 0
, valid:n
```
(values can be also NaN)

The failures can be reproduced locally with `smoke_test_fwd.sh` or `CK_TILE_FMHA_LONG_TESTS=1 bin/test_ck_tile_fmha_fwd_fp16 --gtest_filter="TestCkTileFmhaFwd/AllLong.FmhaFwdFp16/*"`.
It may need hundreds of repeats to trigger the failure so it's preferable to run the tests with `--gtest_repeat=-1 --gtest_shuffle --gtest_throw_on_failure`.

The cause: `BlockFmhaPipelineQRKSVS` reuses LDS for K and dropout so there must be `block_sync_lds` between loading k_lds_window by gemm_0 and storing dropout randval. The issue is similar to #2876 and #2934.

Theoretically gfx9 GPUs are also affected but there are less instances with the `"qr"` pipeline (most of fp16 and bf16 instances use `"qr_async"`, fp8 instances use `"qr"` but without dropout).

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

