### PR TITLE
[WIP] Fix CI failed on hdim=160

### DIFF
--- a/example/ck_tile/01_fmha/CMakeLists.txt
+++ b/example/ck_tile/01_fmha/CMakeLists.txt
@@ -44,7 +44,7 @@ set(FMHA_FWD_CODE_GEN_COMMON_ARGS
   ${CMAKE_CURRENT_LIST_DIR}/generate.py
   --targets ${FMHA_TARGETS_ARG}
   --api ${FMHA_FWD_APIS}
-  --optdim 32,64,128,256
+  --optdim 32,64,128,160,256
   # --filter fmha_fwd...
 )
 set(FMHA_BWD_CODE_GEN_COMMON_ARGS
@@ -52,7 +52,7 @@ set(FMHA_BWD_CODE_GEN_COMMON_ARGS
   --targets ${FMHA_TARGETS_ARG}
   --api bwd
   --receipt 3
-  --optdim 32,64,96,128,256
+  --optdim 32,64,96,128,160,256
   # --filter fmha_bwd_dot...@fmha_bwd_convert...@fmha_bwd...
 )
 

--- a/example/ck_tile/01_fmha/codegen/ops/fmha_fwd.py
+++ b/example/ck_tile/01_fmha/codegen/ops/fmha_fwd.py
@@ -30,7 +30,7 @@ from codegen.utils import check_duplicates_and_paddings, if_, indent, update_fil
 
 DTYPE_BITS = {"fp32": 32, "fp16": 16, "bf16": 16, "fp8": 8, "bf8": 8}
 
-K0_MAX_SUBMAX_MAP = {32: 32, 48: 48, 64: 64, 96: 128, 128: 128, 192: 192, 256: 256}
+K0_MAX_SUBMAX_MAP = {32: 32, 48: 48, 64: 64, 96: 128, 128: 128, 160: 160, 192: 192, 256: 256}
 
 FMHA_FWD_KERNEL_HEADER = """// SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.\n
@@ -667,7 +667,7 @@ class KernelComponentFactoryGfx9:
                               FmhaFwdTileSize( 32,  32, 128, 128,  32, 128,  1, 1, 1,  1, 1, 1,  32, 32, 16,  32, 32, 16,  -1),
                               FmhaFwdTileSize(128,  64,  32, 128,  16, 128,  4, 1, 1,  4, 1, 1,  32, 32, 16,  32, 32, 16,  -1),
                               FmhaFwdTileSize(128, 128,  32, 128,  32, 128,  4, 1, 1,  4, 1, 1,  32, 32, 16,  32, 32, 16,  -1)],
-              # (160, 160) : [FmhaFwdTileSize(128, 128 , 32, 160,  32, 160,  4, 1, 1,  4, 1, 1,  32, 32, 16,  32, 32, 16,   1)],
+                (160, 160) : [FmhaFwdTileSize(128, 128 , 32, 160,  32, 160,  4, 1, 1,  4, 1, 1,  32, 32, 16,  32, 32, 16,   1)],
                 (192, 128) : [FmhaFwdTileSize(128, 128,  32, 128,  32, 192,  4, 1, 1,  4, 1, 1,  32, 32, 16,  32, 32, 16,  -1)],
                 (192, 192) : [FmhaFwdTileSize(128, 128,  32, 192,  32, 192,  4, 1, 1,  4, 1, 1,  32, 32, 16,  32, 32, 16,   1)],
                 (256, 256) : [FmhaFwdTileSize(128, 128,  32, 256,  32, 256,  4, 1, 1,  4, 1, 1,  32, 32, 16,  32, 32, 16,  -1)],

--- a/example/ck_tile/01_fmha/codegen/ops/fmha_fwd.py
+++ b/example/ck_tile/01_fmha/codegen/ops/fmha_fwd.py
@@ -30,7 +30,16 @@ from codegen.utils import check_duplicates_and_paddings, if_, indent, update_fil
 
 DTYPE_BITS = {"fp32": 32, "fp16": 16, "bf16": 16, "fp8": 8, "bf8": 8}
 
-K0_MAX_SUBMAX_MAP = {32: 32, 48: 48, 64: 64, 96: 128, 128: 128, 160: 160, 192: 192, 256: 256}
+K0_MAX_SUBMAX_MAP = {
+    32: 32,
+    48: 48,
+    64: 64,
+    96: 128,
+    128: 128,
+    160: 160,
+    192: 192,
+    256: 256,
+}
 
 FMHA_FWD_KERNEL_HEADER = """// SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.\n

--- a/example/ck_tile/01_fmha/codegen/ops/fmha_fwd_splitkv.py
+++ b/example/ck_tile/01_fmha/codegen/ops/fmha_fwd_splitkv.py
@@ -788,7 +788,7 @@ class KernelComponentFactoryBase:
                 "64": FmhaFwdSplitKVCombineTileSize(32, -1),
                 "96": FmhaFwdSplitKVCombineTileSize(32, -1),
                 "128": FmhaFwdSplitKVCombineTileSize(32, -1),
-                # "160" : FmhaFwdSplitKVCombineTileSize(32, -1),
+                "160" : FmhaFwdSplitKVCombineTileSize(32, -1),
                 "256": FmhaFwdSplitKVCombineTileSize(32, -1),
             }
         elif dtype in ["fp8", "bf8"]:
