### PR TITLE
[CK_BUILDER] Add missing enums to data_type_sizeof

### DIFF
--- a/experimental/builder/include/ck_tile/builder/testing/type_traits.hpp
+++ b/experimental/builder/include/ck_tile/builder/testing/type_traits.hpp
@@ -31,13 +31,20 @@ constexpr size_t data_type_sizeof(DataType data_type)
     {
     case DataType::UNDEFINED_DATA_TYPE: return 0;
     case DataType::FP32: return 4;
+    case DataType::FP32_FP32: return 8;
     case DataType::FP16: return 2;
+    case DataType::FP16_FP16: return 4;
     case DataType::BF16: return 2;
+    case DataType::BF16_BF16: return 4;
     case DataType::FP8: return 1;
+    case DataType::BF8: return 1;
+    case DataType::FP64: return 8;
     case DataType::INT32: return 4;
     case DataType::I8: return 1;
+    case DataType::I8_I8: return 2;
     case DataType::U8: return 1;
     }
+    return 0; // Default case to ensure all control paths return a value
 }
 
 } // namespace ck_tile::builder::test


### PR DESCRIPTION
Fixes broken build on gfx942. This was some test code that got merged at the same time and we hit a race condition in our CI.

