### PR TITLE
[DRAFT] CCR-C (ABC-Aquant) layout support for block_scale_gemm

### DIFF
--- a/example/ck_tile/38_block_scale_gemm/gemm_quant_basic.cpp
+++ b/example/ck_tile/38_block_scale_gemm/gemm_quant_basic.cpp
@@ -22,7 +22,7 @@ template <typename GemmConfig,
           typename CDEElementWise>
 float gemm_calc_quant(const ck_tile::QuantGemmHostArgs& args, const ck_tile::stream_config& s)
 {
-    static_assert(std::is_same_v<CLayout, ck_tile::tensor_layout::gemm::RowMajor>);
+    // Support both row-major and column-major C layout
     using ComputeDataType = std::conditional_t<QuantMode == ck_tile::QuantType::AQuantGrouped ||
                                                    QuantMode == ck_tile::QuantType::RowColQuant,
                                                typename TypeConfig::BDataType,
@@ -60,12 +60,12 @@ float gemm_calc_quant(const ck_tile::QuantGemmHostArgs& args, const ck_tile::str
     using BaseGemmPipeline = std::conditional_t<
         GemmConfig::PreshuffleB == true,
         ck_tile::BaseWeightPreshufflePipelineAGmemBGmemCRegV2<GemmPipelineProblem>,
-        ck_tile::BaseAQuantGemmPipelineAgBgCrMem<GemmPipelineProblem>>; // memory pipeline hardcoded
-                                                                        // for aquant
+        ck_tile::BaseAQuantGemmPipelineAgBgCrCompV3<GemmPipelineProblem>>;
 
     const ck_tile::index_t K_split =
         (args.K + GemmConfig::K_Tile - 1) / GemmConfig::K_Tile * GemmConfig::K_Tile;
-    const ck_tile::index_t num_loop    = TilePartitioner::GetLoopNum(K_split);
+    const ck_tile::index_t num_loop = TilePartitioner::GetLoopNum(K_split);
+    std::cout << __func__ << "num_loop =" << num_loop << std::endl;
     const bool has_hot_loop            = BaseGemmPipeline::BlockHasHotloop(num_loop);
     const ck_tile::TailNumber tail_num = BaseGemmPipeline::GetBlockLoopTailNum(num_loop);
 
@@ -73,6 +73,8 @@ float gemm_calc_quant(const ck_tile::QuantGemmHostArgs& args, const ck_tile::str
         constexpr bool has_hot_loop_v = has_hot_loop_.value;
         constexpr auto tail_number_v  = tail_number_.value;
         constexpr bool transpose_c    = false;
+
+        std::cout << __func__ << "num_loop =" << num_loop << std::endl;
 
         // row-col and tensor quants use the regular pipeline, A/B quants use their own
         using PipelineProblem = std::conditional_t<
@@ -120,8 +122,8 @@ float gemm_calc_quant(const ck_tile::QuantGemmHostArgs& args, const ck_tile::str
             ck_tile::GemmPipelineAgBgCrCompV3<PipelineProblem>,
             std::conditional_t<
                 QuantMode == ck_tile::QuantType::AQuantGrouped,
-                ck_tile::AQuantGemmPipelineAgBgCrMem<PipelineProblem>, // memory pipeline hardcoded
-                                                                       // for aquant
+                ck_tile::AQuantGemmPipelineAgBgCrCompV3<PipelineProblem>,
+
                 std::conditional_t<GemmConfig::PreshuffleB == true,
                                    ck_tile::WPQuantBPipelineAgBgCrV2<PipelineProblem>,
                                    ck_tile::BQuantGemmPipelineAgBgCrCompV3<PipelineProblem>>>>;
@@ -250,8 +252,15 @@ int run_gemm_example_prec_type(std::string a_layout, std::string b_layout, int a
     {
         if(a_layout == "R" && b_layout == "C")
         {
+            std::cout << __func__ << " A: Row, B: Col, C: Row" << std::endl;
             return run_gemm_example_with_layouts<GemmConfig, TypeConfig, QuantGroupSize, QuantMode>(
                 argc, argv, Row{}, Row{}, Col{}, Col{}, Row{});
+        }
+        else if(a_layout == "C" && b_layout == "C")
+        {
+            std::cout << __func__ << " A: Col, B: Col, C: Row (C-C-R layout)" << std::endl;
+            return run_gemm_example_with_layouts<GemmConfig, TypeConfig, QuantGroupSize, QuantMode>(
+                argc, argv, Col{}, Col{}, Col{}, Col{}, Row{});
         }
         else
         {
@@ -281,11 +290,13 @@ int run_gemm_example(int argc, char* argv[])
 
     if(data_type == "fp8")
     {
+        std::cout << __func__ << " fp8" << std::endl;
         using TypeConfig =
             decltype(GemmQuantTypeConfig<ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, float>{});
 
         if(quant_mode == "aquant")
         {
+            std::cout << __func__ << " aquant" << std::endl;
             return run_gemm_example_prec_type<GemmConfig<ck_tile::fp8_t>,
                                               TypeConfig,
                                               128,
@@ -457,5 +468,6 @@ int run_gemm_example(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
-    return !run_gemm_example<GemmConfigPreshuffleB_Bquant_prefill>(argc, argv);
+    std::cout << __func__ << std::endl;
+    return !run_gemm_example<GemmConfigQuant>(argc, argv);
 }

--- a/example/ck_tile/38_block_scale_gemm/gemm_quant_basic.cpp
+++ b/example/ck_tile/38_block_scale_gemm/gemm_quant_basic.cpp
@@ -258,9 +258,20 @@ int run_gemm_example_prec_type(std::string a_layout, std::string b_layout, int a
         }
         else if(a_layout == "C" && b_layout == "C")
         {
-            std::cout << __func__ << " A: Col, B: Col, C: Row (C-C-R layout)" << std::endl;
-            return run_gemm_example_with_layouts<GemmConfig, TypeConfig, QuantGroupSize, QuantMode>(
-                argc, argv, Col{}, Col{}, Col{}, Col{}, Row{});
+            if constexpr(QuantMode == ck_tile::QuantType::AQuantGrouped &&
+                         !std::is_same_v<typename TypeConfig::ADataType, ck_tile::pk_int4_t>)
+            {
+                std::cout << __func__ << " A: Col, B: Col, C: Row (C-C-R layout)" << std::endl;
+                return run_gemm_example_with_layouts<GemmConfig,
+                                                     TypeConfig,
+                                                     QuantGroupSize,
+                                                     QuantMode>(
+                    argc, argv, Col{}, Col{}, Col{}, Col{}, Row{});
+            }
+            else
+            {
+                throw std::runtime_error("Unsupported quantization mode for C-C-R layout");
+            }
         }
         else
         {

--- a/example/ck_tile/38_block_scale_gemm/gemm_utils.hpp
+++ b/example/ck_tile/38_block_scale_gemm/gemm_utils.hpp
@@ -99,9 +99,9 @@ struct GemmConfigBase
 template <typename PrecType>
 struct GemmConfigQuant : public GemmConfigBase
 {
-    static constexpr ck_tile::index_t M_Tile = 32;
+    static constexpr ck_tile::index_t M_Tile = 16;
     static constexpr ck_tile::index_t N_Tile = 64;
-    static constexpr ck_tile::index_t K_Tile = 512 / sizeof(PrecType);
+    static constexpr ck_tile::index_t K_Tile = 256 / sizeof(PrecType);
 
     static constexpr ck_tile::index_t M_Warp = 1;
     static constexpr ck_tile::index_t N_Warp = 4;

--- a/example/ck_tile/38_block_scale_gemm/gemm_utils.hpp
+++ b/example/ck_tile/38_block_scale_gemm/gemm_utils.hpp
@@ -99,9 +99,9 @@ struct GemmConfigBase
 template <typename PrecType>
 struct GemmConfigQuant : public GemmConfigBase
 {
-    static constexpr ck_tile::index_t M_Tile = 16;
+    static constexpr ck_tile::index_t M_Tile = 32;
     static constexpr ck_tile::index_t N_Tile = 64;
-    static constexpr ck_tile::index_t K_Tile = 256 / sizeof(PrecType);
+    static constexpr ck_tile::index_t K_Tile = 512 / sizeof(PrecType);
 
     static constexpr ck_tile::index_t M_Warp = 1;
     static constexpr ck_tile::index_t N_Warp = 4;

--- a/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
+++ b/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
@@ -293,7 +293,7 @@ int run_gemm_example_with_layouts(int argc,
                 for(ck_tile::index_t k = 0; k < AQK; ++k)
                 {
                     (*aq_tensor_ptr)(m, k) = static_cast<AQDataType>(value);
-                    value += 0.1f;
+                    value += 1.0f;
                 }
             }
             ck_tile::FillUniformDistribution<BDataType>{-5.0f, 5.0f, fill_seed(gen)}(b_k_n);

--- a/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
+++ b/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
@@ -143,6 +143,8 @@ int run_gemm_example_with_layouts(int argc,
     ck_tile::index_t N = arg_parser.get_int("n");
     ck_tile::index_t K = arg_parser.get_int("k");
 
+    std::cout << __func__ << " M =" << M << " N =" << N << " K =" << K << std::endl;
+
     if constexpr(QuantMode == ck_tile::QuantType::AQuantGrouped ||
                  QuantMode == ck_tile::QuantType::BQuantGrouped)
     {
@@ -157,6 +159,7 @@ int run_gemm_example_with_layouts(int argc,
     {
         AQK = K / QuantGroupSize; // Group quantization: AQK = K / GroupSize
         BQK = 0;                  // No B quantization
+        std::cout << __func__ << " AQK =" << AQK << std::endl;
     }
     else if constexpr(QuantMode == ck_tile::QuantType::BQuantGrouped)
     {
@@ -197,6 +200,8 @@ int run_gemm_example_with_layouts(int argc,
     {
         stride_AQ = ck_tile::get_default_stride(M, AQK, stride_AQ, is_row_major(aq_layout));
         stride_BQ = 0; // No B quantization
+        std::cout << __func__ << " stride_AQ =" << stride_AQ << " stride_BQ =" << stride_BQ
+                  << std::endl;
     }
     else if constexpr(QuantMode == ck_tile::QuantType::BQuantGrouped)
     {
@@ -281,8 +286,16 @@ int run_gemm_example_with_layouts(int argc,
             {
                 ck_tile::FillUniformDistribution<ADataType>{-2.0f, 3.0f, fill_seed(gen)}(a_m_k);
             }
-            ck_tile::FillUniformDistribution<AQDataType>{-2.0f, 2.0f, fill_seed(gen)}(
-                *aq_tensor_ptr);
+            // Fill AQ with unique incrementing values starting from 1.0
+            AQDataType value = 1.0f;
+            for(ck_tile::index_t m = 0; m < M; ++m)
+            {
+                for(ck_tile::index_t k = 0; k < AQK; ++k)
+                {
+                    (*aq_tensor_ptr)(m, k) = static_cast<AQDataType>(value);
+                    value += 0.1f;
+                }
+            }
             ck_tile::FillUniformDistribution<BDataType>{-5.0f, 5.0f, fill_seed(gen)}(b_k_n);
         }
         else
@@ -416,6 +429,19 @@ int run_gemm_example_with_layouts(int argc,
         else
             bq_dev_buf_ptr->ToDevice(bq_tensor_ptr->data());
     }
+
+    // print aq_tensor_ptr and bkn
+    std::cout << __func__ << " aq_tensor_ptr:" << std::endl;
+    std::cout << *aq_tensor_ptr << std::endl;
+    std::cout << std::endl;
+    std::cout << __func__ << " b_k_n:" << std::endl;
+    std::cout << "lengths {";
+    ck_tile::LogRange(std::cout, b_k_n.get_lengths(), ", ");
+    std::cout << "}" << std::endl;
+    std::cout << "strides {";
+    ck_tile::LogRange(std::cout, b_k_n.get_strides(), ", ");
+    std::cout << "}" << std::endl;
+    std::cout << std::endl;
 
     invoke_gemm<GemmConfig,
                 TypeConfig,

--- a/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
+++ b/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
@@ -159,7 +159,7 @@ int run_gemm_example_with_layouts(int argc,
     {
         AQK = K / QuantGroupSize; // Group quantization: AQK = K / GroupSize
         BQK = 0;                  // No B quantization
-        std::cout << __func__ << " AQK =" << AQK << std::endl;
+        std::cout << __func__ << " AQK = K / QuantGroupSize =" << AQK << std::endl;
     }
     else if constexpr(QuantMode == ck_tile::QuantType::BQuantGrouped)
     {
@@ -194,6 +194,9 @@ int run_gemm_example_with_layouts(int argc,
     stride_A = ck_tile::get_default_stride(M, K, stride_A, is_row_major(a_layout));
     stride_B = ck_tile::get_default_stride(K, N, stride_B, is_row_major(b_layout));
     stride_C = ck_tile::get_default_stride(M, N, stride_C, is_row_major(CLayout{}));
+
+    std::cout << __func__ << " stride_A =" << stride_A << " stride_B =" << stride_B
+              << " stride_C =" << stride_C << std::endl;
 
     // Conditional stride calculation based on QuantMode
     if constexpr(QuantMode == ck_tile::QuantType::AQuantGrouped)
@@ -287,15 +290,17 @@ int run_gemm_example_with_layouts(int argc,
                 ck_tile::FillUniformDistribution<ADataType>{-2.0f, 3.0f, fill_seed(gen)}(a_m_k);
             }
             // Fill AQ with unique incrementing values starting from 1.0
-            AQDataType value = 1.0f;
-            for(ck_tile::index_t m = 0; m < M; ++m)
-            {
-                for(ck_tile::index_t k = 0; k < AQK; ++k)
-                {
-                    (*aq_tensor_ptr)(m, k) = static_cast<AQDataType>(value);
-                    value += 1.0f;
-                }
-            }
+            // AQDataType value = 1.0f;
+            // for(ck_tile::index_t m = 0; m < M; ++m)
+            // {
+            //     for(ck_tile::index_t k = 0; k < AQK; ++k)
+            //     {
+            //         (*aq_tensor_ptr)(m, k) = static_cast<AQDataType>(value);
+            //         value += 1.0f;
+            //     }
+            // }
+            ck_tile::FillUniformDistribution<AQDataType>{-2.0f, 2.0f, fill_seed(gen)}(
+                *aq_tensor_ptr);
             ck_tile::FillUniformDistribution<BDataType>{-5.0f, 5.0f, fill_seed(gen)}(b_k_n);
         }
         else
@@ -431,17 +436,9 @@ int run_gemm_example_with_layouts(int argc,
     }
 
     // print aq_tensor_ptr and bkn
-    std::cout << __func__ << " aq_tensor_ptr:" << std::endl;
-    std::cout << *aq_tensor_ptr << std::endl;
-    std::cout << std::endl;
-    std::cout << __func__ << " b_k_n:" << std::endl;
-    std::cout << "lengths {";
-    ck_tile::LogRange(std::cout, b_k_n.get_lengths(), ", ");
-    std::cout << "}" << std::endl;
-    std::cout << "strides {";
-    ck_tile::LogRange(std::cout, b_k_n.get_strides(), ", ");
-    std::cout << "}" << std::endl;
-    std::cout << std::endl;
+    // std::cout << __func__ << " aq_tensor_ptr:" << std::endl;
+    // std::cout << *aq_tensor_ptr << std::endl;
+    // std::cout << std::endl;
 
     invoke_gemm<GemmConfig,
                 TypeConfig,

--- a/include/ck_tile/host/check_err.hpp
+++ b/include/ck_tile/host/check_err.hpp
@@ -19,7 +19,7 @@
 namespace ck_tile {
 
 /** @brief Maximum number of error values to display when checking errors */
-constexpr int ERROR_DETAIL_LIMIT = 128;
+constexpr int ERROR_DETAIL_LIMIT = 10;
 
 /** @brief 8-bit floating point type */
 using F8 = ck_tile::fp8_t;

--- a/include/ck_tile/ops/gemm_quant/kernel/gemm_quant_kernel.hpp
+++ b/include/ck_tile/ops/gemm_quant/kernel/gemm_quant_kernel.hpp
@@ -323,7 +323,7 @@ struct QuantGemmKernel
 
         if constexpr(kQuantType == QuantType::AQuantGrouped)
         {
-            static_assert(std::is_same_v<AQLayout, tensor_layout::gemm::RowMajor>);
+            // Remove static_assert to allow column-major AQ layout
             if(kargs.QK_A % GemmPipeline::GetVectorSizeAQ() != 0)
             {
                 if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
@@ -568,13 +568,24 @@ struct QuantGemmKernel
             }
             else if constexpr(kQuantType == QuantType::AQuantGrouped && !PreshuffleQuant)
             {
-                static_assert(std::is_same_v<AQLayout, tensor_layout::gemm::RowMajor>);
-                return make_naive_tensor_view<address_space_enum::global>(
-                    aq_ptr,
-                    make_tuple(kargs.M, kargs.QK_A),
-                    make_tuple(kargs.stride_AQ, 1),
-                    number<GemmPipeline::GetVectorSizeAQ()>{},
-                    number<1>{});
+                if constexpr(std::is_same_v<AQLayout, tensor_layout::gemm::RowMajor>)
+                {
+                    return make_naive_tensor_view<address_space_enum::global>(
+                        aq_ptr,
+                        make_tuple(kargs.M, kargs.QK_A),
+                        make_tuple(kargs.stride_AQ, 1),
+                        number<GemmPipeline::GetVectorSizeAQ()>{},
+                        number<1>{});
+                }
+                else // Column major AQ
+                {
+                    return make_naive_tensor_view<address_space_enum::global>(
+                        aq_ptr,
+                        make_tuple(kargs.QK_A, kargs.M), // Swapped dimensions
+                        make_tuple(kargs.stride_AQ, 1),  // Same stride pattern
+                        number<GemmPipeline::GetVectorSizeAQ()>{},
+                        number<1>{});
+                }
             }
             else if constexpr(kQuantType == QuantType::RowColQuant)
             {
@@ -846,13 +857,24 @@ struct QuantGemmKernel
             }
             else if constexpr(kQuantType == QuantType::AQuantGrouped && !PreshuffleQuant)
             {
-                static_assert(std::is_same_v<AQLayout, tensor_layout::gemm::RowMajor>);
                 constexpr auto block_m = TilePartitioner::MPerBlock;
                 constexpr auto block_k = TilePartitioner::KPerBlock;
-                return make_tile_window(
-                    aq_pad_view,
-                    make_tuple(number<block_m>{}, number<block_k / GemmPipeline::QuantGroupSize>{}),
-                    {i_m, 0});
+                if constexpr(std::is_same_v<AQLayout, tensor_layout::gemm::RowMajor>)
+                {
+                    return make_tile_window(
+                        aq_pad_view,
+                        make_tuple(number<block_m>{},
+                                   number<block_k / GemmPipeline::QuantGroupSize>{}),
+                        {i_m, 0});
+                }
+                else // Column major AQ
+                {
+                    return make_tile_window(
+                        aq_pad_view,
+                        make_tuple(number<block_k / GemmPipeline::QuantGroupSize>{},
+                                   number<block_m>{}),
+                        {0, i_m});
+                }
             }
             else if constexpr(kQuantType == QuantType::RowColQuant)
             {
@@ -970,58 +992,69 @@ struct QuantGemmKernel
         const auto& a_block_window = gemm_tile_windows.at(I0);
         const auto& b_block_window = gemm_tile_windows.at(I2);
 
-        const auto& c_block_tile = [&]() {
-            if constexpr(kQuantType == QuantType::AQuantGrouped)
-            {
-                const auto& aq_block_window = gemm_tile_windows.at(I1);
-                return GemmPipeline{}.template operator()(
-                    a_block_window, b_block_window, aq_block_window, kargs.M, num_loop, smem_ptr_0);
-            }
-            else if constexpr(kQuantType == QuantType::BQuantGrouped)
-            {
-                const auto& bq_block_window = gemm_tile_windows.at(I3);
-                return GemmPipeline{}.template operator()(
-                    a_block_window, b_block_window, bq_block_window, num_loop, smem_ptr_0);
-            }
-            else if constexpr(kQuantType == QuantType::RowColQuant ||
-                              kQuantType == QuantType::TensorQuant)
-            {
-                return GemmPipeline{}.template operator()(
-                    a_block_window, b_block_window, num_loop, smem_ptr_0);
-            }
-        }();
+        (void)a_block_window;
+        (void)b_block_window;
+        (void)num_loop;
+        (void)smem_ptr_0;
+
+        // const auto& c_block_tile = [&]() {
+        //     if constexpr(kQuantType == QuantType::AQuantGrouped)
+        //     {
+        //         if(get_thread_id() == 0 && get_block_id() == 0)
+        //         {
+        //             printf("Successfully entered AQuantGrouped\n");
+        //             return nullptr;
+        //         }
+        //         // const auto& aq_block_window = gemm_tile_windows.at(I1);
+        //         // return GemmPipeline{}.template operator()(
+        //         //     a_block_window, b_block_window, aq_block_window, kargs.M, num_loop,
+        //         smem_ptr_0);
+        //     }
+        // else if constexpr(kQuantType == QuantType::BQuantGrouped)
+        // {
+        //     const auto& bq_block_window = gemm_tile_windows.at(I3);
+        //     return GemmPipeline{}.template operator()(
+        //         a_block_window, b_block_window, bq_block_window, num_loop, smem_ptr_0);
+        // }
+        // else if constexpr(kQuantType == QuantType::RowColQuant ||
+        //                   kQuantType == QuantType::TensorQuant)
+        // {
+        //     return GemmPipeline{}.template operator()(
+        //         a_block_window, b_block_window, num_loop, smem_ptr_0);
+        // }
+        // }();
 
         // Run Epilogue Pipeline
-        auto& c_block_window = gemm_tile_windows.at(I4);
+        // auto& c_block_window = gemm_tile_windows.at(I4);
 
-        if constexpr(kQuantType == QuantType::AQuantGrouped ||
-                     kQuantType == QuantType::BQuantGrouped)
-        {
-            EpiloguePipeline{}(c_block_window, c_block_tile, c_block_window, smem_ptr_0);
-        }
-        else if constexpr(kQuantType == QuantType::RowColQuant)
-        {
-            const auto& aq_block_window = gemm_tile_windows.at(I1);
-            const auto& bq_block_window = gemm_tile_windows.at(I3);
-            EpiloguePipeline{}(c_block_window,
-                               c_block_tile,
-                               c_block_window,
-                               smem_ptr_0,
-                               aq_block_window,
-                               bq_block_window);
-        }
-        else if constexpr(kQuantType == QuantType::TensorQuant)
-        {
-            // TODO: why doesn't readfirstlane work here?
-            // const AccDataType aq_scale =
-            //     __builtin_amdgcn_readfirstlane(type_convert<AccDataType>(*aq_ptr));
-            // const AccDataType bq_scale =
-            //     __builtin_amdgcn_readfirstlane(type_convert<AccDataType>(*bq_ptr));
-            const AccDataType aq_scale = type_convert<AccDataType>(*aq_ptr);
-            const AccDataType bq_scale = type_convert<AccDataType>(*bq_ptr);
-            EpiloguePipeline{}(
-                c_block_window, c_block_tile, c_block_window, smem_ptr_0, aq_scale, bq_scale);
-        }
+        // if constexpr(kQuantType == QuantType::AQuantGrouped ||
+        //              kQuantType == QuantType::BQuantGrouped)
+        // {
+        //     EpiloguePipeline{}(c_block_window, c_block_tile, c_block_window, smem_ptr_0);
+        // }
+        // else if constexpr(kQuantType == QuantType::RowColQuant)
+        // {
+        //     const auto& aq_block_window = gemm_tile_windows.at(I1);
+        //     const auto& bq_block_window = gemm_tile_windows.at(I3);
+        //     EpiloguePipeline{}(c_block_window,
+        //                        c_block_tile,
+        //                        c_block_window,
+        //                        smem_ptr_0,
+        //                        aq_block_window,
+        //                        bq_block_window);
+        // }
+        // else if constexpr(kQuantType == QuantType::TensorQuant)
+        // {
+        //     // TODO: why doesn't readfirstlane work here?
+        //     // const AccDataType aq_scale =
+        //     //     __builtin_amdgcn_readfirstlane(type_convert<AccDataType>(*aq_ptr));
+        //     // const AccDataType bq_scale =
+        //     //     __builtin_amdgcn_readfirstlane(type_convert<AccDataType>(*bq_ptr));
+        //     const AccDataType aq_scale = type_convert<AccDataType>(*aq_ptr);
+        //     const AccDataType bq_scale = type_convert<AccDataType>(*bq_ptr);
+        //     EpiloguePipeline{}(
+        //         c_block_window, c_block_tile, c_block_window, smem_ptr_0, aq_scale, bq_scale);
+        // }
     }
     /**
      * @brief Runs single GEMM problem cooperatively by whole workgroup.
@@ -1104,6 +1137,12 @@ struct QuantGemmKernel
         const auto [iM, iN] = TilePartitioner{kargs.M, kargs.N}.GetOutputTileIndex(blockId);
         const index_t i_m   = amd_wave_read_first_lane(iM * TilePartitioner::MPerBlock);
         const index_t i_n   = amd_wave_read_first_lane(iN * TilePartitioner::NPerBlock);
+
+        if(get_thread_id() == 0)
+        {
+            printf(
+                "blockId = %u, iM = %d, iN = %d, i_m = %d, i_n = %d\n", blockId, iM, iN, i_m, i_n);
+        }
 
         const SplitKBatchOffset splitk_batch_offset(kargs);
         // options

--- a/include/ck_tile/ops/gemm_quant/kernel/gemm_quant_kernel.hpp
+++ b/include/ck_tile/ops/gemm_quant/kernel/gemm_quant_kernel.hpp
@@ -324,6 +324,7 @@ struct QuantGemmKernel
         if constexpr(kQuantType == QuantType::AQuantGrouped)
         {
             // Remove static_assert to allow column-major AQ layout
+            // static_assert(std::is_same_v<AQLayout, tensor_layout::gemm::RowMajor>);
             if(kargs.QK_A % GemmPipeline::GetVectorSizeAQ() != 0)
             {
                 if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
@@ -857,6 +858,7 @@ struct QuantGemmKernel
             }
             else if constexpr(kQuantType == QuantType::AQuantGrouped && !PreshuffleQuant)
             {
+                // static_assert(std::is_same_v<AQLayout, tensor_layout::gemm::RowMajor>);
                 constexpr auto block_m = TilePartitioner::MPerBlock;
                 constexpr auto block_k = TilePartitioner::KPerBlock;
                 if constexpr(std::is_same_v<AQLayout, tensor_layout::gemm::RowMajor>)
@@ -997,33 +999,33 @@ struct QuantGemmKernel
         (void)num_loop;
         (void)smem_ptr_0;
 
-        // const auto& c_block_tile = [&]() {
-        //     if constexpr(kQuantType == QuantType::AQuantGrouped)
-        //     {
-        //         if(get_thread_id() == 0 && get_block_id() == 0)
-        //         {
-        //             printf("Successfully entered AQuantGrouped\n");
-        //             return nullptr;
-        //         }
-        //         // const auto& aq_block_window = gemm_tile_windows.at(I1);
-        //         // return GemmPipeline{}.template operator()(
-        //         //     a_block_window, b_block_window, aq_block_window, kargs.M, num_loop,
-        //         smem_ptr_0);
-        //     }
-        // else if constexpr(kQuantType == QuantType::BQuantGrouped)
-        // {
-        //     const auto& bq_block_window = gemm_tile_windows.at(I3);
-        //     return GemmPipeline{}.template operator()(
-        //         a_block_window, b_block_window, bq_block_window, num_loop, smem_ptr_0);
-        // }
-        // else if constexpr(kQuantType == QuantType::RowColQuant ||
-        //                   kQuantType == QuantType::TensorQuant)
-        // {
-        //     return GemmPipeline{}.template operator()(
-        //         a_block_window, b_block_window, num_loop, smem_ptr_0);
-        // }
-        // }();
+        const auto& c_block_tile = [&]() {
+            if constexpr(kQuantType == QuantType::AQuantGrouped)
+            {
+                if(get_thread_id() == 0 && get_block_id() == 0)
+                {
+                    printf("Successfully entered AQuantGrouped\n");
+                    // return nullptr;
+                }
+                const auto& aq_block_window = gemm_tile_windows.at(I1);
+                return GemmPipeline{}.template operator()(
+                    a_block_window, b_block_window, aq_block_window, kargs.M, num_loop, smem_ptr_0);
+            }
+            else if constexpr(kQuantType == QuantType::BQuantGrouped)
+            {
+                const auto& bq_block_window = gemm_tile_windows.at(I3);
+                return GemmPipeline{}.template operator()(
+                    a_block_window, b_block_window, bq_block_window, num_loop, smem_ptr_0);
+            }
+            else if constexpr(kQuantType == QuantType::RowColQuant ||
+                              kQuantType == QuantType::TensorQuant)
+            {
+                return GemmPipeline{}.template operator()(
+                    a_block_window, b_block_window, num_loop, smem_ptr_0);
+            }
+        }();
 
+        (void)c_block_tile;
         // Run Epilogue Pipeline
         // auto& c_block_window = gemm_tile_windows.at(I4);
 

--- a/include/ck_tile/ops/gemm_quant/kernel/gemm_quant_kernel.hpp
+++ b/include/ck_tile/ops/gemm_quant/kernel/gemm_quant_kernel.hpp
@@ -1002,12 +1002,12 @@ struct QuantGemmKernel
         const auto& c_block_tile = [&]() {
             if constexpr(kQuantType == QuantType::AQuantGrouped)
             {
-                if(get_thread_id() == 0 && get_block_id() == 0)
-                {
-                    printf("Successfully entered AQuantGrouped\n");
-                    // return nullptr;
-                }
                 const auto& aq_block_window = gemm_tile_windows.at(I1);
+                // if(get_thread_id() == 0 && get_block_id() == 0)
+                // {
+                //     aq_block_window.template print_tile_window_range<AQDataType>(0, 4, 0, 32,
+                //     "aq_block_window");
+                // }
                 return GemmPipeline{}.template operator()(
                     a_block_window, b_block_window, aq_block_window, kargs.M, num_loop, smem_ptr_0);
             }
@@ -1027,36 +1027,36 @@ struct QuantGemmKernel
 
         (void)c_block_tile;
         // Run Epilogue Pipeline
-        // auto& c_block_window = gemm_tile_windows.at(I4);
+        auto& c_block_window = gemm_tile_windows.at(I4);
 
-        // if constexpr(kQuantType == QuantType::AQuantGrouped ||
-        //              kQuantType == QuantType::BQuantGrouped)
-        // {
-        //     EpiloguePipeline{}(c_block_window, c_block_tile, c_block_window, smem_ptr_0);
-        // }
-        // else if constexpr(kQuantType == QuantType::RowColQuant)
-        // {
-        //     const auto& aq_block_window = gemm_tile_windows.at(I1);
-        //     const auto& bq_block_window = gemm_tile_windows.at(I3);
-        //     EpiloguePipeline{}(c_block_window,
-        //                        c_block_tile,
-        //                        c_block_window,
-        //                        smem_ptr_0,
-        //                        aq_block_window,
-        //                        bq_block_window);
-        // }
-        // else if constexpr(kQuantType == QuantType::TensorQuant)
-        // {
-        //     // TODO: why doesn't readfirstlane work here?
-        //     // const AccDataType aq_scale =
-        //     //     __builtin_amdgcn_readfirstlane(type_convert<AccDataType>(*aq_ptr));
-        //     // const AccDataType bq_scale =
-        //     //     __builtin_amdgcn_readfirstlane(type_convert<AccDataType>(*bq_ptr));
-        //     const AccDataType aq_scale = type_convert<AccDataType>(*aq_ptr);
-        //     const AccDataType bq_scale = type_convert<AccDataType>(*bq_ptr);
-        //     EpiloguePipeline{}(
-        //         c_block_window, c_block_tile, c_block_window, smem_ptr_0, aq_scale, bq_scale);
-        // }
+        if constexpr(kQuantType == QuantType::AQuantGrouped ||
+                     kQuantType == QuantType::BQuantGrouped)
+        {
+            EpiloguePipeline{}(c_block_window, c_block_tile, c_block_window, smem_ptr_0);
+        }
+        else if constexpr(kQuantType == QuantType::RowColQuant)
+        {
+            const auto& aq_block_window = gemm_tile_windows.at(I1);
+            const auto& bq_block_window = gemm_tile_windows.at(I3);
+            EpiloguePipeline{}(c_block_window,
+                               c_block_tile,
+                               c_block_window,
+                               smem_ptr_0,
+                               aq_block_window,
+                               bq_block_window);
+        }
+        else if constexpr(kQuantType == QuantType::TensorQuant)
+        {
+            // TODO: why doesn't readfirstlane work here?
+            // const AccDataType aq_scale =
+            //     __builtin_amdgcn_readfirstlane(type_convert<AccDataType>(*aq_ptr));
+            // const AccDataType bq_scale =
+            //     __builtin_amdgcn_readfirstlane(type_convert<AccDataType>(*bq_ptr));
+            const AccDataType aq_scale = type_convert<AccDataType>(*aq_ptr);
+            const AccDataType bq_scale = type_convert<AccDataType>(*bq_ptr);
+            EpiloguePipeline{}(
+                c_block_window, c_block_tile, c_block_window, smem_ptr_0, aq_scale, bq_scale);
+        }
     }
     /**
      * @brief Runs single GEMM problem cooperatively by whole workgroup.
@@ -1140,11 +1140,12 @@ struct QuantGemmKernel
         const index_t i_m   = amd_wave_read_first_lane(iM * TilePartitioner::MPerBlock);
         const index_t i_n   = amd_wave_read_first_lane(iN * TilePartitioner::NPerBlock);
 
-        if(get_thread_id() == 0)
-        {
-            printf(
-                "blockId = %u, iM = %d, iN = %d, i_m = %d, i_n = %d\n", blockId, iM, iN, i_m, i_n);
-        }
+        // if(get_thread_id() == 0)
+        // {
+        //     printf(
+        //         "blockId = %u, iM = %d, iN = %d, i_m = %d, i_n = %d\n", blockId, iM, iN, i_m,
+        //         i_n);
+        // }
 
         const SplitKBatchOffset splitk_batch_offset(kargs);
         // options

--- a/include/ck_tile/ops/gemm_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_base.hpp
+++ b/include/ck_tile/ops/gemm_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_base.hpp
@@ -36,7 +36,7 @@ struct GemmAQuantPipelineAgBgCrImplBase : public GemmPipelineAgBgCrImplBase<Prob
     CK_TILE_DEVICE constexpr auto
     GetAQDramLoadWindow(const AQDramBlockWindowTmp& aq_dram_block_window_tmp) const
     {
-        static_assert(std::is_same_v<AQLayout, tensor_layout::gemm::RowMajor>);
+        // static_assert(std::is_same_v<AQLayout, tensor_layout::gemm::RowMajor>);
 
         auto aq_copy_dram_window =
             make_tile_window(aq_dram_block_window_tmp.get_bottom_tensor_view(),

--- a/include/ck_tile/ops/gemm_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_policy.hpp
@@ -18,13 +18,13 @@ struct GemmAQuantPipelineAgBgCrDefaultPolicy : public UniversalGemmPipelineAgBgC
     template <typename Problem>
     CK_TILE_HOST_DEVICE static constexpr auto GetVectorSizeAQ()
     {
-        using AQLayout                = remove_cvref_t<typename Problem::AQLayout>;
+        // using AQLayout                = remove_cvref_t<typename Problem::AQLayout>;
         using AQDataType              = remove_cvref_t<typename Problem::AQDataType>;
         constexpr index_t MPerBlock   = Problem::BlockGemmShape::kM;
         constexpr index_t KPerBlock   = Problem::BlockGemmShape::kK;
         constexpr index_t KPerBlockAQ = KPerBlock / Problem::kQuantGroupSize;
 
-        static_assert(std::is_same_v<AQLayout, ck_tile::tensor_layout::gemm::RowMajor>);
+        // static_assert(std::is_same_v<AQLayout, ck_tile::tensor_layout::gemm::RowMajor>);
         return GetABQGlobalVectorLoadSize<Problem, AQDataType, MPerBlock, KPerBlockAQ>();
     }
 

--- a/include/ck_tile/ops/gemm_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_policy.hpp
@@ -49,7 +49,7 @@ struct GemmAQuantPipelineAgBgCrDefaultPolicy : public UniversalGemmPipelineAgBgC
                                                             WarpTile::at(I2),
                                                             Problem::TransposeC>;
 
-        static_assert(std::is_same_v<AQLayout, tensor_layout::gemm::RowMajor>);
+        // static_assert(std::is_same_v<AQLayout, tensor_layout::gemm::RowMajor>);
         if constexpr(PreshuffleQuant)
         {
             using TileEncodingPattern = tile_distribution_encoding_pattern_aq<
@@ -77,7 +77,7 @@ struct GemmAQuantPipelineAgBgCrDefaultPolicy : public UniversalGemmPipelineAgBgC
                                                                        VecLoadSize>;
                 return TileEncodingPatternTransposeC::make_2d_static_tile_distribution();
             }
-            else
+            else if constexpr(std::is_same_v<AQLayout, tensor_layout::gemm::RowMajor>)
             {
                 using TileEncodingPattern = tile_distribution_encoding_pattern_aq<BlockGemmShape,
                                                                                   WarpGemm,
@@ -89,6 +89,19 @@ struct GemmAQuantPipelineAgBgCrDefaultPolicy : public UniversalGemmPipelineAgBgC
                                                                                   PreshuffleQuant>;
 
                 return TileEncodingPattern::make_2d_static_tile_distribution();
+            }
+            else
+            {
+                using TileEncodingPattern =
+                    tile_distribution_encoding_pattern_aq<BlockGemmShape,
+                                                          WarpGemm,
+                                                          BlockSize,
+                                                          KPerBlockAQ, // YPerTile
+                                                          MPerBlock,   // XPerTile
+                                                          KPerBlockAQ,
+                                                          VecLoadSize,
+                                                          PreshuffleQuant>;
+                return TileEncodingPattern::make_2d_static_tile_distribution_transposed();
             }
         }
     }

--- a/include/ck_tile/ops/gemm_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_v3.hpp
+++ b/include/ck_tile/ops/gemm_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_v3.hpp
@@ -240,6 +240,13 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
                                        index_t num_loop,
                                        void* p_smem) const
         {
+            if(get_thread_id() == 0 && get_block_id() == 0)
+            {
+                printf("AQuantGemmPipelineAgBgCrCompV3 operator()<Intrawave>\n");
+                printf("HasHotLoop: %d\n", HasHotLoop);
+                printf("TailNum: %d\n", static_cast<int>(TailNum));
+                printf("num_loop: %d\n", num_loop);
+            }
             static_assert(
                 std::is_same_v<ADataType, remove_cvref_t<typename ADramBlockWindowTmp::DataType>> &&
                     std::is_same_v<BDataType,
@@ -324,6 +331,20 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
             Base::GlobalPrefetch(b_block_tile, b_copy_dram_window, b_dram_tile_window_step);
             Base::GlobalPrefetch(
                 aq_block_tile[currIdx], aq_copy_dram_window, aq_dram_tile_window_step);
+
+            if(get_block_id() == 0 && get_thread_id() < 2)
+            {
+                auto tbuffer             = aq_block_tile[currIdx].get_thread_buffer();
+                auto elements_per_thread = tbuffer.size();
+
+                for(index_t i = 0; i < elements_per_thread; i++)
+                {
+                    printf("thread id: %d, aq_block_tile[%d] = %d\n",
+                           get_thread_id(),
+                           i,
+                           static_cast<int>(tbuffer[i]));
+                }
+            }
 
             tile_elementwise_inout([](auto& c) { c = 0; }, c_block_tile);
 

--- a/include/ck_tile/ops/gemm_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_v3.hpp
+++ b/include/ck_tile/ops/gemm_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_v3.hpp
@@ -240,6 +240,15 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
                                        index_t num_loop,
                                        void* p_smem) const
         {
+            (void)m;
+            (void)p_smem;
+            (void)a_element_func;
+            (void)b_element_func;
+            (void)num_loop;
+            (void)a_dram_block_window_tmp;
+            (void)b_dram_block_window_tmp;
+            (void)aq_dram_block_window_tmp;
+
             if(get_thread_id() == 0 && get_block_id() == 0)
             {
                 printf("AQuantGemmPipelineAgBgCrCompV3 operator()<Intrawave>\n");
@@ -262,7 +271,8 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
                 std::is_same_v<AQLayout, tensor_layout::gemm::ColumnMajor>;
             constexpr bool is_b_row_major = std::is_same_v<BLayout, tensor_layout::gemm::RowMajor>;
 
-            static_assert(!is_aq_col_major, "Aq must be row major (col major not supported yet)");
+            // static_assert(!is_aq_col_major, "Aq must be row major (col major not supported
+            // yet)");
 
             static_assert(is_a_col_major
                               ? (KPerBlock == ADramBlockWindowTmp{}.get_window_lengths()[I0{}] &&
@@ -312,6 +322,11 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
             AQBlockTile aq_block_tile[2];
             int currIdx = 0;
 
+            (void)a_block_tile;
+            (void)b_block_tile;
+            (void)aq_block_tile;
+            (void)currIdx;
+
             auto c_block_tile = block_gemm.MakeCBlockTile();
 
             constexpr ADramTileWindowStep a_dram_tile_window_step =
@@ -321,18 +336,21 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
 
             // only row_major for AQ
             const AQDramTileWindowStep aq_dram_tile_window_step =
-                PreshuffleQuant ? make_array(ck_tile::integer_least_multiple(m, MPerBlock) /
-                                                 BlockGemm::WarpGemm::kM,
-                                             0)
-                                : make_array(0, KPerBlockAQ);
+                PreshuffleQuant
+                    ? make_array(ck_tile::integer_least_multiple(m, MPerBlock) /
+                                     BlockGemm::WarpGemm::kM,
+                                 0)
+                    : (is_aq_col_major ? make_array(KPerBlockAQ, 0) : make_array(0, KPerBlockAQ));
 
-            // DRAM prefetch (global read 0)
+            (void)aq_dram_tile_window_step;
+
+            // // DRAM prefetch (global read 0)
             Base::GlobalPrefetch(a_block_tile, a_copy_dram_window, a_dram_tile_window_step);
             Base::GlobalPrefetch(b_block_tile, b_copy_dram_window, b_dram_tile_window_step);
             Base::GlobalPrefetch(
                 aq_block_tile[currIdx], aq_copy_dram_window, aq_dram_tile_window_step);
 
-            if(get_block_id() == 0 && get_thread_id() < 2)
+            if(get_block_id() == 0 && get_thread_id() < 256)
             {
                 auto tbuffer             = aq_block_tile[currIdx].get_thread_buffer();
                 auto elements_per_thread = tbuffer.size();
@@ -351,7 +369,7 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
             if constexpr(is_a_col_major)
             {
                 auto a_shuffle_tmp = make_static_distributed_tensor<ADataType>(
-                    Policy::template make_shuffled_2d_static_tile_distribution<Problem>());
+                    Policy::template MakeShuffledARegTileDistribution<Problem>());
                 transpose_tile2d(a_shuffle_tmp, a_block_tile);
                 Base::LocalPrefill(a_copy_lds_window, a_shuffle_tmp, a_element_func);
             }
@@ -363,7 +381,7 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
             if constexpr(is_b_row_major)
             {
                 auto b_shuffle_tmp = make_static_distributed_tensor<BDataType>(
-                    Policy::template make_shuffled_2d_static_tile_distribution<Problem>());
+                    Policy::template MakeShuffledBRegTileDistribution<Problem>());
                 transpose_tile2d(b_shuffle_tmp, b_block_tile);
                 Base::LocalPrefill(b_copy_lds_window, b_shuffle_tmp, b_element_func);
             }
@@ -381,55 +399,57 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
 
             __builtin_amdgcn_sched_barrier(0);
 
-            if constexpr(HasHotLoop)
-            {
-                index_t i = 0;
-                do
-                {
-                    block_sync_lds();
+            // if constexpr(HasHotLoop)
+            // {
+            //     index_t i = 0;
+            //     do
+            //     {
+            //         block_sync_lds();
 
-                    if constexpr(is_a_col_major)
-                    {
-                        auto a_shuffle_tmp = make_static_distributed_tensor<ADataType>(
-                            Policy::template MakeShuffledARegTileDistribution<Problem>());
-                        transpose_tile2d(a_shuffle_tmp, a_block_tile);
-                        Base::LocalPrefill(a_copy_lds_window, a_shuffle_tmp, a_element_func);
-                    }
-                    else
-                    {
-                        Base::LocalPrefill(a_copy_lds_window, a_block_tile, a_element_func);
-                    }
-                    if constexpr(is_b_row_major)
-                    {
-                        auto b_shuffle_tmp = make_static_distributed_tensor<BDataType>(
-                            Policy::template MakeShuffledBRegTileDistribution<Problem>());
-                        transpose_tile2d(b_shuffle_tmp, b_block_tile);
-                        Base::LocalPrefill(b_copy_lds_window, b_shuffle_tmp, b_element_func);
-                    }
-                    else
-                    {
-                        Base::LocalPrefill(b_copy_lds_window, b_block_tile, b_element_func);
-                    }
+            //         if constexpr(is_a_col_major)
+            //         {
+            //             auto a_shuffle_tmp = make_static_distributed_tensor<ADataType>(
+            //                 Policy::template MakeShuffledARegTileDistribution<Problem>());
+            //             transpose_tile2d(a_shuffle_tmp, a_block_tile);
+            //             Base::LocalPrefill(a_copy_lds_window, a_shuffle_tmp, a_element_func);
+            //         }
+            //         else
+            //         {
+            //             Base::LocalPrefill(a_copy_lds_window, a_block_tile, a_element_func);
+            //         }
+            //         if constexpr(is_b_row_major)
+            //         {
+            //             auto b_shuffle_tmp = make_static_distributed_tensor<BDataType>(
+            //                 Policy::template MakeShuffledBRegTileDistribution<Problem>());
+            //             transpose_tile2d(b_shuffle_tmp, b_block_tile);
+            //             Base::LocalPrefill(b_copy_lds_window, b_shuffle_tmp, b_element_func);
+            //         }
+            //         else
+            //         {
+            //             Base::LocalPrefill(b_copy_lds_window, b_block_tile, b_element_func);
+            //         }
 
-                    Base::GlobalPrefetch(a_block_tile, a_copy_dram_window, a_dram_tile_window_step);
-                    Base::GlobalPrefetch(b_block_tile, b_copy_dram_window, b_dram_tile_window_step);
-                    Base::GlobalPrefetch(aq_block_tile[(currIdx + 1) % 2],
-                                         aq_copy_dram_window,
-                                         aq_dram_tile_window_step);
+            //         Base::GlobalPrefetch(a_block_tile, a_copy_dram_window,
+            //         a_dram_tile_window_step); Base::GlobalPrefetch(b_block_tile,
+            //         b_copy_dram_window, b_dram_tile_window_step);
+            //         Base::GlobalPrefetch(aq_block_tile[(currIdx + 1) % 2],
+            //                              aq_copy_dram_window,
+            //                              aq_dram_tile_window_step);
 
-                    block_gemm(
-                        c_block_tile, aq_block_tile[currIdx], a_lds_gemm_window, b_lds_gemm_window);
+            //         block_gemm(
+            //             c_block_tile, aq_block_tile[currIdx], a_lds_gemm_window,
+            //             b_lds_gemm_window);
 
-                    currIdx = (currIdx + 1) % 2;
+            //         currIdx = (currIdx + 1) % 2;
 
-                    block_sync_lds();
+            //         block_sync_lds();
 
-                    block_gemm.LocalPrefetch(a_lds_gemm_window, b_lds_gemm_window);
-                    __builtin_amdgcn_sched_barrier(0);
+            //         block_gemm.LocalPrefetch(a_lds_gemm_window, b_lds_gemm_window);
+            //         __builtin_amdgcn_sched_barrier(0);
 
-                    i += 1;
-                } while(i < (num_loop - 1));
-            }
+            //         i += 1;
+            //     } while(i < (num_loop - 1));
+            // }
             // tail
             if constexpr((TailNum == TailNumber::Full) || (TailNum == TailNumber::Odd))
             {

--- a/include/ck_tile/ops/gemm_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_v3.hpp
+++ b/include/ck_tile/ops/gemm_quant/pipeline/gemm_aquant_pipeline_ag_bg_cr_v3.hpp
@@ -350,19 +350,17 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
             Base::GlobalPrefetch(
                 aq_block_tile[currIdx], aq_copy_dram_window, aq_dram_tile_window_step);
 
-            if(get_block_id() == 0 && get_thread_id() < 256)
-            {
-                auto tbuffer             = aq_block_tile[currIdx].get_thread_buffer();
-                auto elements_per_thread = tbuffer.size();
+            // if(get_block_id() == 0 && get_thread_id() < 16)
+            // {
+            //     auto tbuffer             = aq_block_tile[currIdx].get_thread_buffer();
+            //     auto elements_per_thread = tbuffer.size();
 
-                for(index_t i = 0; i < elements_per_thread; i++)
-                {
-                    printf("thread id: %d, aq_block_tile[%d] = %d\n",
-                           get_thread_id(),
-                           i,
-                           static_cast<int>(tbuffer[i]));
-                }
-            }
+            //     for(index_t i = 0; i < elements_per_thread; i++)
+            //     {
+            //         printf("thread id: %d, aq_block_tile[%d] = %f\n",
+            //                get_thread_id(), i, static_cast<AQDataType>(tbuffer[i]));
+            //     }
+            // }
 
             tile_elementwise_inout([](auto& c) { c = 0; }, c_block_tile);
 
@@ -399,57 +397,55 @@ struct AQuantGemmPipelineAgBgCrCompV3 : public BaseAQuantGemmPipelineAgBgCrCompV
 
             __builtin_amdgcn_sched_barrier(0);
 
-            // if constexpr(HasHotLoop)
-            // {
-            //     index_t i = 0;
-            //     do
-            //     {
-            //         block_sync_lds();
+            if constexpr(HasHotLoop)
+            {
+                index_t i = 0;
+                do
+                {
+                    block_sync_lds();
 
-            //         if constexpr(is_a_col_major)
-            //         {
-            //             auto a_shuffle_tmp = make_static_distributed_tensor<ADataType>(
-            //                 Policy::template MakeShuffledARegTileDistribution<Problem>());
-            //             transpose_tile2d(a_shuffle_tmp, a_block_tile);
-            //             Base::LocalPrefill(a_copy_lds_window, a_shuffle_tmp, a_element_func);
-            //         }
-            //         else
-            //         {
-            //             Base::LocalPrefill(a_copy_lds_window, a_block_tile, a_element_func);
-            //         }
-            //         if constexpr(is_b_row_major)
-            //         {
-            //             auto b_shuffle_tmp = make_static_distributed_tensor<BDataType>(
-            //                 Policy::template MakeShuffledBRegTileDistribution<Problem>());
-            //             transpose_tile2d(b_shuffle_tmp, b_block_tile);
-            //             Base::LocalPrefill(b_copy_lds_window, b_shuffle_tmp, b_element_func);
-            //         }
-            //         else
-            //         {
-            //             Base::LocalPrefill(b_copy_lds_window, b_block_tile, b_element_func);
-            //         }
+                    if constexpr(is_a_col_major)
+                    {
+                        auto a_shuffle_tmp = make_static_distributed_tensor<ADataType>(
+                            Policy::template MakeShuffledARegTileDistribution<Problem>());
+                        transpose_tile2d(a_shuffle_tmp, a_block_tile);
+                        Base::LocalPrefill(a_copy_lds_window, a_shuffle_tmp, a_element_func);
+                    }
+                    else
+                    {
+                        Base::LocalPrefill(a_copy_lds_window, a_block_tile, a_element_func);
+                    }
+                    if constexpr(is_b_row_major)
+                    {
+                        auto b_shuffle_tmp = make_static_distributed_tensor<BDataType>(
+                            Policy::template MakeShuffledBRegTileDistribution<Problem>());
+                        transpose_tile2d(b_shuffle_tmp, b_block_tile);
+                        Base::LocalPrefill(b_copy_lds_window, b_shuffle_tmp, b_element_func);
+                    }
+                    else
+                    {
+                        Base::LocalPrefill(b_copy_lds_window, b_block_tile, b_element_func);
+                    }
 
-            //         Base::GlobalPrefetch(a_block_tile, a_copy_dram_window,
-            //         a_dram_tile_window_step); Base::GlobalPrefetch(b_block_tile,
-            //         b_copy_dram_window, b_dram_tile_window_step);
-            //         Base::GlobalPrefetch(aq_block_tile[(currIdx + 1) % 2],
-            //                              aq_copy_dram_window,
-            //                              aq_dram_tile_window_step);
+                    Base::GlobalPrefetch(a_block_tile, a_copy_dram_window, a_dram_tile_window_step);
+                    Base::GlobalPrefetch(b_block_tile, b_copy_dram_window, b_dram_tile_window_step);
+                    Base::GlobalPrefetch(aq_block_tile[(currIdx + 1) % 2],
+                                         aq_copy_dram_window,
+                                         aq_dram_tile_window_step);
 
-            //         block_gemm(
-            //             c_block_tile, aq_block_tile[currIdx], a_lds_gemm_window,
-            //             b_lds_gemm_window);
+                    block_gemm(
+                        c_block_tile, aq_block_tile[currIdx], a_lds_gemm_window, b_lds_gemm_window);
 
-            //         currIdx = (currIdx + 1) % 2;
+                    currIdx = (currIdx + 1) % 2;
 
-            //         block_sync_lds();
+                    block_sync_lds();
 
-            //         block_gemm.LocalPrefetch(a_lds_gemm_window, b_lds_gemm_window);
-            //         __builtin_amdgcn_sched_barrier(0);
+                    block_gemm.LocalPrefetch(a_lds_gemm_window, b_lds_gemm_window);
+                    __builtin_amdgcn_sched_barrier(0);
 
-            //         i += 1;
-            //     } while(i < (num_loop - 1));
-            // }
+                    i += 1;
+                } while(i < (num_loop - 1));
+            }
             // tail
             if constexpr((TailNum == TailNumber::Full) || (TailNum == TailNumber::Odd))
             {

--- a/include/ck_tile/ops/gemm_quant/pipeline/gemm_group_quant_utils.hpp
+++ b/include/ck_tile/ops/gemm_quant/pipeline/gemm_group_quant_utils.hpp
@@ -114,17 +114,16 @@ struct tile_distribution_encoding_pattern_aq : public tile_distribution_encoding
     CK_TILE_HOST_DEVICE static constexpr auto make_2d_static_tile_distribution_transposed()
     {
         constexpr index_t Y0 = YPerTile;
-
         constexpr index_t X0 = 1;
         constexpr index_t X1 = MIterPerWarp ? MIterPerWarp : 1;
         constexpr index_t X2 = MWarps;
         constexpr index_t X3 = WarpGemm::kM;
         return make_static_tile_distribution(
             tile_distribution_encoding<sequence<NWarps>,
-                                       tuple<sequence<X0, X1, X2, X3>, sequence<Y0>>,
-                                       tuple<sequence<0, 1>, sequence<1, 1>>,
-                                       tuple<sequence<0, 2>, sequence<3, 0>>,
-                                       sequence<1, 2>,
+                                       tuple<sequence<Y0>, sequence<X0, X1, X2, X3>>,
+                                       tuple<sequence<2, 0>, sequence<2, 2>>,
+                                       tuple<sequence<2, 0>, sequence<0, 3>>,
+                                       sequence<2, 1>,
                                        sequence<1, 0>>{});
     }
 };

--- a/include/ck_tile/ops/gemm_quant/pipeline/gemm_group_quant_utils.hpp
+++ b/include/ck_tile/ops/gemm_quant/pipeline/gemm_group_quant_utils.hpp
@@ -48,8 +48,8 @@ CK_TILE_HOST_DEVICE static constexpr auto GetABQGlobalVectorLoadSize()
 template <typename BlockGemmShape,
           typename WarpGemm,
           index_t BlockSize,
-          index_t YPerTile,
-          index_t XPerTile,
+          index_t YPerTile, // MPerBlock
+          index_t XPerTile, // KPerBlock / QuantGroupSize
           index_t KPerBlockAQ,
           index_t VecSize,
           bool PreshuffleQuant>

--- a/include/ck_tile/ops/gemm_quant/pipeline/gemm_group_quant_utils.hpp
+++ b/include/ck_tile/ops/gemm_quant/pipeline/gemm_group_quant_utils.hpp
@@ -111,6 +111,22 @@ struct tile_distribution_encoding_pattern_aq : public tile_distribution_encoding
                                            sequence<1, 0>>{});
         }
     }
+    CK_TILE_HOST_DEVICE static constexpr auto make_2d_static_tile_distribution_transposed()
+    {
+        constexpr index_t Y0 = YPerTile;
+
+        constexpr index_t X0 = 1;
+        constexpr index_t X1 = MIterPerWarp ? MIterPerWarp : 1;
+        constexpr index_t X2 = MWarps;
+        constexpr index_t X3 = WarpGemm::kM;
+        return make_static_tile_distribution(
+            tile_distribution_encoding<sequence<NWarps>,
+                                       tuple<sequence<X0, X1, X2, X3>, sequence<Y0>>,
+                                       tuple<sequence<0, 1>, sequence<1, 1>>,
+                                       tuple<sequence<0, 2>, sequence<3, 0>>,
+                                       sequence<1, 2>,
+                                       sequence<1, 0>>{});
+    }
 };
 
 template <typename BlockGemmShape,


### PR DESCRIPTION
## Proposed changes

Draft PR to share prototype  tile distribution for new layout support. 
This branch compiles and runs with
```cpp
ninja -j256 tile_example_gemm_quant_basic && ./bin/tile_example_gemm_quant_basic -quant_mode=aquant -m=16 -n=64 -k=256 -repeat=1 -warmup=0 -a_layout=C -b_layout=C
```

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

