### PR TITLE
feat(block_scale_gemm): Support Row-Row-Row major layout for aquant quant mode

### DIFF
--- a/example/ck_tile/38_block_scale_gemm/gemm_quant_basic.cpp
+++ b/example/ck_tile/38_block_scale_gemm/gemm_quant_basic.cpp
@@ -60,8 +60,8 @@ float gemm_calc_quant(const ck_tile::QuantGemmHostArgs& args, const ck_tile::str
     using BaseGemmPipeline = std::conditional_t<
         GemmConfig::PreshuffleB == true,
         ck_tile::BaseWeightPreshufflePipelineAGmemBGmemCRegV2<GemmPipelineProblem>,
-        ck_tile::BaseAQuantGemmPipelineAgBgCrMem<GemmPipelineProblem>>; // memory pipeline hardcoded
-                                                                        // for aquant
+        ck_tile::BaseAQuantGemmPipelineAgBgCrCompV3<GemmPipelineProblem>>; // memory pipeline
+                                                                           // hardcoded for aquant
 
     const ck_tile::index_t K_split =
         (args.K + GemmConfig::K_Tile - 1) / GemmConfig::K_Tile * GemmConfig::K_Tile;
@@ -120,8 +120,8 @@ float gemm_calc_quant(const ck_tile::QuantGemmHostArgs& args, const ck_tile::str
             ck_tile::GemmPipelineAgBgCrCompV3<PipelineProblem>,
             std::conditional_t<
                 QuantMode == ck_tile::QuantType::AQuantGrouped,
-                ck_tile::AQuantGemmPipelineAgBgCrMem<PipelineProblem>, // memory pipeline hardcoded
-                                                                       // for aquant
+                ck_tile::AQuantGemmPipelineAgBgCrCompV3<PipelineProblem>,
+
                 std::conditional_t<GemmConfig::PreshuffleB == true,
                                    ck_tile::WPQuantBPipelineAgBgCrV2<PipelineProblem>,
                                    ck_tile::BQuantGemmPipelineAgBgCrCompV3<PipelineProblem>>>>;
@@ -455,7 +455,4 @@ int run_gemm_example(int argc, char* argv[])
     }
 }
 
-int main(int argc, char* argv[])
-{
-    return !run_gemm_example<GemmConfigPreshuffleB_Bquant_prefill>(argc, argv);
-}
+int main(int argc, char* argv[]) { return !run_gemm_example<GemmConfigQuant>(argc, argv); }

