### PR TITLE
Disable test_tile_gemm_quant_bquant_preshuffle.

### DIFF
--- a/test/ck_tile/gemm_block_scale/CMakeLists.txt
+++ b/test/ck_tile/gemm_block_scale/CMakeLists.txt
@@ -24,10 +24,12 @@ if(GPU_TARGETS MATCHES "gfx94|gfx95|gfx12")
     target_compile_options(test_tile_gemm_quant_bquant PRIVATE ${TEST_GEMM_COMPILE_OPTIONS})
 
     # BQuant tests (with PreshuffleB)
-    add_gtest_executable(test_tile_gemm_quant_bquant_preshuffle 
-        test_gemm_quant_bquant_preshuffle.cpp
-    )
-    target_compile_options(test_tile_gemm_quant_bquant_preshuffle PRIVATE ${TEST_GEMM_COMPILE_OPTIONS})
+    # disabling this test until it can be built within reasonable time!
+    # currently taking ~50 minutes on gfx12!
+    #add_gtest_executable(test_tile_gemm_quant_bquant_preshuffle
+    #    test_gemm_quant_bquant_preshuffle.cpp
+    #)
+    #target_compile_options(test_tile_gemm_quant_bquant_preshuffle PRIVATE ${TEST_GEMM_COMPILE_OPTIONS})
 
     # RowColQuant tests
     add_gtest_executable(test_tile_gemm_quant_rowcol 


### PR DESCRIPTION
## Proposed changes

Test test_tile_gemm_quant_bquant_preshuffle takes about 50 minutes to build for gfx12 and is crippling our CI.
It needs to be refactored. Until then we'll have to disable it.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged
