### PR TITLE
[CK Grouped Gemm] Fix grouped gemm split k test

### DIFF
--- a/include/ck/host_utility/kernel_launch.hpp
+++ b/include/ck/host_utility/kernel_launch.hpp
@@ -138,6 +138,9 @@ float launch_and_time_kernel_with_preprocess(const StreamConfig& stream_config,
         for(int i = 0; i < nrepeat; ++i)
         {
             preprocess();
+            // Synchronize to ensure async preprocess operations (e.g., hipMemsetAsync) complete
+            // before kernel launch, especially critical for large workspace buffers
+            hip_check_error(hipStreamSynchronize(stream_config.stream_id_));
             kernel<<<grid_dim, block_dim, lds_byte, stream_config.stream_id_>>>(args...);
             hip_check_error(hipGetLastError());
         }

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_gemm_multiple_d_splitk_xdl_cshuffle_two_stage.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_gemm_multiple_d_splitk_xdl_cshuffle_two_stage.hpp
@@ -358,15 +358,27 @@ struct DeviceGroupedGemmMultipleDSplitKXdlCShuffleTwoStage
 
                 const index_t stride_a = gemm_descs[i].stride_A_;
                 const index_t stride_b = gemm_descs[i].stride_B_;
-                const index_t stride_e = gemm_descs[i].stride_C_;
 
                 const index_t m_padded  = GridwiseGemm64::CalculateMPadded(M);
                 const index_t n_padded  = GridwiseGemm64::CalculateNPadded(N);
                 const index_t k_padded  = GridwiseGemm64::CalculateKPadded(K, K_BATCH);
                 const index_t k0_padded = GridwiseGemm64::CalculateK0Padded(K, K_BATCH);
 
+                // For TwoStage kernels, use dense stride for workspace (based on padded dimensions)
+                // not the user's output stride, to avoid sparse layouts and minimize memory usage
+                const index_t workspace_stride = [&]() {
+                    if constexpr(is_same<tensor_layout::gemm::RowMajor, ELayout>::value)
+                    {
+                        return n_padded; // Row-major: stride along columns
+                    }
+                    else // ColumnMajor
+                    {
+                        return m_padded; // Column-major: stride along rows
+                    }
+                }();
+
                 const auto c_grid_desc_m_n =
-                    GridwiseGemm64::MakeCGridDescriptor_M_N(M, N, stride_e);
+                    GridwiseGemm64::MakeCGridDescriptor_M_N(M, N, workspace_stride);
 
                 DsGridDesc_M_N ds_grid_desc_m_n;
                 DsGridPointer p_ds_grid;
@@ -415,7 +427,7 @@ struct DeviceGroupedGemmMultipleDSplitKXdlCShuffleTwoStage
                                                K,
                                                stride_a,
                                                stride_b,
-                                               stride_e,
+                                               workspace_stride, // Use dense stride for workspace
                                                m_padded,
                                                n_padded,
                                                k_padded,
@@ -488,6 +500,12 @@ struct DeviceGroupedGemmMultipleDSplitKXdlCShuffleTwoStage
                               << "grid_size_: " << karg.KPadded << std::endl;
                 }
             }
+
+            // Update workspace pointers after changing block layout
+            if(p_workspace_ != nullptr)
+            {
+                UpdateEPointers();
+            }
         }
 
         void UpdateEPointers()
@@ -499,14 +517,14 @@ struct DeviceGroupedGemmMultipleDSplitKXdlCShuffleTwoStage
             for(auto& arg : gemm_kernel_args_)
             {
                 arg.karg_.p_c_grid = p_workspace + offset;
-                index_t tiles      = (arg.block_end_ - arg.block_start_) / arg.karg_.k_batch;
-                offset += tiles * MPerBlock * NPerBlock;
+                // Workspace uses MPadded rows × StrideC columns (where StrideC = dense padded
+                // dimension)
+                offset += arg.karg_.MPadded * arg.karg_.StrideC;
                 if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
                 {
-                    std::cout << "block_start: " << arg.block_start_ << "\n"
-                              << "block_end: " << arg.block_end_ << "\n"
-                              << "tiles: " << tiles << "\n"
-                              << "offset: " << offset << std::endl;
+                    std::cout << "UpdateEPointers: MPadded=" << arg.karg_.MPadded
+                              << ", StrideC=" << arg.karg_.StrideC << ", offset=" << offset
+                              << std::endl;
                 }
             }
         }
