### PR TITLE
[ck_tile] Pooling example - Improved tile sizes

### DIFF
--- a/example/ck_tile/36_pooling/pool3d.cpp
+++ b/example/ck_tile/36_pooling/pool3d.cpp
@@ -31,8 +31,8 @@ auto create_args(int argc, char* argv[])
         .insert("RightPy", "1", "right padding h")
         .insert("RightPx", "1", "right padding w")
         .insert("v", "1", "cpu validation or not")
-        .insert("warmup", "5", "cold iter")
-        .insert("repeat", "10", "hot iter");
+        .insert("warmup", "20", "cold iter")
+        .insert("repeat", "100", "hot iter");
 
     bool result = arg_parser.parse(argc, argv);
     return std::make_tuple(result, arg_parser);

--- a/example/ck_tile/36_pooling/pool3d.cpp
+++ b/example/ck_tile/36_pooling/pool3d.cpp
@@ -31,8 +31,8 @@ auto create_args(int argc, char* argv[])
         .insert("RightPy", "1", "right padding h")
         .insert("RightPx", "1", "right padding w")
         .insert("v", "1", "cpu validation or not")
-        .insert("warmup", "0", "cold iter")
-        .insert("repeat", "1", "hot iter");
+        .insert("warmup", "5", "cold iter")
+        .insert("repeat", "10", "hot iter");
 
     bool result = arg_parser.parse(argc, argv);
     return std::make_tuple(result, arg_parser);
@@ -120,10 +120,10 @@ bool run(const ck_tile::ArgParser& arg_parser)
     in_buf.ToDevice(in.data());
 
     using ReduceOp   = ck_tile::ReduceOp::Max;
-    using BlockWarps = ck_tile::sequence<4, 1>;
-    using BlockTile  = ck_tile::sequence<128, 128>;
-    using WarpTile   = ck_tile::sequence<32, 128>;
-    using ThreadTile = ck_tile::sequence<8, 8>;
+    using BlockWarps = ck_tile::sequence<1, 1>;
+    using BlockTile  = ck_tile::sequence<128, 1>;
+    using WarpTile   = ck_tile::sequence<128, 1>;
+    using ThreadTile = ck_tile::sequence<2, 1>;
 
     using Shape   = ck_tile::PoolShape<BlockWarps, BlockTile, WarpTile, ThreadTile>;
     using Problem = ck_tile::PoolProblem<InDataType,

--- a/test/ck_tile/pooling/test_pooling.cpp
+++ b/test/ck_tile/pooling/test_pooling.cpp
@@ -295,10 +295,10 @@ class TestCkTilePooling : public ::testing::Test
     }
 };
 
-using Shape1_BlockWarps = ck_tile::sequence<4, 1>;
-using Shape1_BlockTile  = ck_tile::sequence<128, 128>;
-using Shape1_WarpTile   = ck_tile::sequence<32, 128>;
-using Shape1_ThreadTile = ck_tile::sequence<8, 8>;
+using Shape1_BlockWarps = ck_tile::sequence<1, 1>;
+using Shape1_BlockTile  = ck_tile::sequence<128, 1>;
+using Shape1_WarpTile   = ck_tile::sequence<128, 1>;
+using Shape1_ThreadTile = ck_tile::sequence<2, 1>;
 
 // Cross-warp configuration
 using Shape2_BlockWarps = ck_tile::sequence<2, 2>;


### PR DESCRIPTION
- modified tile sizes for improved example performance

## Checklist

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

