### PR TITLE
Generating Redis Server Stats

### DIFF
--- a/script/sccache_wrapper.sh
+++ b/script/sccache_wrapper.sh
@@ -52,5 +52,22 @@ if [ "${ENFORCE_REDIS}" == "true" ]; then
 fi
 setup_rocm_compilers_hash_file
 $SCCACHE_BIN --version
+echo "=== Starting sccache server at $(date) ==="
 $SCCACHE_BIN --start-server
+
+# Log initial sccache statistics
+echo "=== Initial sccache statistics ==="
+$SCCACHE_BIN --show-stats || echo "Could not get initial stats"
+
+# Test Redis connectivity and performance
+echo "=== Testing Redis connectivity ==="
+start_time=$(date +%s%N)
+redis-cli -u ${SCCACHE_REDIS} ping || echo "Redis ping failed"
+end_time=$(date +%s%N)
+latency=$(( (end_time - start_time) / 1000000 ))
+echo "Redis ping latency: ${latency}ms"
+
+# Check Redis memory status
+echo "=== Redis memory status ==="
+redis-cli -u ${SCCACHE_REDIS} info memory | grep -E "(used_memory|maxmemory|evicted_keys)" || echo "Could not get Redis memory info"
 


### PR DESCRIPTION
## Proposed changes

Adding additional logging to capture stats from the Redis server. This data will be used to track the status of the Redis server and aid in creating early detection warnings.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

