### PR TITLE
feat(precommit-hooks): add check for correct copyright header

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 import fnmatch
 import json
 import os

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,12 @@ repos:
             )$
 -   repo: local
     hooks:
-    # -   id: copyright-year-checker
-    #     name: copyright-year-checker
-    #     entry: script/check_copyright_year.sh
-    #     verbose: false
-    #     language: script
-    #     types: [c++]
+    -   id: copyright-header-checker
+        name: Check copyright headers
+        entry: script/check_copyright_year.sh
+        verbose: false
+        language: script
+        types_or: [c++, python, shell, cmake]
     -   id: remove-exec-bit
         name: Remove executable bit from non-executable files
         entry: script/remove_exec_bit.sh

--- a/example/ck_tile/18_flatmm/mxgemm/mx_flatmm_instance.cmake
+++ b/example/ck_tile/18_flatmm/mxgemm/mx_flatmm_instance.cmake
@@ -1,5 +1,5 @@
-# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
-# SPDX-License-Identifier: MIT
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 function(mx_flatmm_instance_generate FILE_LIST)
     set(C_DATA_TYPE FP16)

--- a/example/ck_tile/18_flatmm/mxgemm/mx_flatmm_instance.cmake
+++ b/example/ck_tile/18_flatmm/mxgemm/mx_flatmm_instance.cmake
@@ -1,5 +1,5 @@
-// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier: MIT
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
 
 function(mx_flatmm_instance_generate FILE_LIST)
     set(C_DATA_TYPE FP16)

--- a/include/ck_tile/core.hpp
+++ b/include/ck_tile/core.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/core/algorithm/cluster_descriptor.hpp"

--- a/include/ck_tile/host.hpp
+++ b/include/ck_tile/host.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/host/arg_parser.hpp"

--- a/include/ck_tile/ops/add_rmsnorm2d_rdquant.hpp
+++ b/include/ck_tile/ops/add_rmsnorm2d_rdquant.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/add_rmsnorm2d_rdquant/kernel/add_rmsnorm2d_rdquant_fwd_kernel.hpp"

--- a/include/ck_tile/ops/batched_contraction.hpp
+++ b/include/ck_tile/ops/batched_contraction.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/batched_contraction/kernel/batched_contraction_kernel.hpp"

--- a/include/ck_tile/ops/batched_transpose.hpp
+++ b/include/ck_tile/ops/batched_transpose.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/batched_transpose/kernel/batched_transpose_kernel.hpp"

--- a/include/ck_tile/ops/common.hpp
+++ b/include/ck_tile/ops/common.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/common/generic_2d_block_shape.hpp"

--- a/include/ck_tile/ops/elementwise.hpp
+++ b/include/ck_tile/ops/elementwise.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/elementwise/binary_elementwise_operation.hpp"

--- a/include/ck_tile/ops/epilogue.hpp
+++ b/include/ck_tile/ops/epilogue.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/epilogue/cshuffle_epilogue.hpp"

--- a/include/ck_tile/ops/flatmm.hpp
+++ b/include/ck_tile/ops/flatmm.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/flatmm/block/block_flatmm_asmem_bsmem_creg_v1.hpp"

--- a/include/ck_tile/ops/fmha.hpp
+++ b/include/ck_tile/ops/fmha.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/fmha/block/block_attention_bias_enum.hpp"

--- a/include/ck_tile/ops/fused_moe.hpp
+++ b/include/ck_tile/ops/fused_moe.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/fused_moe/kernel/fused_moegemm_kernel.hpp"

--- a/include/ck_tile/ops/gemm.hpp
+++ b/include/ck_tile/ops/gemm.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/gemm/block/block_gemm_areg_bgmem_creg_v1.hpp"

--- a/include/ck_tile/ops/gemm_quant.hpp
+++ b/include/ck_tile/ops/gemm_quant.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/gemm_quant/block/block_gemm_quant_common.hpp"