--- a/example/ck_tile/38_block_scale_gemm/gemm_quant_basic.cpp
+++ b/example/ck_tile/38_block_scale_gemm/gemm_quant_basic.cpp
@@ -245,7 +245,8 @@ int run_gemm_example_prec_type(std::string a_layout, std::string b_layout, int a
     }
 
     if constexpr(std::is_same_v<typename TypeConfig::ADataType, ck_tile::fp8_t> ||
-                 std::is_same_v<typename TypeConfig::ADataType, ck_tile::bf8_t>)
+                 std::is_same_v<typename TypeConfig::ADataType, ck_tile::bf8_t> ||
+                 std::is_same_v<typename TypeConfig::ADataType, ck_tile::pk_int4_t>)
     {
         if(a_layout == "R" && b_layout == "C")
         {
@@ -262,21 +263,21 @@ int run_gemm_example_prec_type(std::string a_layout, std::string b_layout, int a
                                                      QuantMode>(
                     argc, argv, Row{}, Row{}, Row{}, Row{}, Row{});
             }
-            // else if(a_layout == "C" && b_layout == "C")
-            // {
-            //     return run_gemm_example_with_layouts<GemmConfig,
-            //                                          TypeConfig,
-            //                                          QuantGroupSize,
-            //                                          QuantMode>(
-            //         argc, argv, Col{}, Col{}, Col{}, Col{}, Col{});
-            // }
             else if(a_layout == "C" && b_layout == "R")
             {
-                return run_gemm_example_with_layouts<GemmConfig,
-                                                     TypeConfig,
-                                                     QuantGroupSize,
-                                                     QuantMode>(
-                    argc, argv, Col{}, Row{}, Row{}, Col{}, Row{});
+                if constexpr(!std::is_same_v<typename TypeConfig::ADataType, ck_tile::pk_int4_t>)
+                {
+                    return run_gemm_example_with_layouts<GemmConfig,
+                                                         TypeConfig,
+                                                         QuantGroupSize,
+                                                         QuantMode>(
+                        argc, argv, Col{}, Row{}, Row{}, Col{}, Row{});
+                }
+                else
+                {
+                    throw std::runtime_error(
+                        "Unsupported memory layout (C,R) for pk_int4_t data type!");
+                }
             }
             else
             {

--- a/example/ck_tile/38_block_scale_gemm/gemm_quant_basic.cpp
+++ b/example/ck_tile/38_block_scale_gemm/gemm_quant_basic.cpp
@@ -60,8 +60,7 @@ float gemm_calc_quant(const ck_tile::QuantGemmHostArgs& args, const ck_tile::str
     using BaseGemmPipeline = std::conditional_t<
         GemmConfig::PreshuffleB == true,
         ck_tile::BaseWeightPreshufflePipelineAGmemBGmemCRegV2<GemmPipelineProblem>,
-        ck_tile::BaseAQuantGemmPipelineAgBgCrCompV3<GemmPipelineProblem>>; // memory pipeline
-                                                                           // hardcoded for aquant
+        ck_tile::BaseAQuantGemmPipelineAgBgCrCompV3<GemmPipelineProblem>>;
 
     const ck_tile::index_t K_split =
         (args.K + GemmConfig::K_Tile - 1) / GemmConfig::K_Tile * GemmConfig::K_Tile;
@@ -252,6 +251,21 @@ int run_gemm_example_prec_type(std::string a_layout, std::string b_layout, int a
         {
             return run_gemm_example_with_layouts<GemmConfig, TypeConfig, QuantGroupSize, QuantMode>(
                 argc, argv, Row{}, Row{}, Col{}, Col{}, Row{});
+        }
+        if constexpr(QuantMode == ck_tile::QuantType::AQuantGrouped)
+        {
+            if(a_layout == "R" && b_layout == "R")
+            {
+                return run_gemm_example_with_layouts<GemmConfig,
+                                                     TypeConfig,
+                                                     QuantGroupSize,
+                                                     QuantMode>(
+                    argc, argv, Row{}, Row{}, Row{}, Row{}, Row{});
+            }
+            else
+            {
+                throw std::runtime_error("Unsupported memory layout for the input matrices!");
+            }
         }
         else
         {

--- a/example/ck_tile/38_block_scale_gemm/gemm_quant_basic.cpp
+++ b/example/ck_tile/38_block_scale_gemm/gemm_quant_basic.cpp
@@ -36,19 +36,20 @@ float gemm_calc_quant(const ck_tile::QuantGemmHostArgs& args, const ck_tile::str
 
     using TilePartitioner = ck_tile::GemmTile1DPartitioner<GemmShape>;
 
-    using GemmTraits = ck_tile::TileGemmQuantTraits<GemmConfig::kPadM,
-                                                    GemmConfig::kPadN,
-                                                    GemmConfig::kPadK,
-                                                    GemmConfig::PreshuffleQuant,
-                                                    GemmConfig::PreshuffleB,
-                                                    ALayout,
-                                                    BLayout,
-                                                    CLayout,
-                                                    QuantMode,
-                                                    ALayout, // for AQLayout
-                                                    BLayout, // for BQLayout
-                                                    false,
-                                                    GemmConfig::DoubleSmemBuffer>;
+    using GemmTraits =
+        ck_tile::TileGemmQuantTraits<GemmConfig::kPadM,
+                                     GemmConfig::kPadN,
+                                     GemmConfig::kPadK,
+                                     GemmConfig::PreshuffleQuant,
+                                     GemmConfig::PreshuffleB,
+                                     ALayout,
+                                     BLayout,
+                                     CLayout,
+                                     QuantMode,
+                                     ck_tile::tensor_layout::gemm::RowMajor,    // for AQLayout
+                                     ck_tile::tensor_layout::gemm::ColumnMajor, // for BQLayout
+                                     false,
+                                     GemmConfig::DoubleSmemBuffer>;
 
     using GemmPipelineProblem = ck_tile::GemmPipelineProblemBase<typename TypeConfig::ADataType,
                                                                  typename TypeConfig::BDataType,
@@ -243,8 +244,7 @@ int run_gemm_example_prec_type(std::string a_layout, std::string b_layout, int a
             "Preshuffling weight matrix is not supported for AQuant or RowColQuant");
     }
 
-    if constexpr(std::is_same_v<typename TypeConfig::ADataType, ck_tile::pk_int4_t> ||
-                 std::is_same_v<typename TypeConfig::ADataType, ck_tile::fp8_t> ||
+    if constexpr(std::is_same_v<typename TypeConfig::ADataType, ck_tile::fp8_t> ||
                  std::is_same_v<typename TypeConfig::ADataType, ck_tile::bf8_t>)
     {
         if(a_layout == "R" && b_layout == "C")
@@ -261,6 +261,22 @@ int run_gemm_example_prec_type(std::string a_layout, std::string b_layout, int a
                                                      QuantGroupSize,
                                                      QuantMode>(
                     argc, argv, Row{}, Row{}, Row{}, Row{}, Row{});
+            }
+            // else if(a_layout == "C" && b_layout == "C")
+            // {
+            //     return run_gemm_example_with_layouts<GemmConfig,
+            //                                          TypeConfig,
+            //                                          QuantGroupSize,
+            //                                          QuantMode>(
+            //         argc, argv, Col{}, Col{}, Col{}, Col{}, Col{});
+            // }
+            else if(a_layout == "C" && b_layout == "R")
+            {
+                return run_gemm_example_with_layouts<GemmConfig,
+                                                     TypeConfig,
+                                                     QuantGroupSize,
+                                                     QuantMode>(
+                    argc, argv, Col{}, Row{}, Row{}, Col{}, Row{});
             }
             else
             {

--- a/include/ck_tile/ops/gemm_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_v3.hpp
+++ b/include/ck_tile/ops/gemm_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_v3.hpp
@@ -330,7 +330,7 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
             if constexpr(is_a_col_major)
             {
                 auto a_shuffle_tmp = make_static_distributed_tensor<ADataType>(
-                    Policy::template make_shuffled_2d_static_tile_distribution<Problem>());
+                    Policy::template MakeShuffledARegTileDistribution<Problem>());
                 transpose_tile2d(a_shuffle_tmp, a_block_tile);
                 Base::LocalPrefill(a_copy_lds_window, a_shuffle_tmp, a_element_func);
             }
@@ -342,7 +342,7 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
             if constexpr(is_b_row_major)
             {
                 auto b_shuffle_tmp = make_static_distributed_tensor<BDataType>(
-                    Policy::template make_shuffled_2d_static_tile_distribution<Problem>());
+                    Policy::template MakeShuffledBRegTileDistribution<Problem>());
                 transpose_tile2d(b_shuffle_tmp, b_block_tile);
                 Base::LocalPrefill(b_copy_lds_window, b_shuffle_tmp, b_element_func);
             }

--- a/test/ck_tile/gemm_block_scale/test_gemm_quant_typed.cpp
+++ b/test/ck_tile/gemm_block_scale/test_gemm_quant_typed.cpp
@@ -31,6 +31,12 @@ using AQuantTypes = ::testing::Types<
     std::tuple<RowMajor, ColumnMajor, RowMajor, PkInt4, FP8, FP8, Half, AQuantGrouped, GemmConfigBase, GroupSize>,
     std::tuple<RowMajor, ColumnMajor, RowMajor, PkInt4, BF8, BF8, Half, AQuantGrouped, GemmConfigBase, GroupSize>,
 
+    // RRR layout (RowMajor A, RowMajor B, RowMajor C) with basic config
+    std::tuple<RowMajor, RowMajor, RowMajor, FP8, FP8, float, Half, AQuantGrouped, GemmConfigBase, GroupSize>,
+    std::tuple<RowMajor, RowMajor, RowMajor, BF8, BF8, float, Half, AQuantGrouped, GemmConfigBase, GroupSize>,
+    std::tuple<RowMajor, RowMajor, RowMajor, PkInt4, FP8, FP8, Half, AQuantGrouped, GemmConfigBase, GroupSize>,
+    std::tuple<RowMajor, RowMajor, RowMajor, PkInt4, BF8, BF8, Half, AQuantGrouped, GemmConfigBase, GroupSize>,
+
     // PreshuffleQuant = false && TransposeC = true 
     std::tuple<RowMajor, ColumnMajor, RowMajor, FP8, FP8, float, Half, AQuantGrouped, GemmConfigTransposeC, GroupSize>,
     std::tuple<RowMajor, ColumnMajor, RowMajor, BF8, BF8, float, Half, AQuantGrouped, GemmConfigTransposeC, GroupSize>,


### PR DESCRIPTION
## Proposed changes

This PR adds RRR layout support for aquat in `example/ck_tile/38_block_scale_gemm/gemm_quant_basic.cpp`.
Unit tests are added.

This PR is not updated with develop. It awaits the regression introduced in #3074 to be fixed.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

