### PR TITLE
[CK_BUILDER] Guard a builder test to avoid gfx11

### DIFF
--- a/experimental/builder/test/conv/test_ckb_conv_fwd_1d_i8.cpp
+++ b/experimental/builder/test/conv/test_ckb_conv_fwd_1d_i8.cpp
@@ -9,6 +9,8 @@ namespace {
 using namespace ck_tile::builder::test_utils;
 
 // 1D I8 (channels-last) with and DEFAULT specialization
+// (not supported on gfx11 and gfx12)
+#if !defined(__gfx11__) && !defined(__gfx12__)
 TEST(FwdConvInstances,
      Create_DeviceGroupedConvFwdMultipleD_Wmma_CShuffle_Instance_1D_FP32_ChannelsFirst_scale)
 {
@@ -31,5 +33,6 @@ TEST(FwdConvInstances,
     run_test<Builder>(
         {"DeviceGroupedConvFwdMultipleD_Wmma_CShuffle", "128, 64, 64, 64", "Default"});
 }
+#endif
 
 } // namespace


### PR DESCRIPTION
We're getting a compile error on gfx11 for an I8 test that doesn't have a supported WMMA implementation. We'll need to build architecture support into the builder, but to get things green I'm just adding an #ifndef guard around the test.