--- a/include/ck_tile/ops/grouped_convolution.hpp
+++ b/include/ck_tile/ops/grouped_convolution.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/grouped_convolution/kernel/grouped_convolution_backward_data_kernel.hpp"

--- a/include/ck_tile/ops/image_to_column.hpp
+++ b/include/ck_tile/ops/image_to_column.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/image_to_column/kernel/image_to_column_kernel.hpp"

--- a/include/ck_tile/ops/layernorm2d.hpp
+++ b/include/ck_tile/ops/layernorm2d.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/layernorm2d/kernel/layernorm2d_fwd_kernel.hpp"

--- a/include/ck_tile/ops/norm_reduce.hpp
+++ b/include/ck_tile/ops/norm_reduce.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/norm_reduce/block/block_norm_reduce.hpp"

--- a/include/ck_tile/ops/permute.hpp
+++ b/include/ck_tile/ops/permute.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/permute/kernel/generic_permute_kernel.hpp"

--- a/include/ck_tile/ops/pooling.hpp
+++ b/include/ck_tile/ops/pooling.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/pooling/kernel/pool_kernel.hpp"

--- a/include/ck_tile/ops/reduce.hpp
+++ b/include/ck_tile/ops/reduce.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/reduce/block/block_reduce.hpp"

--- a/include/ck_tile/ops/rmsnorm2d.hpp
+++ b/include/ck_tile/ops/rmsnorm2d.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/rmsnorm2d/kernel/rmsnorm2d_fwd_kernel.hpp"

--- a/include/ck_tile/ops/smoothquant.hpp
+++ b/include/ck_tile/ops/smoothquant.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/smoothquant/kernel/moe_smoothquant_kernel.hpp"

--- a/include/ck_tile/ops/softmax.hpp
+++ b/include/ck_tile/ops/softmax.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/softmax/block/block_softmax_2d.hpp"

--- a/include/ck_tile/ops/topk.hpp
+++ b/include/ck_tile/ops/topk.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/topk/block/block_topk_stream_2d.hpp"

--- a/include/ck_tile/ops/topk_softmax.hpp
+++ b/include/ck_tile/ops/topk_softmax.hpp
@@ -1,6 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2018-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #pragma once
 
 #include "ck_tile/ops/topk_softmax/kernel/topk_softmax_kernel.hpp"

--- a/include/ck_tile/remod.py
+++ b/include/ck_tile/remod.py
@@ -1,7 +1,6 @@
 # Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier: MIT
 
-from datetime import datetime
 import pathlib
 from pathlib import Path
 import subprocess
@@ -13,8 +12,8 @@ OPS = "ops"
 OPS_COMMON = "common"  # common header will be duplicated into ops/* other module
 
 IGNORED_DIRS = ["utility", "ref"]
-HEADER_COMMON = f"""// SPDX-License-Identifier: MIT
-// Copyright (c) 2018-{datetime.now().year}, Advanced Micro Devices, Inc. All rights reserved.\n
+HEADER_COMMON = """// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 """
 
 

--- a/script/check_copyright_year.sh
+++ b/script/check_copyright_year.sh
@@ -15,27 +15,27 @@ SPDX_LINE="SPDX-License-Identifier: MIT"
 
 check_file() {
     local file=$1
+    local basename="${file##*/}"
     local ext="${file##*.}"
     local comment_char
 
-    # Determine comment character based on file extension
-    case "$ext" in
-        cpp|hpp|inc)
-            comment_char="//"
-            ;;
-        py|sh|cmake)
-            comment_char="#"
-            ;;
-        *)
-            # If the filename is *.cmake or CMakeLists.txt, use #
-            if [[ "$file" == *CMakeLists.txt ]] || [[ "$file" == *.cmake ]]; then
+    # Determine comment character based on filename or extension
+    if [[ "$basename" == "CMakeLists.txt" ]]; then
+        comment_char="#"
+    else
+        case "$ext" in
+            cpp|hpp|inc)
+                comment_char="//"
+                ;;
+            py|sh|cmake)
                 comment_char="#"
-            else
+                ;;
+            *)
                 # Skip files with unsupported extensions
                 return 0
-            fi
-            ;;
-    esac
+                ;;
+        esac
+    fi
 
     # Build expected header patterns
     expected_copyright="$comment_char $COPYRIGHT_LINE"

--- a/script/check_copyright_year.sh
+++ b/script/check_copyright_year.sh
@@ -2,18 +2,70 @@
 # Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier: MIT
 
+# This script checks if files have the correct copyright header template.
+# It supports .hpp, .cpp, .inc, .py, .sh, and .cmake files.
+#
+# Usage: ./check_copyright_year.sh <file1> <file2> ...
 
-current_year=$(date +%Y)
 exit_code=0
 
-for file in $@; do
-    if grep -q "Copyright (c)" $file
-    then
-        if ! grep -q "Copyright (c).*$current_year" $file
-        then
-            echo "ERROR: File $file has a copyright notice without the current year ($current_year)."
-            exit_code=1
-        fi
+# Expected copyright header lines (without comment characters)
+COPYRIGHT_LINE="Copyright (c) Advanced Micro Devices, Inc., or its affiliates."
+SPDX_LINE="SPDX-License-Identifier: MIT"
+
+check_file() {
+    local file=$1
+    local ext="${file##*.}"
+    local comment_char
+
+    # Determine comment character based on file extension
+    case "$ext" in
+        cpp|hpp|inc)
+            comment_char="//"
+            ;;
+        py|sh|cmake)
+            comment_char="#"
+            ;;
+        *)
+            # If the filename is *.cmake or CMakeLists.txt, use #
+            if [[ "$file" == *CMakeLists.txt ]] || [[ "$file" == *.cmake ]]; then
+                comment_char="#"
+            else
+                # Skip files with unsupported extensions
+                return 0
+            fi
+            ;;
+    esac
+
+    # Build expected header patterns
+    expected_copyright="$comment_char $COPYRIGHT_LINE"
+    expected_spdx="$comment_char $SPDX_LINE"
+
+    # Check if file contains both required lines
+    if ! grep -qF "$expected_copyright" "$file"; then
+        echo "ERROR: File $file is missing the correct copyright header line."
+        echo "  Expected: $expected_copyright"
+        return 1
+    fi
+
+    if ! grep -qF "$expected_spdx" "$file"; then
+        echo "ERROR: File $file is missing the correct SPDX license identifier line."
+        echo "  Expected: $expected_spdx"
+        return 1
+    fi
+
+    return 0
+}
+
+# Process each file provided as argument
+for file in "$@"; do
+    # Skip if file doesn't exist or is a directory
+    if [[ ! -f "$file" ]]; then
+        continue
+    fi
+
+    if ! check_file "$file"; then
+        exit_code=1
     fi
 done
 

--- a/script/update_amd_copyright_headers.py
+++ b/script/update_amd_copyright_headers.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
+"""
+Purpose:
+  Normalize and enforce AMD two-line copyright + SPDX headers across files.
+
+Target files:
+  - C/C++-style: .cpp, .hpp, .inc  -> uses "//" comment style
+  - Hash-style:  .py, .cmake, .sh, and CMakeLists.txt -> uses "#" style
+
+Header formats inserted (top of file, followed by exactly one blank line):
+  C/C++  :
+    // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+    // SPDX-License-Identifier: MIT
+    <blank>
+  Hash   :
+    <blank>
+
+Shebang special case (hash-style only):
+  - If line 1 starts with "#!", keep shebang, then a blank line, then the
+    two hash-style header lines, then a blank line.
+
+Removal rules:
+  - Remove any comment lines (anywhere in file) containing the keywords
+    "copyright" or "spdx" (case-insensitive). Blank lines are preserved.
+  - Remove long-form MIT license block comment when:
+      a) The file starts with the block (absolute top), OR
+      b) The block appears immediately after the AMD header position
+         (i.e., when remainder at insertion point begins with "/*" and
+         the first content line is "* The MIT License (MIT)").
+
+Blank-line normalization:
+  - Enforce exactly ONE blank line immediately after the AMD header.
+    (Drop only the leading blank lines at the insertion point before
+     re-inserting the header.)
+  - Do not change blank lines between other non-copyright comments.
+
+Preservation:
+  - Preserve original newline style: CRLF (\r\n) vs LF (\n).
+  - Preserve UTF-8 BOM if present.
+  - Do not modify non-comment code lines.
+
+Idempotency:
+  - Running this script multiple times does not further modify files.
+"""
+
+from __future__ import annotations
+import re
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+AMD_CPP_HEADER_TEXT = [
+    "// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.",
+    "// SPDX-License-Identifier: MIT",
+]
+AMD_HASH_HEADER_TEXT = [
+    "# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.",
+    "# SPDX-License-Identifier: MIT",
+]
+
+CPP_EXTS = {".cpp", ".hpp", ".inc"}
+HASH_EXTS = {".py", ".cmake", ".sh"}
+
+# --- Encoding helpers -------------------------------------------------------
+
+
+def has_bom(raw: bytes) -> bool:
+    return raw.startswith(b"\xef\xbb\xbf")
+
+
+def decode_text(raw: bytes) -> str:
+    return raw.decode("utf-8-sig", errors="replace")
+
+
+def encode_text(text: str, bom: bool) -> bytes:
+    data = text.encode("utf-8")
+    return (b"\xef\xbb\xbf" + data) if bom else data
+
+
+# --- Newline detection ------------------------------------------------------
+
+
+def detect_newline_sequence(raw: bytes) -> str:
+    if b"\r\n" in raw:
+        return "\r\n"
+    elif b"\n" in raw:
+        return "\n"
+    else:
+        return "\n"
+
+
+# --- Utilities --------------------------------------------------------------
+
+
+def is_comment_line(line: str, style: str) -> bool:
+    stripped = line.lstrip()
+    if style == "cpp":
+        return (
+            stripped.startswith("//")
+            or stripped.startswith("/*")
+            or stripped.startswith("*")
+            or stripped.startswith("*/")
+        )
+    elif style == "hash":
+        return stripped.startswith("#")
+    return False
+
+
+def has_keywords(line: str) -> bool:
+    lower_line = line.lower()
+    return ("copyright" in lower_line) or ("spdx" in lower_line)
+
+
+# --- MIT License banner detection ------------------------------
+MIT_C_FIRST_LINE_RE = re.compile(r"^\s*\*\s*The MIT License \(MIT\)")
+MIT_HASH_FIRST_LINE_RE = re.compile(r"^\s*#\s*The MIT License \(MIT\)")
+
+
+def remove_top_mit_block(lines: List[str]) -> Tuple[List[str], bool]:
+    """
+    Unified MIT banner removal at the top of 'lines'.
+    Supports:
+      - C-style block starting with '/*' and ending with '*/'; removes only if
+        a line within the block matches MIT_C_FIRST_LINE_RE.
+      - Hash-style banner: contiguous top run of lines starting with '#';
+        removes only if any line in that run matches MIT_HASH_FIRST_LINE_RE.
+    Returns (new_lines, removed_flag). Preserves EOLs.
+    """
+    if not lines:
+        return lines, False
+
+    first = lines[0].lstrip()
+
+    # C-style block
+    if first.startswith("/*"):
+        end_idx, saw_mit = None, False
+        for i, line in enumerate(lines[1:], 1):
+            if not saw_mit and MIT_C_FIRST_LINE_RE.match(line):
+                saw_mit = True
+            s = line.lstrip()
+            if s.startswith("*/") or s.rstrip().endswith("*/"):
+                end_idx = i + 1
+                break
+        if end_idx is not None and saw_mit:
+            return lines[end_idx:], True
+        return lines, False
+
+    # Hash-style contiguous banner
+    if first.startswith("#"):
+        end_idx, saw_mit = 0, False
+        for i, line in enumerate(lines):
+            if line.lstrip().startswith("#"):
+                if not saw_mit and MIT_HASH_FIRST_LINE_RE.match(line):
+                    saw_mit = True
+                end_idx = i + 1
+            else:
+                break
+        if saw_mit:
+            return lines[end_idx:], True
+        return lines, False
+
+    return lines, False
+
+
+# --- Removal + normalization helpers ---------------------------------------
+
+
+def remove_keyword_comment_lines_globally(lines: List[str], style: str) -> List[str]:
+    """Remove comment lines containing keywords anywhere in the file.
+    **Do not** remove blank lines; preserve all other lines as-is."""
+    out: List[str] = []
+    for line in lines:
+        if is_comment_line(line, style) and has_keywords(line):
+            continue
+        out.append(line)
+    return out
+
+
+def drop_leading_blank_lines(lines: List[str]) -> List[str]:
+    """Drop only the leading blank lines at the start of the given list."""
+    i = 0
+    while i < len(lines) and lines[i].strip() == "":
+        i += 1
+    return lines[i:]
+
+
+# --- Header builder ---------------------------------------------------------
+
+
+def build_header_lines(style: str, nl: str) -> List[str]:
+    base = AMD_CPP_HEADER_TEXT if style == "cpp" else AMD_HASH_HEADER_TEXT
+    return [base[0] + nl, base[1] + nl, nl]  # header + exactly one blank
+
+
+# --- Main transforms --------------------------------------------------------
+
+
+def process_cpp(text: str, nl: str) -> str:
+    lines = text.splitlines(True)
+
+    # Remove MIT block if it is at the *absolute* top
+    lines, _ = remove_top_mit_block(lines)
+
+    # Remove keyworded comment lines globally (blank lines preserved)
+    lines = remove_keyword_comment_lines_globally(lines, style="cpp")
+
+    # Normalize insertion point and remove MIT block if it appears *after header*
+    lines = drop_leading_blank_lines(lines)
+    lines, _ = remove_top_mit_block(lines)
+
+    # Prepend AMD header (guarantee exactly one blank after)
+    return "".join(build_header_lines("cpp", nl) + lines)
+
+
+def process_hash(text: str, nl: str) -> str:
+    lines = text.splitlines(True)
+    if not lines:
+        return "".join(build_header_lines("hash", nl))
+
+    shebang = lines[0].startswith("#!")
+
+    if shebang:
+        remainder = remove_keyword_comment_lines_globally(lines[1:], style="hash")
+        remainder = drop_leading_blank_lines(remainder)
+        remainder, _ = remove_top_mit_block(remainder)  # remove MIT block after header
+        new_top = [lines[0], nl] + build_header_lines("hash", nl)
+        return "".join(new_top + remainder)
+    else:
+        remainder = remove_keyword_comment_lines_globally(lines, style="hash")
+        remainder = drop_leading_blank_lines(remainder)
+        remainder, _ = remove_top_mit_block(remainder)  # remove MIT block after header
+        return "".join(build_header_lines("hash", nl) + remainder)
+
+
+# --- File processing & CLI --------------------------------------------------
+
+
+def process_file(path: Path) -> bool:
+    name = path.name
+    suffix = path.suffix.lower()
+    if suffix in CPP_EXTS:
+        style = "cpp"
+    elif suffix in HASH_EXTS or name == "CMakeLists.txt":
+        style = "hash"
+    else:
+        return False
+
+    raw = path.read_bytes()
+    bom = has_bom(raw)
+    nl = detect_newline_sequence(raw)
+    text = decode_text(raw)
+
+    updated = process_cpp(text, nl) if style == "cpp" else process_hash(text, nl)
+    if updated != text:
+        path.write_bytes(encode_text(updated, bom))
+        return True
+    return False
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__)
+        return 2
+    changed = 0
+    skipped = 0
+    errors: List[str] = []
+    for arg in argv[1:]:
+        p = Path(arg)
+        try:
+            if not p.exists():
+                errors.append(f"Not found: {p}")
+                continue
+            if p.is_dir():
+                errors.append(f"Is a directory (pass specific files): {p}")
+                continue
+            if process_file(p):
+                changed += 1
+                print(f"Updated: {p}")
+            else:
+                skipped += 1
+                print(f"Skipped (no change needed or unsupported type): {p}")
+        except Exception as e:
+            errors.append(f"Error processing {p}: {e}")
+    print(f"\nSummary: {changed} updated, {skipped} skipped, {len(errors)} errors")
+    for msg in errors:
+        print(f" - {msg}")
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/test/ck_tile/core/arch/mma/test_amdgcn_mma.cpp
+++ b/test/ck_tile/core/arch/mma/test_amdgcn_mma.cpp
@@ -1,5 +1,5 @@
-// Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier:  MIT
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include <hip/hip_runtime.h>
 #include <gtest/gtest.h>

