### PR TITLE
[CK TILE GEMM Quant] Revert to use BaseAQuantGemmPipelineAgBgCrMem

### DIFF
--- a/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
+++ b/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
@@ -61,12 +61,15 @@ float gemm_calc_quant(const ck_tile::QuantGemmHostArgs& args, const ck_tile::str
                                                                  GemmTraits,
                                                                  ComputeDataType>;
 
-    // This example only supports BQuant (no AQuant)
-    // For non-preshuffled BQuant, use BaseBQuantGemmPipelineAgBgCrCompV3
+    // NOTE: BaseAQuantGemmPipelineAgBgCrMem is utilized when GemmConfig::PreshuffleB is set to
+    // false. This choice is due to the suboptimal performance of
+    // BaseBQuantGemmPipelineAgBgCrCompV3. The suspected cause is inefficiencies in the TailHandler
+    // of BaseBQuantGemmPipelineAgBgCrCompV3. Until the issue is resolved,
+    // BaseAQuantGemmPipelineAgBgCrMem is used, despite the name being somewhat misleading.
     using BaseGemmPipeline = std::conditional_t<
         GemmConfig::PreshuffleB == true,
         ck_tile::BaseWeightPreshufflePipelineAGmemBGmemCRegV2<GemmPipelineProblem>,
-        ck_tile::BaseBQuantGemmPipelineAgBgCrCompV3<GemmPipelineProblem>>;
+        ck_tile::BaseAQuantGemmPipelineAgBgCrMem<GemmPipelineProblem>>;
 
     const ck_tile::index_t K_split =
         (args.K + GemmConfig::K_Tile - 1) / GemmConfig::K_Tile * GemmConfig::K_Tile;


### PR DESCRIPTION
compared 306e25a27d73c05879541d0b1f5e0b6aa8 with latest develop br (1b1c46e508c1fd40a03f54114b6b78629032fb4f)

Found that these 2 commits have the same perf. 

However, different GemmConfig and BaseGemmPipeline are used in these 2 commits. So gemm quant example will give different performance data.

GemmConfig : M =32768 N =4096 K =2048 StrideA =2048 StrideAQ =0 StrideB =2048 StrideC =4096 A_Layout =RowMajor B_Layout =ColumnMajor C_Layout =RowMajor StrideBQ =16 A_Type = fp8 AQ_Type = fp32 B_Type = fp8 BQ_Type = fp32 Acc_Type = fp32 C_Type = fp16 QuantMode = BQuantGrouped PreshuffleQuant = false

|branch | preshuffle_B | base pipeline | time|
|-- | -- | -- | --|
|1b1c46e508c1fd40a03f54114b6b78629032fb4f | true | BaseWeightPreshufflePipelineAGmemBGmemCRegV2 | 0.778795 ms|
|1b1c46e508c1fd40a03f54114b6b78629032fb4f | true | BaseAQuantGemmPipelineAgBgCrMem | 0.780953 ms|
|1b1c46e508c1fd40a03f54114b6b78629032fb4f | false | BaseBQuantGemmPipelineAgBgCrCompV3 | 1.34292 ms|
|1b1c46e508c1fd40a03f54114b6b78629032fb4f | false | BaseAQuantGemmPipelineAgBgCrMem | 0.946237 ms|

Summary: 

- 2D BQuant PR did not change the perf of Gemm Quant
- BaseGemmPipeline affects the perf of Gemm Quant
  - BaseBQuantGemmPipelineAgBgCrCompV3 has a worse perf than BaseWeightPreshufflePipelineAGmemBGmemCRegV2 and BaseAQuantGemmPipelineAgBgCrMem
  - My initial thought is that TailHandler is the cause.
- BaseAQuantGemmPipelineAgBgCrMem has some issues so that it cannot be used as the GemmPipeline. But it works for BaseGemmPipeline. 
- We can use BaseAQuantGemmPipelineAgBgCrMem as the BaseGemmPipeline for now. 
  


## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

