### PR TITLE
Fix compilation errors with clang22.

### DIFF
--- a/include/ck_tile/core/utility/static_counter.hpp
+++ b/include/ck_tile/core/utility/static_counter.hpp
@@ -102,11 +102,14 @@ struct static_counter_uniq_;
 }
 
 #define MAKE_SC() \
-    ck_tile::static_counter<ck_tile::impl::static_counter_uniq_<__COUNTER__>> {}
-#define MAKE_SC_WITH(start_, step_) \
-    ck_tile::static_counter<ck_tile::impl::static_counter_uniq_<__COUNTER__>, start_, step_> {}
-#define NEXT_SC(c_) c_.next<__COUNTER__>()
-#define NEXT_SCI(c_, static_i_) c_.next<__COUNTER__ + static_i_>()
+    __extension__ ck_tile::static_counter<ck_tile::impl::static_counter_uniq_<__COUNTER__>> {}
+#define MAKE_SC_WITH(start_, step_)                                                     \
+    __extension__ ck_tile::                                                             \
+        static_counter<ck_tile::impl::static_counter_uniq_<__COUNTER__>, start_, step_> \
+    {                                                                                   \
+    }
+#define NEXT_SC(c_) __extension__ c_.next<__COUNTER__>()
+#define NEXT_SCI(c_, static_i_) __extension__ c_.next<__COUNTER__ + static_i_>()
 
 // Usage:
 // constexpr auto c = MAKE_SC()

--- a/profiler/src/profiler_operation_registry.hpp
+++ b/profiler/src/profiler_operation_registry.hpp
@@ -74,6 +74,6 @@ class ProfilerOperationRegistry final
 #define PP_CONCAT(x, y) PP_CONCAT_IMPL(x, y)
 #define PP_CONCAT_IMPL(x, y) x##y
 
-#define REGISTER_PROFILER_OPERATION(name, description, operation)              \
-    static const bool PP_CONCAT(operation_registration_result_, __COUNTER__) = \
+#define REGISTER_PROFILER_OPERATION(name, description, operation)                            \
+    __extension__ static const bool PP_CONCAT(operation_registration_result_, __COUNTER__) = \
         ::ProfilerOperationRegistry::GetInstance().Add(name, description, operation)


### PR DESCRIPTION
## Proposed changes

I've recently observed a new compilation error with clang22:

[2025-11-04T21:24:34.940Z] /var/jenkins/workspace/MLLIBS_composable_kernel_develop/profiler/src/profile_groupnorm_bwd_data.cpp:102:1: error: '__COUNTER__' is a C2y extension [-Werror,-Wc2y-extensions]
[2025-11-04T21:24:34.940Z]   102 | REGISTER_PROFILER_OPERATION("groupnorm_bwd_data",
[2025-11-04T21:24:34.940Z]       | ^
[2025-11-04T21:24:34.941Z] /var/jenkins/workspace/MLLIBS_composable_kernel_develop/profiler/src/profiler_operation_registry.hpp:78:65: note: expanded from macro 'REGISTER_PROFILER_OPERATION'
[2025-11-04T21:24:34.941Z]    78 |     static const bool PP_CONCAT(operation_registration_result_, __COUNTER__) = \
[2025-11-04T21:24:34.941Z]       |                                                                 ^
[2025-11-04T21:24:34.941Z] 1 error generated when compiling for gfx10-3-generic.

This should fix it.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged