### PR TITLE
[CK_TILE] Fix for comp pipeline v4

### DIFF
--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v4.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v4.hpp
@@ -22,7 +22,7 @@ struct BaseGemmPipelineAgBgCrCompV4
 
     CK_TILE_HOST_DEVICE static constexpr bool BlockHasHotloop(index_t num_loop)
     {
-        return num_loop > PrefetchStages;
+        return num_loop > 3;
     }
 
     CK_TILE_HOST_DEVICE static constexpr TailNumber GetBlockLoopTailNum(index_t num_loop)

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v4.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v4.hpp
@@ -23,7 +23,7 @@ struct BaseGemmPipelineAgBgCrCompV4
     CK_TILE_HOST_DEVICE static constexpr bool BlockHasHotloop(index_t num_loop)
     {
         constexpr index_t HotLoopGlobalReads = 2;
-        return num_loop >= (HotLoopGlobalReads  + PrefetchStages);
+        return num_loop >= (HotLoopGlobalReads + PrefetchStages);
     }
 
     CK_TILE_HOST_DEVICE static constexpr TailNumber GetBlockLoopTailNum(index_t num_loop)

--- a/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v4.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_v4.hpp
@@ -22,7 +22,8 @@ struct BaseGemmPipelineAgBgCrCompV4
 
     CK_TILE_HOST_DEVICE static constexpr bool BlockHasHotloop(index_t num_loop)
     {
-        return num_loop > 3;
+        constexpr index_t HotLoopGlobalReads = 2;
+        return num_loop >= (HotLoopGlobalReads  + PrefetchStages);
     }
 
     CK_TILE_HOST_DEVICE static constexpr TailNumber GetBlockLoopTailNum(index_t num_loop)


### PR DESCRIPTION
Current version of comp v4 pipeline has a bug in case of using `num_loop = 3`. In that case following would happen:
`BlockHasHotloop` would return `true`, which would lead to using the HotLoop, and the `GetBlockLoopTailNum` would return `TailNumber::Three`, which in the end would lead to having 5 iterations instead of the 3. With `splitk=1` this bug doesn't show up, because the last iterations are just padded to 0, but in other cases the bug results in incorrect values.
