### PR TITLE
Add .clangd and CMakeUserPresets.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,12 @@ docs/doxygen/xml
 cmake-build*/
 build*/
 
+# LSP configuration
+.clangd
+
+# User-defined CMake presets
+CMakeUserPresets.json
+
 # Python virtualenv
 .venv/
 


### PR DESCRIPTION
## Proposed changes

For those who don't want to rely on VSCode settings for LSP configuration, a `.clangd` file in the project root is necessary, but should not be committed into source control.

It's also convenient to gather presets for CMake configuration into a `CMakeUserPresets.json` file, but such files should also not be committed.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