--- a/test/ck_tile/core/arch/test_arch.cpp
+++ b/test/ck_tile/core/arch/test_arch.cpp
@@ -1,5 +1,5 @@
-// Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier:  MIT
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include <gtest/gtest.h>
 #include "ck_tile/core/arch/arch.hpp"

--- a/tile_engine/include/utility/validation.hpp
+++ b/tile_engine/include/utility/validation.hpp
@@ -1,5 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c), Advanced Micro Devices, Inc. All rights reserved.
 
 #pragma once
 

--- a/tile_engine/ops/gemm_streamk/CMakeLists.txt
+++ b/tile_engine/ops/gemm_streamk/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 set(GEMM_STREAMK_DATATYPE "fp8;fp16" CACHE STRING "List of datatypes for GEMM (semicolon-separated)")
 set(GEMM_STREAMK_LAYOUT "rcr" CACHE STRING "List of layout for GEMM (semicolon-separated)")
 set(GEMM_CONFIG_FILE "" CACHE STRING "Custom config file name (without path, must be in configs/ folder)")

--- a/tile_engine/ops/gemm_streamk/gemm_streamk_benchmark.hpp
+++ b/tile_engine/ops/gemm_streamk/gemm_streamk_benchmark.hpp
@@ -1,5 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #pragma once
 

