### PR TITLE
[ci] Adding org var and dynamic selection of targets

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: d76278526218def9fb1b016bc9e421738cb4f8f6 # 2025-12-09 commit
+          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
       - name: Setup ccache
         run: |

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -35,21 +35,44 @@ jobs:
       BASE_REF: HEAD^
     outputs:
       enable_therock_ci: ${{ steps.configure.outputs.enable_therock_ci }}
+      linux_package_targets: ${{ steps.configure_linux.outputs.package_targets }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           # We need the parent commit to do a diff
           fetch-depth: 2
+      
+      - name: Checkout TheRock repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "ROCm/TheRock"
+          path: TheRock
+          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
       - name: "Configuring CI options"
         id: configure
         run: python .github/scripts/therock_configure_ci.py
 
+      - name: Fetch Linux targets for build and test
+        env:
+          THEROCK_PACKAGE_PLATFORM: "linux"
+          # TODO(geomin12): Allow dynamic values of AMDGPU_FAMILIES, with opt-in options
+          AMDGPU_FAMILIES: "gfx94X"
+          # Variable comes from ROCm organization variable 'ROCM_THEROCK_TEST_RUNNERS'
+          ROCM_THEROCK_TEST_RUNNERS: ${{ vars.ROCM_THEROCK_TEST_RUNNERS }}
+          LOAD_TEST_RUNNERS_FROM_VAR: true
+        id: configure_linux
+        run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py
+
   therock-ci-linux:
-    name: TheRock CI Linux
+    name: TheRock CI Linux (${{ matrix.target_bundle.amdgpu_family }})
     needs: setup
     if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target_bundle: ${{ fromJSON(needs.setup.outputs.linux_package_targets) }}
     permissions:
       contents: read
       id-token: write
@@ -64,8 +87,8 @@ jobs:
         -DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel
         -DTHEROCK_USE_EXTERNAL_ROCM_LIBRARIES=ON
         -DTHEROCK_ROCM_LIBRARIES_SOURCE_DIR=../
-      amdgpu_families: "gfx94X-dcgpu"
-      test_runs_on: "linux-mi325-1gpu-ossci-rocm-frac"
+      amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
+      test_runs_on: ${{ matrix.target_bundle.test_machine }}
 
   therock_ci_summary:
     name: TheRock CI Summary

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: d76278526218def9fb1b016bc9e421738cb4f8f6 # 2025-12-09 commit
+          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: d76278526218def9fb1b016bc9e421738cb4f8f6 # 2025-12-09 commit
+          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
       - name: "Configuring CI options"
         env:


### PR DESCRIPTION
Changes: 
- Pulling test runner labels from the ROCm organization variable, in order to update faster and be more dynamic
- Test labels and AMD GPU families are pulled from TheRock instead of hard-coded, allowing for the eventual expansion