### PR TITLE
[CK_BUILDER] fixes

### DIFF
--- a/experimental/builder/include/ck_tile/builder/reflect/instance_traits_device_grouped_conv_fwd_multiple_abd_xdl_cshuffle.hpp
+++ b/experimental/builder/include/ck_tile/builder/reflect/instance_traits_device_grouped_conv_fwd_multiple_abd_xdl_cshuffle.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "instance_traits.hpp"
+#include "instance_traits_util.hpp"
 
 // Forward declaration to avoid circular dependency.
 namespace ck::tensor_operation::device {

--- a/experimental/builder/include/ck_tile/builder/reflect/instance_traits_device_grouped_conv_fwd_multiple_d_xdl_large_tensor_cshuffle.hpp
+++ b/experimental/builder/include/ck_tile/builder/reflect/instance_traits_device_grouped_conv_fwd_multiple_d_xdl_large_tensor_cshuffle.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "instance_traits.hpp"
+#include "instance_traits_util.hpp"
 
 // Forward declaration to avoid circular dependency.
 namespace ck::tensor_operation::device {

--- a/experimental/builder/test/conv/test_conv_traits.cpp
+++ b/experimental/builder/test/conv/test_conv_traits.cpp
@@ -74,7 +74,7 @@ TEST_F(ConvTraitsTest, ConvFwdTraitsExtraction)
                          8>, // CDEBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock
             8,               // CDEBlockTransferScalarPerVector_NPerBlock
             ck::BlockGemmPipelineScheduler::Intrawave, // BlkGemmPipeSched
-            ck::PipelineVersion::v1,                   // BlkGemmPipelineVer
+            ck::BlockGemmPipelineVersion::v1,          // BlkGemmPipelineVer
             ck::half_t,                                // AComputeDataType
             ck::half_t,                                // BComputeDataType
             false>;                                    // DirectLoad

--- a/experimental/builder/test/test_testing_utils.cpp
+++ b/experimental/builder/test/test_testing_utils.cpp
@@ -32,10 +32,10 @@ TEST(InstanceSet, FromFactory)
     EXPECT_THAT(instances.instances.size(), testing::Gt(0));
 
     const auto* el =
-        "DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3<2,NHWGC,GKYXC,EmptyTuple,NHWGK,fp16,fp16,"
-        "fp32,fp16,EmptyTuple,fp16,PassThrough,PassThrough,PassThrough,OddC,MNKPadding,64,16,16,64,"
-        "8,8,16,16,1,1,Seq(8,8,1),Seq(1,0,2),Seq(1,0,2),2,8,8,0,Seq(8,8,1),Seq(1,0,2),Seq(1,0,2),2,"
-        "8,8,0,1,1,Seq(1,16,1,4),4,Intrawave,v2,fp16,fp16>";
+        "DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle<2,NHWGC,GKYXC,EmptyTuple,NHWGK,fp16,fp16,"
+        "fp32,fp16,EmptyTuple,fp16,PassThrough,PassThrough,PassThrough,Default,MNKPadding,1,128,"
+        "128,128,32,8,8,32,32,4,2,Seq(4,32,1),Seq(1,0,2),Seq(1,0,2),2,8,8,1,Seq(4,32,1),Seq(1,0,2),"
+        "Seq(1,0,2),2,8,8,1,1,1,Seq(1,16,1,8),8,fp16,fp16,Default,1>";
     EXPECT_THAT(instances.instances, testing::Contains(el));
 }
 


### PR DESCRIPTION
## Background

It looks like some CK builder tests do currently not compile. I'm not exactly sure what happened as to why these don't compile properly anymore, because from what I can tell they should never have worked properly.

## Proposed changes

This pull request fixes 2 missing headers, one invalid type, and a changed instance string.

~This pull request is currently based on top of @shumway's fixes branch, since that is also required to properly fix the tests. I will rebase it once those changes have been merged.~ Rebased

To test without waiting for CK's device ops library to be built, run the following:
```
$ ninja test_ckb_conv_builder test_ckb_conv_description test_ckb_conv_traits test_ckb_get_instance_string test_ckb_
inline_diff
$ for f in $(ls bin/ | grep test_ckb); do bin/$f; done
```
and check whether all tests pass. If you feel like waiting for a device ops library build, also check `test_ckb_testing_utils`.