@@ -517,8 +535,9 @@ struct DeviceGroupedGemmMultipleDSplitKXdlCShuffleTwoStage
 
             for(const auto& arg : gemm_kernel_args_)
             {
-                index_t tiles = (arg.block_end_ - arg.block_start_) / arg.karg_.k_batch;
-                size_bytes += tiles * MPerBlock * NPerBlock * sizeof(WorkspaceDataType);
+                // Workspace uses MPadded rows × StrideC columns (where StrideC = dense padded
+                // dimension)
+                size_bytes += arg.karg_.MPadded * arg.karg_.StrideC * sizeof(WorkspaceDataType);
             }
             return size_bytes;
         }

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_gemm_xdl_splitk_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_gemm_xdl_splitk_cshuffle.hpp
@@ -488,6 +488,9 @@ struct DeviceGroupedGemmXdlSplitKCShuffle : public DeviceGroupedGemmSplitK<ALayo
                                                        karg.M * karg.N * sizeof(EDataType),
                                                        stream_config.stream_id_));
                     }
+
+                    // Ensure memset completes before kernel launch
+                    hip_check_error(hipStreamSynchronize(stream_config.stream_id_));
                 }
 
                 ave_time =
@@ -620,7 +623,44 @@ struct DeviceGroupedGemmXdlSplitKCShuffle : public DeviceGroupedGemmSplitK<ALayo
         bool isWave64  = get_warp_size() == 64;
         for(std::size_t i = 0; i < arg.gemm_kernel_args_.size(); ++i)
         {
-            const auto& a        = arg.gemm_kernel_args_[i].karg_;
+            const auto& a = arg.gemm_kernel_args_[i].karg_;
+
+            // Validate stride requirements for SplitK (k_batch > 1)
+            // AMD buffer atomic operations require contiguous output layout
+            if(a.k_batch > 1)
+            {
+                if constexpr(std::is_same_v<ELayout, tensor_layout::gemm::RowMajor>)
+                {
+                    if(a.StrideC != a.N)
+                    {
+                        if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
+                        {
+                            std::cout << "[" << __func__ << "] group id: " << i
+                                      << " SplitK (k_batch=" << a.k_batch
+                                      << ") requires contiguous output stride."
+                                      << " For RowMajor layout: StrideC must equal N."
+                                      << " Got StrideC=" << a.StrideC << ", N=" << a.N << std::endl;
+                        }
+                        return false;
+                    }
+                }
+                else if constexpr(std::is_same_v<ELayout, tensor_layout::gemm::ColumnMajor>)
+                {
+                    if(a.StrideC != a.M)
+                    {
+                        if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
+                        {
+                            std::cout << "[" << __func__ << "] group id: " << i
+                                      << " SplitK (k_batch=" << a.k_batch
+                                      << ") requires contiguous output stride."
+                                      << " For ColumnMajor layout: StrideC must equal M."
+                                      << " Got StrideC=" << a.StrideC << ", M=" << a.M << std::endl;
+                        }
+                        return false;
+                    }
+                }
+            }
+
             bool group_arg_valid = false;
             if(isWave64)
             {

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_gemm_xdl_splitk_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_gemm_xdl_splitk_cshuffle.hpp
@@ -623,38 +623,40 @@ struct DeviceGroupedGemmXdlSplitKCShuffle : public DeviceGroupedGemmSplitK<ALayo
         bool isWave64  = get_warp_size() == 64;
         for(std::size_t i = 0; i < arg.gemm_kernel_args_.size(); ++i)
         {
-            const auto& a = arg.gemm_kernel_args_[i].karg_;
+            const auto& kernel_arg = arg.gemm_kernel_args_[i].karg_;
 
             // Validate stride requirements for SplitK (k_batch > 1)
             // AMD buffer atomic operations require contiguous output layout
-            if(a.k_batch > 1)
+            if(kernel_arg.k_batch > 1)
             {
                 if constexpr(std::is_same_v<ELayout, tensor_layout::gemm::RowMajor>)
                 {
-                    if(a.StrideC != a.N)
+                    if(kernel_arg.StrideC != kernel_arg.N)
                     {
                         if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
                         {
                             std::cout << "[" << __func__ << "] group id: " << i
-                                      << " SplitK (k_batch=" << a.k_batch
+                                      << " SplitK (k_batch=" << kernel_arg.k_batch
                                       << ") requires contiguous output stride."
                                       << " For RowMajor layout: StrideC must equal N."
-                                      << " Got StrideC=" << a.StrideC << ", N=" << a.N << std::endl;
+                                      << " Got StrideC=" << kernel_arg.StrideC
+                                      << ", N=" << kernel_arg.N << std::endl;
                         }
                         return false;
                     }
                 }
                 else if constexpr(std::is_same_v<ELayout, tensor_layout::gemm::ColumnMajor>)
                 {
-                    if(a.StrideC != a.M)
+                    if(kernel_arg.StrideC != kernel_arg.M)
                     {
                         if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
                         {
                             std::cout << "[" << __func__ << "] group id: " << i
-                                      << " SplitK (k_batch=" << a.k_batch
+                                      << " SplitK (k_batch=" << kernel_arg.k_batch
                                       << ") requires contiguous output stride."
                                       << " For ColumnMajor layout: StrideC must equal M."
-                                      << " Got StrideC=" << a.StrideC << ", M=" << a.M << std::endl;
+                                      << " Got StrideC=" << kernel_arg.StrideC
+                                      << ", M=" << kernel_arg.M << std::endl;
                         }
                         return false;
                     }
@@ -666,7 +668,7 @@ struct DeviceGroupedGemmXdlSplitKCShuffle : public DeviceGroupedGemmSplitK<ALayo
             {
                 if constexpr(NXdlPerWave64 > 0)
                 {
-                    group_arg_valid = GridwiseGemm64::CheckValidity(a);
+                    group_arg_valid = GridwiseGemm64::CheckValidity(kernel_arg);
                 }
             }
             else
@@ -674,7 +676,7 @@ struct DeviceGroupedGemmXdlSplitKCShuffle : public DeviceGroupedGemmSplitK<ALayo
                 if constexpr(NXdlPerWave32 > 0)
                 {
                     group_arg_valid = GridwiseGemm32::CheckValidity(
-                        reinterpret_cast<const typename GridwiseGemm32::Argument&>(a));
+                        reinterpret_cast<const typename GridwiseGemm32::Argument&>(kernel_arg));
                 }
             }
 
@@ -684,7 +686,7 @@ struct DeviceGroupedGemmXdlSplitKCShuffle : public DeviceGroupedGemmSplitK<ALayo
                 {
                     std::cout << "[" << __func__ << "] group id: " << i
                               << " has invalid GridwiseGemm settings!" << std::endl;
-                    a.Print();
+                    kernel_arg.Print();
                 }
             }
             supported = supported && group_arg_valid;


### PR DESCRIPTION
## Proposed changes

The tests run by `script/profile_grouped_gemm.sh` were failing with illegal memory accesses.

Two memory access issues are solved by this PR:
1. The splitk kernel is disabled for split-k > 1 with non-contiguous strides since the buffer atomics require contiguous memory.
2. Workspace sizes and pointers, and a race condition are fixed in the two-stage kernel.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

