### PR TITLE
[CK_TILE][FMHA] Fix Python 3.8 compatibility in fmha codegen

### DIFF
--- a/example/ck_tile/01_fmha/codegen/ops/fmha_fwd.py
+++ b/example/ck_tile/01_fmha/codegen/ops/fmha_fwd.py
@@ -770,7 +770,7 @@ def create_kernel(
 
 class CompatibilityRuleFactory:
     @staticmethod
-    def get_rules() -> list[CompatibilityRule]:
+    def get_rules() -> List[CompatibilityRule]:
         # in group mode, spad/skpad must be true, since we can't predict if seqlen of current batch need pad or not
         def check_mode(problem_ctx: ProblemContext, kernel_ctx: KernelContext) -> bool:
             if problem_ctx.mode == "group":
@@ -812,7 +812,7 @@ class CompatibilityRuleFactoryGfx9(CompatibilityRuleFactory):
     _AVAILABLE_PIPELINES = frozenset({"qr", "qr_async", "qs"})
 
     @classmethod
-    def get_rules(cls) -> list[CompatibilityRule]:
+    def get_rules(cls) -> List[CompatibilityRule]:
         rules = CompatibilityRuleFactory.get_rules()
 
         def check_hdim_tile(
@@ -846,7 +846,7 @@ class CompatibilityRuleFactoryGfx950(CompatibilityRuleFactoryGfx9):
     )
 
     @classmethod
-    def get_rules(cls) -> list[CompatibilityRule]:
+    def get_rules(cls) -> List[CompatibilityRule]:
         rules = CompatibilityRuleFactoryGfx9.get_rules()
 
         def check_tile_pipeline(


### PR DESCRIPTION
## Proposed changes

The FMHA codegen scripts fail on Python 3.8 with:
```
TypeError: 'type' object is not subscriptable
```

This is caused by using PEP 585 generic syntax (`list[...]`, `dict[...]`) which is only supported in Python 3.9+.

### Solution

Add `from __future__ import annotations` to enable postponed evaluation of annotations (PEP 563), making the code compatible with Python 3.8.

### Notes

- CMake's `find_package(Python3)` specifies minimum version 3.6, so we should maintain 3.8 compatibility.
- Alternatively, we could use `typing.List` style hints, but `__future__` annotations is cleaner and forward-compatible.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

