### PR TITLE
[CK_TILE] fix enforcing fixed vectorsizes for ck tile conv

### DIFF
--- a/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -545,7 +545,7 @@ struct UniversalGemmBasePolicy
     }
 
     template <typename Problem, bool IsWave32Host = false>
-    CK_TILE_HOST_DEVICE static constexpr auto GetVectorSizeA()
+    CK_TILE_HOST_DEVICE static constexpr index_t GetVectorSizeA()
     {
         using AsLayout              = remove_cvref_t<typename Problem::AsLayoutTuple>;
         using AsDataType            = remove_cvref_t<typename Problem::AsDataTypeTuple>;
@@ -554,6 +554,11 @@ struct UniversalGemmBasePolicy
 
         using ALayout   = remove_cvref_t<std::tuple_element_t<number<0>{}, AsLayout>>;
         using ADataType = remove_cvref_t<std::tuple_element_t<number<0>{}, AsDataType>>;
+
+        if constexpr(Problem::FixedVectorSize)
+        {
+            return Problem::VectorSizeA;
+        }
 
         if constexpr(std::is_same_v<ALayout, ck_tile::tensor_layout::gemm::RowMajor>)
         {
@@ -574,7 +579,7 @@ struct UniversalGemmBasePolicy
     }
 
     template <typename Problem, bool IsWave32Host = false>
-    CK_TILE_HOST_DEVICE static constexpr auto GetVectorSizeB()
+    CK_TILE_HOST_DEVICE static constexpr index_t GetVectorSizeB()
     {
         using BsLayout              = remove_cvref_t<typename Problem::BsLayoutTuple>;
         using BsDataType            = remove_cvref_t<typename Problem::BsDataTypeTuple>;
@@ -583,6 +588,11 @@ struct UniversalGemmBasePolicy
 
         using BLayout   = remove_cvref_t<std::tuple_element_t<number<0>{}, BsLayout>>;
         using BDataType = remove_cvref_t<std::tuple_element_t<number<0>{}, BsDataType>>;
+
+        if constexpr(Problem::FixedVectorSize)
+        {
+            return Problem::VectorSizeB;
+        }
 
         if constexpr(std::is_same_v<BLayout, ck_tile::tensor_layout::gemm::RowMajor>)
         {


### PR DESCRIPTION
This PR fixes a bug of inconsistent behavior of `FixedVectorSize` parameter inside CK Tile Convolutions and was discovered while porting convolution instances from old ck to ck tile. This parameter is used to disable automatic vectorsize selection and allow kernel user to specify some arbitral size of vectorloads.
Current behavior is that: `gemm_pipeline_problem.hpp` uses `FixedVectorSize`, but we were lacking the enforcing `if` statement inside `universal gemm policy`, which caused some part of the code to use automatic vectorload size selection, and the other part of code to use the arbitrary vectorload size, which was causing undefined behavior of some kernels and compilation errors for others, since the tile shapes were inconsistent. I have checked the behavior of this change on ckTileProfiler branch and it works for all cases tested there, but we definitely should create some tests to allow early detection and avoid that kind of bugs in the future.