--- a/tile_engine/ops/gemm_streamk/gemm_streamk_benchmark_single.cpp
+++ b/tile_engine/ops/gemm_streamk/gemm_streamk_benchmark_single.cpp
@@ -1,5 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #include <iostream>
 #include <functional>

--- a/tile_engine/ops/gemm_streamk/gemm_streamk_common.hpp
+++ b/tile_engine/ops/gemm_streamk/gemm_streamk_common.hpp
@@ -1,5 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #pragma once
 

--- a/tile_engine/ops/gemm_streamk/gemm_streamk_instance_builder.py
+++ b/tile_engine/ops/gemm_streamk/gemm_streamk_instance_builder.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 
 import os
 import json

--- a/tile_engine/ops/gemm_streamk/gemm_streamk_profiler.hpp
+++ b/tile_engine/ops/gemm_streamk/gemm_streamk_profiler.hpp
@@ -1,5 +1,5 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #pragma once
 

--- a/tile_engine/ops/gemm_streamk/gemm_streamk_validation_utils.py
+++ b/tile_engine/ops/gemm_streamk/gemm_streamk_validation_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
 
 """
 Validation utilities for GEMM kernel generation.


### PR DESCRIPTION
## Proposed changes

This PR adds a script that verifies that files to be committed have the correct copyright header. 
Also updates the remod.py script with the new copyright header template.

Script is made part of precommit-hooks and would not let incorrect header formats be pushed to the repository. 

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged #3293 

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