@@ -812,7 +812,7 @@ class KernelComponentFactoryGfx9(KernelComponentFactoryBase):
                 "64" : FmhaFwdTileSize( 64,  64, 32,  64, 32,  64, 4, 1, 1, 4, 1, 1, 16, 16, 16, 16, 16, 16, -1),
                 "96" : FmhaFwdTileSize( 64, 128, 32, 128, 32,  96, 4, 1, 1, 4, 1, 1, 16, 16, 16, 16, 16, 16, -1),
                 "128": FmhaFwdTileSize( 64, 128, 32, 128, 32, 128, 4, 1, 1, 4, 1, 1, 16, 16, 16, 16, 16, 16, -1),
-                # "160" : FmhaFwdTileSize(64, 128, 32, 160, 32, 160, 4, 1, 1, 4, 1, 1, 16, 16, 16, 16, 16, 16, -1),
+                "160" : FmhaFwdTileSize(64, 128, 32, 160, 32, 160, 4, 1, 1, 4, 1, 1, 16, 16, 16, 16, 16, 16, -1),
                 "256": FmhaFwdTileSize( 64, 128, 32, 256, 32, 256, 4, 1, 1, 4, 1, 1, 16, 16, 16, 16, 16, 16, -1),
             }  # fmt: skip
         elif dtype in ["fp8", "bf8"]:

--- a/example/ck_tile/01_fmha/codegen/ops/fmha_fwd_splitkv.py
+++ b/example/ck_tile/01_fmha/codegen/ops/fmha_fwd_splitkv.py
@@ -788,7 +788,7 @@ class KernelComponentFactoryBase:
                 "64": FmhaFwdSplitKVCombineTileSize(32, -1),
                 "96": FmhaFwdSplitKVCombineTileSize(32, -1),
                 "128": FmhaFwdSplitKVCombineTileSize(32, -1),
-                "160" : FmhaFwdSplitKVCombineTileSize(32, -1),
+                "160": FmhaFwdSplitKVCombineTileSize(32, -1),
                 "256": FmhaFwdSplitKVCombineTileSize(32, -1),
             }
         elif dtype in ["fp8", "bf8"]:

--- a/example/ck_tile/01_fmha/script/smoke_test_fwd.sh
+++ b/example/ck_tile/01_fmha/script/smoke_test_fwd.sh
@@ -65,7 +65,7 @@ run_fp16_bf16_tests() {
     for prec in "fp16" "bf16" ; do
     for mode in 1 0 ; do
     for perm in 0 1 ; do
-    for hdim in 32 64 128 256 ; do
+    for hdim in 32 64 128 160 256 ; do
     for lse in 0 1 ; do
     for bias in "n" "e" "a" ; do
     for p_drop in 0.0 0.2 ; do
@@ -92,7 +92,7 @@ run_fp8_tests() {
     for perm in 0 1 ; do
     for bias in "n" "e" "a" ; do
     for b in 1 2 ; do
-    for hdim in 64 128 256 ; do
+    for hdim in 64 128 160 256 ; do
     
     $EXE -prec=fp8 -init=0 -b=$b -h=1 -d=$hdim -s=128 -bias=$bias -iperm=$perm -operm=$perm -vlayout=r -squant=1 -kname=$KNAME $COMMON_ARGS
 
@@ -103,7 +103,7 @@ run_fp8bf16_tests() {
     for perm in 0 1 ; do
     for bias in "n" "e" "a" ; do
     for b in 1 2 ; do
-    for hdim in 64 128 256 ; do
+    for hdim in 64 128 160 256 ; do
 
     $EXE -prec=fp8bf16 -init=0 -b=$b -h=1 -d=$hdim -s=128 -bias=$bias -iperm=$perm -operm=$perm -vlayout=r -squant=1 -kname=$KNAME $COMMON_ARGS
 
@@ -114,7 +114,7 @@ run_fp8fp32_tests() {
     for perm in 0 1 ; do
     for bias in "n" "e" "a" ; do
     for b in 1 2 ; do
-    for hdim in 128 ; do
+    for hdim in 128 160; do
 
     $EXE -prec=fp8fp32 -init=0 -b=$b -h=1 -d=$hdim -s=128 -bias=$bias -iperm=$perm -operm=$perm -vlayout=r -squant=1 -kname=$KNAME $COMMON_ARGS
 
@@ -125,7 +125,7 @@ run_fp16_appendkv_tests() {
     for s in $(seq 63 1 65) ; do
     for s_k in 65 129 ; do
     for s_knew in 0 64 $s_k ; do
-    for hdim in 32 64 128 256 ; do
+    for hdim in 32 64 128 160 256 ; do
     for ri in 0 1 ; do
     for rdim in 0 16 32 $hdim ; do
     for page_block_size in 0 128 ; do


### PR DESCRIPTION
## Proposed changes

AITER reported that FA fail on hdim=160.

Related PR:
- https://github.com/ROCm/composable_kernel/pull/2539
- https://github.com/ROCm/composable_kernel/pull/2580 

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

