### PR TITLE
Fix minor issues in cmake-ck-dev script

### DIFF
--- a/script/cmake-ck-dev.sh
+++ b/script/cmake-ck-dev.sh
@@ -47,5 +47,5 @@ cmake                                                                           
 -D GPU_TARGETS=$GPU_TARGETS                                                                       \
 -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON                                                                 \
 -D USE_BITINT_EXTENSION_INT4=OFF                                                                  \
-"${REST_ARGS[@]}"                                                                                 \                                                                                     \
+"${REST_ARGS[@]}"                                                                                 \
 ${MY_PROJECT_SOURCE}

--- a/script/cmake-ck-dev.sh
+++ b/script/cmake-ck-dev.sh
@@ -25,7 +25,7 @@ GPU_TARGETS="gfx908;gfx90a;gfx942"
 if [ $# -ge 1 ]; then
     case "$1" in
         gfx*)
-            GPU_TARGETS=$1
+            GPU_TARGETS="$1"
             shift 1
             echo "GPU targets provided: $GPU_TARGETS"
             REST_ARGS=("$@")
@@ -44,8 +44,8 @@ cmake                                                                           
 -D CMAKE_CXX_FLAGS="-ftemplate-backtrace-limit=0  -fPIE  -Wno-gnu-line-marker -fbracket-depth=512" \
 -D CMAKE_BUILD_TYPE=Release                                                                       \
 -D BUILD_DEV=ON                                                                                   \
--D GPU_TARGETS=$GPU_TARGETS                                                                       \
+-D GPU_TARGETS="$GPU_TARGETS"                                                                     \
 -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON                                                                 \
 -D USE_BITINT_EXTENSION_INT4=OFF                                                                  \
 "${REST_ARGS[@]}"                                                                                 \
-${MY_PROJECT_SOURCE}
+"${MY_PROJECT_SOURCE}"


### PR DESCRIPTION
## Proposed changes

This removes an errant slash from `script/cmake-ck-dev.sh` which was causing the `$MY_PROJECT_SOURCE` argument to be ignored, producing a warning from `cmake` and causing the command to fail when `cmake` defaults don't catch the correct directory. Variable quoting was also inconsistent and quotes are added to prevent other similar issues.

