### PR TITLE
Improve XDL to WMMA porting for grouped conv fwd

### DIFF
--- a/experimental/builder/test/conv/ck/test_ckb_conv_fwd_2d_bf16_scaleadd_relu.cpp
+++ b/experimental/builder/test/conv/ck/test_ckb_conv_fwd_2d_bf16_scaleadd_relu.cpp
@@ -33,7 +33,7 @@ TEST(FwdConvInstances,
     constexpr auto FwdConvAlgorithm =
         ConvAlgorithm_DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle{}
             .with_thread_block(FwdThreadBlock_64_64x32x32)
-            .with_gemm_config(FwdGemmParams_Xdl_2x2_per_wave)
+            .with_gemm_config(FwdGemmParams_Xdl_2x1_per_wave)
             .with_transfer(FwdTransfer_4x16x1)
             .with_specializations(ConvFwdSpecialization::DEFAULT, GemmSpecialization::MNKPadding)
             .with_prefetch_config(1, 1, PipelineScheduler::DEFAULT);

--- a/experimental/builder/test/conv/ck/test_ckb_conv_fwd_3d_fp16.cpp
+++ b/experimental/builder/test/conv/ck/test_ckb_conv_fwd_3d_fp16.cpp
@@ -28,7 +28,7 @@ TEST(FwdConvInstances,
     constexpr auto FwdConvAlgorithm =
         ConvAlgorithm_DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3{}
             .with_thread_block(FwdThreadBlock_256_128x128x32)
-            .with_gemm_config(FwdGemmParams_Xdl_4x4_per_wave)
+            .with_gemm_config(FwdGemmParams_Xdl_2x1_per_wave)
             .with_transfer(FwdTransfer_4x64x1)
             .with_specializations(ConvFwdSpecialization::FILTER_1X1_PAD0,
                                   GemmSpecialization::MNKPadding)

--- a/experimental/builder/test/test_conv_description.cpp
+++ b/experimental/builder/test/test_conv_description.cpp
@@ -111,8 +111,8 @@ struct DefaultAlgorithm
                                              .bk1            = 8,
                                              .m_per_xdl      = 16,
                                              .n_per_xdl      = 16,
-                                             .m_xdl_per_wave = 4,
-                                             .n_xdl_per_wave = 4};
+                                             .m_xdl_per_wave = 8,
+                                             .n_xdl_per_wave = 8};
 
     ckb::test::TransferABC transfer{
         .a =
@@ -188,7 +188,7 @@ TEST(ConvDescriptionTest, DefaultInstanceHasDetailedDescription)
                     "   ├─ Pipeline scheduler: INTRAWAVE\n"
                     "   ├─ Warp Gemm parameters: \n"
                     "   │  ├─ subtile size: 16×16\n"
-                    "   │  └─ Number of warp gemm iterations: 4×4\n"
+                    "   │  └─ Number of warp gemm iterations: 8×8\n"
                     "   └─ Memory access:\n"
                     "      ├─ A Tile transfer: \n"
                     "      │  ├─ Tile dimensions: 4×256×8×\n"

--- a/experimental/builder/test/utils/ckb_conv_test_configs.hpp
+++ b/experimental/builder/test/utils/ckb_conv_test_configs.hpp
@@ -68,7 +68,7 @@ constexpr TransferABC FwdTransfer_4x64x1{
                 {.m_block = 1, .m_wave_per_xdl = 32, .n_block = 1, .n_wave_per_xdl = 8},
             .epilogue = {.m_xdl_per_wave_per_shuffle = 1,
                          .n_per_wave_per_shuffle     = 1,
-                         .scalar_per_vector          = 8},
+                         .scalar_per_vector          = 4},
         },
 };
 

--- a/include/ck/tensor_operation/gpu/device/device_base.hpp
+++ b/include/ck/tensor_operation/gpu/device/device_base.hpp
@@ -60,7 +60,7 @@ template <index_t BlockSize_,
           index_t NPerXDL_,
           index_t MXdlPerWave_,
           bool IsWave64>
-static constexpr auto GetNXdlPerWave2()
+static constexpr auto GetXdlPerWave2()
 {
     constexpr index_t Waves  = IsWave64 ? BlockSize_ / 64 : BlockSize_ / 32;
     constexpr index_t MWaves = MPerBlock_ / (MXdlPerWave_ * MPerXDL_);
@@ -84,17 +84,33 @@ static constexpr auto GetNXdlPerWave2()
     }
 }
 
-#define GET_NXDL_PER_WAVE_IMPL              \
-    template <bool IsWave64>                \
-    static constexpr auto GetNXdlPerWave()  \
-    {                                       \
-        return GetNXdlPerWave2<BlockSize,   \
-                               MPerBlock,   \
-                               NPerBlock,   \
-                               MPerXDL,     \
-                               NPerXDL,     \
-                               MXdlPerWave, \
-                               IsWave64>(); \
+#define GET_NXDL_PER_WAVE_IMPL             \
+    template <bool IsWave64>               \
+    static constexpr auto GetNXdlPerWave() \
+    {                                      \
+        return GetXdlPerWave2<BlockSize,   \
+                              MPerBlock,   \
+                              NPerBlock,   \
+                              MPerXDL,     \
+                              NPerXDL,     \
+                              MXdlPerWave, \
+                              IsWave64>(); \
+    }
+
+#define GET_MXDL_PER_WAVE_IMPL                          \
+    template <bool IsWave64,                            \
+              index_t MPerXDLAligned     = MPerXDL,     \
+              index_t NPerXDLAligned     = NPerXDL,     \
+              index_t NXdlPerWaveAligned = NXdlPerWave> \
+    static constexpr auto GetMXdlPerWave()              \
+    {                                                   \
+        return GetXdlPerWave2<BlockSize,                \
+                              NPerBlock,                \
+                              MPerBlock,                \
+                              NPerXDLAligned,           \
+                              MPerXDLAligned,           \
+                              NXdlPerWaveAligned,       \
+                              IsWave64>();              \
     }
 
 template <index_t BlockSize_,

--- a/include/ck/tensor_operation/gpu/device/device_base.hpp
+++ b/include/ck/tensor_operation/gpu/device/device_base.hpp
@@ -130,14 +130,14 @@ static constexpr auto GetWarpTileConfig()
 
     constexpr auto NXdlPerWave =
         IsWave64
-            ? GetNXdlPerWave2<BlockSize_,
-                              MPerBlock_,
-                              NPerBlock_,
-                              MPerXDL_,
-                              NPerXDL_,
-                              MXdlPerWave_,
-                              true>()
-            : GetNXdlPerWave2<BlockSize_, MPerBlock_, NPerBlock_, 16, 16, MXdlPerWave32, false>();
+            ? GetXdlPerWave2<BlockSize_,
+                             MPerBlock_,
+                             NPerBlock_,
+                             MPerXDL_,
+                             NPerXDL_,
+                             MXdlPerWave_,
+                             true>()
+            : GetXdlPerWave2<BlockSize_, MPerBlock_, NPerBlock_, 16, 16, MXdlPerWave32, false>();
 
     if constexpr(IsWave64 == false && NXdlPerWave != 0)
     {

--- a/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_gemm_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_gemm_xdl_cshuffle.hpp
@@ -190,9 +190,9 @@ struct DeviceBatchedGemmGemm_Xdl_CShuffle : public DeviceBatchedGemmGemm<ALayout
     using DeviceOp = DeviceBatchedGemmGemm_Xdl_CShuffle;
 
     static constexpr auto MXdlPerWave64 =
-        GetNXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, true>();
+        GetXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, true>();
     static constexpr auto MXdlPerWave32 =
-        GetNXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, false>();
+        GetXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, false>();
     static constexpr auto I0 = Number<0>{};
     static constexpr auto I1 = Number<1>{};
     static constexpr auto I2 = Number<2>{};

--- a/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_multiple_d_gemm_multiple_d_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_multiple_d_gemm_multiple_d_xdl_cshuffle.hpp
@@ -235,20 +235,20 @@ struct DeviceBatchedGemmMultipleDGemmMultipleD_Xdl_CShuffle
 {
     using DeviceOp = DeviceBatchedGemmMultipleDGemmMultipleD_Xdl_CShuffle;
 
-    static constexpr auto Gemm0MXdlPerWave64 = GetNXdlPerWave2<BlockSize,
-                                                               Gemm0NPerBlock,
-                                                               Gemm0MPerBlock,
-                                                               Gemm0NPerXdl,
-                                                               Gemm0MPerXdl,
-                                                               Gemm0NXdlPerWave,
-                                                               true>();
-    static constexpr auto Gemm0MXdlPerWave32 = GetNXdlPerWave2<BlockSize,
-                                                               Gemm0NPerBlock,
-                                                               Gemm0MPerBlock,
-                                                               Gemm0NPerXdl,
-                                                               Gemm0MPerXdl,
-                                                               Gemm0NXdlPerWave,
-                                                               false>();
+    static constexpr auto Gemm0MXdlPerWave64 = GetXdlPerWave2<BlockSize,
+                                                              Gemm0NPerBlock,
+                                                              Gemm0MPerBlock,
+                                                              Gemm0NPerXdl,
+                                                              Gemm0MPerXdl,
+                                                              Gemm0NXdlPerWave,
+                                                              true>();
+    static constexpr auto Gemm0MXdlPerWave32 = GetXdlPerWave2<BlockSize,
+                                                              Gemm0NPerBlock,
+                                                              Gemm0MPerBlock,
+                                                              Gemm0NPerXdl,
+                                                              Gemm0MPerXdl,
+                                                              Gemm0NXdlPerWave,
+                                                              false>();
 
     static constexpr index_t NumD0Tensor = D0sDataType::Size();
     static constexpr index_t NumD1Tensor = D1sDataType::Size();

--- a/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_softmax_gemm_permute_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_softmax_gemm_permute_xdl_cshuffle.hpp
@@ -223,9 +223,9 @@ struct DeviceBatchedGemmSoftmaxGemmPermute_Xdl_CShuffle
                                                  MaskingSpec>
 {
     static constexpr auto MXdlPerWave64 =
-        GetNXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, true>();
+        GetXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, true>();
     static constexpr auto MXdlPerWave32 =
-        GetNXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, false>();
+        GetXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, false>();
 
     static_assert(NumDimG > 0 && NumDimM > 0 && NumDimN > 0 && NumDimK > 0 && NumDimO > 0,
                   "Number of dimension must be greater than 0");

--- a/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_softmax_gemm_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_batched_gemm_softmax_gemm_xdl_cshuffle.hpp
@@ -211,9 +211,9 @@ struct DeviceBatchedGemmSoftmaxGemm_Xdl_CShuffle
 
     using DeviceOp = DeviceBatchedGemmSoftmaxGemm_Xdl_CShuffle;
     static constexpr auto MXdlPerWave64 =
-        GetNXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, true>();
+        GetXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, true>();
     static constexpr auto MXdlPerWave32 =
-        GetNXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, false>();
+        GetXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, false>();
 
     static constexpr auto I0 = Number<0>{};
     static constexpr auto I1 = Number<1>{};

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_abd_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_abd_xdl_cshuffle.hpp
@@ -325,9 +325,15 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle
                                              BComputeDataType>
 {
     using DeviceOp = DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle;
-    GET_NXDL_PER_WAVE_IMPL
-    static constexpr auto NXdlPerWave64 = GetNXdlPerWave<true>();
-    static constexpr auto NXdlPerWave32 = GetNXdlPerWave<false>();
+    GET_MXDL_PER_WAVE_IMPL
+    // Force usage of 16x16 instruction for WMMA
+    constexpr index_t Wave32MaxMNPerXDL = 16;
+    static constexpr auto MXdlPerWave64 = GetMXdlPerWave<true>();
+    static constexpr auto MXdlPerWave32 =
+        GetMXdlPerWave<false,
+                       Wave32MaxMNPerXDL,
+                       Wave32MaxMNPerXDL,
+                       NXdlPerWave*(NPerXDL / Wave32MaxMNPerXDL)>();
 
     static_assert(NumGroupsToMerge >= 1);
 
@@ -486,35 +492,36 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle
     using GemmADataType = std::conditional_t<!isMultiA && isMultiB, Tuple<ADataType>, ADataType>;
     using GemmBDataType = std::conditional_t<!isMultiB && isMultiA, Tuple<BDataType>, BDataType>;
 
-#define CK_GRIDWISE_GEMM_FWD_MULTIPLE_ABD_XDL_CSHUFFLE_TEMPLATE_PARAMETERS                      \
-    GemmADataType, GemmBDataType, AComputeDataType, AccDataType, CShuffleDataType, DsDataType,  \
-        EDataType, AElementwiseOperation, BElementwiseOperation, CDEElementwiseOperation,       \
-        InMemoryDataOperationEnum::Set, NumGemmKPrefetchStage, BlockSize, MPerBlock, NPerBlock, \
-        KPerBlock, AK1, BK1, MPerXDL, NPerXDL, MXdlPerWave, NXdlPerWave_,                       \
-        ABlockTransferThreadClusterLengths_AK0_M_AK1, ABlockTransferThreadClusterArrangeOrder,  \
-        ABlockTransferSrcAccessOrder, ABlockTransferSrcVectorDim,                               \
-        ABlockTransferSrcScalarPerVector, ABlockTransferDstScalarPerVector_AK1, false,          \
-        ABlockLdsExtraM, BBlockTransferThreadClusterLengths_BK0_N_BK1,                          \
-        BBlockTransferThreadClusterArrangeOrder, BBlockTransferSrcAccessOrder,                  \
-        BBlockTransferSrcVectorDim, BBlockTransferSrcScalarPerVector,                           \
-        BBlockTransferDstScalarPerVector_BK1, false, BBlockLdsExtraN,                           \
-        CShuffleMXdlPerWavePerShuffle, CShuffleNXdlPerWavePerShuffle,                           \
-        CDEBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock,                       \
-        CDEBlockTransferScalarPerVector_NPerBlock, LoopSched, PipelineVersion::v1,              \
+#define CK_GRIDWISE_GEMM_FWD_MULTIPLE_ABD_XDL_CSHUFFLE_TEMPLATE_PARAMETERS                       \
+    GemmADataType, GemmBDataType, AComputeDataType, AccDataType, CShuffleDataType, DsDataType,   \
+        EDataType, AElementwiseOperation, BElementwiseOperation, CDEElementwiseOperation,        \
+        InMemoryDataOperationEnum::Set, NumGemmKPrefetchStage, BlockSize, MPerBlock, NPerBlock,  \
+        KPerBlock, AK1, BK1, MPerXDL_, NPerXDL_, MXdlPerWave_, NXdlPerWave*(NPerXDL / NPerXDL_), \
+        ABlockTransferThreadClusterLengths_AK0_M_AK1, ABlockTransferThreadClusterArrangeOrder,   \
+        ABlockTransferSrcAccessOrder, ABlockTransferSrcVectorDim,                                \
+        ABlockTransferSrcScalarPerVector, ABlockTransferDstScalarPerVector_AK1, false,           \
+        ABlockLdsExtraM, BBlockTransferThreadClusterLengths_BK0_N_BK1,                           \
+        BBlockTransferThreadClusterArrangeOrder, BBlockTransferSrcAccessOrder,                   \
+        BBlockTransferSrcVectorDim, BBlockTransferSrcScalarPerVector,                            \
+        BBlockTransferDstScalarPerVector_BK1, false, BBlockLdsExtraN,                            \
+        CShuffleMXdlPerWavePerShuffle, CShuffleNXdlPerWavePerShuffle*(NPerXDL / NPerXDL_),       \
+        CDEBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock,                        \
+        CDEBlockTransferScalarPerVector_NPerBlock, LoopSched, PipelineVersion::v1,               \
         BComputeDataType
 
 #define CK_GRIDWISE_GEMM_FWD_MULTIPLE_D_XDL_CSHUFFLE_TEMPLATE_PARAMETERS                       \
     GemmADataType, GemmBDataType, AComputeDataType, AccDataType, CShuffleDataType, DsDataType, \
         EDataType, AElementwiseOperation, BElementwiseOperation, CDEElementwiseOperation,      \
-        NumGemmKPrefetchStage, BlockSize, MPerBlock, NPerBlock, KPerBlock, AK1, BK1, MPerXDL,  \
-        NPerXDL, MXdlPerWave, NXdlPerWave_, ABlockTransferThreadClusterLengths_AK0_M_AK1,      \
-        ABlockTransferThreadClusterArrangeOrder, ABlockTransferSrcAccessOrder,                 \
-        ABlockTransferSrcVectorDim, ABlockTransferSrcScalarPerVector,                          \
-        ABlockTransferDstScalarPerVector_AK1, false, ABlockLdsExtraM,                          \
-        BBlockTransferThreadClusterLengths_BK0_N_BK1, BBlockTransferThreadClusterArrangeOrder, \
-        BBlockTransferSrcAccessOrder, BBlockTransferSrcVectorDim,                              \
-        BBlockTransferSrcScalarPerVector, BBlockTransferDstScalarPerVector_BK1, false,         \
-        BBlockLdsExtraN, CShuffleMXdlPerWavePerShuffle, CShuffleNXdlPerWavePerShuffle,         \
+        NumGemmKPrefetchStage, BlockSize, MPerBlock, NPerBlock, KPerBlock, AK1, BK1, MPerXDL_, \
+        NPerXDL_, MXdlPerWave_, NXdlPerWave*(NPerXDL / NPerXDL_),                              \
+        ABlockTransferThreadClusterLengths_AK0_M_AK1, ABlockTransferThreadClusterArrangeOrder, \
+        ABlockTransferSrcAccessOrder, ABlockTransferSrcVectorDim,                              \
+        ABlockTransferSrcScalarPerVector, ABlockTransferDstScalarPerVector_AK1, false,         \
+        ABlockLdsExtraM, BBlockTransferThreadClusterLengths_BK0_N_BK1,                         \
+        BBlockTransferThreadClusterArrangeOrder, BBlockTransferSrcAccessOrder,                 \
+        BBlockTransferSrcVectorDim, BBlockTransferSrcScalarPerVector,                          \
+        BBlockTransferDstScalarPerVector_BK1, false, BBlockLdsExtraN,                          \
+        CShuffleMXdlPerWavePerShuffle, CShuffleNXdlPerWavePerShuffle*(NPerXDL / NPerXDL_),     \
         CDEBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock,                      \
         CDEBlockTransferScalarPerVector_NPerBlock, LoopSched, PipelineVersion::v1,             \
         BComputeDataType, DoElementwiseBeforeCShuffle
@@ -523,7 +530,7 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle
     GemmBDataType, GemmADataType, AComputeDataType, AccDataType, CShuffleDataType, DsDataType, \
         EDataType, BElementwiseOperation, AElementwiseOperation, CDEElementwiseOperation,      \
         NumGemmKPrefetchStage, BlockSize, NPerBlock, MPerBlock, KPerBlock, BK1, AK1, NPerXDL,  \
-        MPerXDL, NXdlPerWave_, MXdlPerWave, BBlockTransferThreadClusterLengths_BK0_N_BK1,      \
+        MPerXDL, NXdlPerWave, MXdlPerWave_, BBlockTransferThreadClusterLengths_BK0_N_BK1,      \
         BBlockTransferThreadClusterArrangeOrder, BBlockTransferSrcAccessOrder,                 \
         BBlockTransferSrcVectorDim, BBlockTransferSrcScalarPerVector,                          \
         BBlockTransferDstScalarPerVector_BK1, false, BBlockLdsExtraN,                          \
@@ -536,34 +543,35 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle
         BComputeDataType, DoElementwiseBeforeCShuffle
 
     // Use appropriate gridwise gemm
-    template <index_t NXdlPerWave_>
+    template <index_t MXdlPerWave_, index_t MPerXDL_, index_t NPerXDL_>
     using GridwiseGemmMultipleABDBase = GridwiseGemmMultipleABD_xdl_cshuffle<
         CK_GRIDWISE_GEMM_FWD_MULTIPLE_ABD_XDL_CSHUFFLE_TEMPLATE_PARAMETERS>;
-    template <index_t NXdlPerWave_>
+    template <index_t MXdlPerWave_, index_t MPerXDL_, index_t NPerXDL_>
     using GridwiseGemmMultipleDBase = GridwiseGemmMultipleD_xdl_cshuffle<
         CK_GRIDWISE_GEMM_FWD_MULTIPLE_D_XDL_CSHUFFLE_TEMPLATE_PARAMETERS>;
-    template <index_t NXdlPerWave_>
+    template <index_t MXdlPerWave_>
     using GridwiseGemmMultipleDCTransposeBase = GridwiseGemmMultipleD_xdl_cshuffle<
         CK_GRIDWISE_GEMM_FWD_CTRANSPOSE_XDL_CSHUFFLE_TEMPLATE_PARAMETERS>;
 #undef CK_GRIDWISE_GEMM_FWD_MULTIPLE_ABD_XDL_CSHUFFLE_TEMPLATE_PARAMETERS
 #undef CK_GRIDWISE_GEMM_FWD_MULTIPLE_D_XDL_CSHUFFLE_TEMPLATE_PARAMETERS
 #undef CK_GRIDWISE_GEMM_FWD_CTRANSPOSE_XDL_CSHUFFLE_TEMPLATE_PARAMETERS
 
-    using GridwiseGemm64 =
-        std::conditional_t<isMultiA || isMultiB,
-                           GridwiseGemmMultipleABDBase<math::max(NXdlPerWave64, 1)>,
-                           GridwiseGemmMultipleDBase<math::max(NXdlPerWave64, 1)>>;
-    using GridwiseGemm32 = std::conditional_t<isMultiA || isMultiB,
-                                              GridwiseGemmMultipleABDBase<NXdlPerWave32>,
-                                              GridwiseGemmMultipleDBase<NXdlPerWave32>>;
+    using GridwiseGemm64 = std::conditional_t<
+        isMultiA || isMultiB,
+        GridwiseGemmMultipleABDBase<math::max(MXdlPerWave64, 1), MPerXDL, NPerXDL>,
+        GridwiseGemmMultipleDBase<math::max(MXdlPerWave64, 1), MPerXDL, NPerXDL>>;
+    using GridwiseGemm32 = std::conditional_t<
+        isMultiA || isMultiB,
+        GridwiseGemmMultipleABDBase<MXdlPerWave32, Wave32MaxMNPerXDL, Wave32MaxMNPerXDL>,
+        GridwiseGemmMultipleDBase<MXdlPerWave32, Wave32MaxMNPerXDL, Wave32MaxMNPerXDL>>;
 
     using GridwiseGemmCTranspose64 =
         std::conditional_t<CTranspose,
-                           GridwiseGemmMultipleDCTransposeBase<math::max(NXdlPerWave64, 1)>,
+                           GridwiseGemmMultipleDCTransposeBase<math::max(MXdlPerWave64, 1)>,
                            GridwiseGemm64>;
     using GridwiseGemmCTranspose32 =
         std::conditional_t<CTranspose,
-                           GridwiseGemmMultipleDCTransposeBase<NXdlPerWave32>,
+                           GridwiseGemmMultipleDCTransposeBase<MXdlPerWave32>,
                            GridwiseGemm32>;
 
     // If ADataTypes or BDataTypes is tuple, user has to pass std::array with pointers.
@@ -913,14 +921,14 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle
 
             if(get_warp_size() == 64)
             {
-                if constexpr(NXdlPerWave64 > 0)
+                if constexpr(MXdlPerWave64 > 0)
                 {
                     InitGridDesc<GridwiseGemm64, GridwiseGemmCTranspose64>();
                 }
             }
             else
             {
-                if constexpr(NXdlPerWave32 > 0)
+                if constexpr(MXdlPerWave32 > 0)
                 {
                     InitGridDesc<GridwiseGemm32, GridwiseGemmCTranspose32>();
                 }
@@ -1388,7 +1396,7 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle
         {
             if(get_warp_size() == 64)
             {
-                if constexpr(NXdlPerWave64 > 0)
+                if constexpr(MXdlPerWave64 > 0)
                 {
                     return RunImp<GridwiseGemm64, GridwiseGemmCTranspose64>(arg, stream_config);
                 }
@@ -1399,7 +1407,7 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle
             }
             else
             {
-                if constexpr(NXdlPerWave32 > 0)
+                if constexpr(MXdlPerWave32 > 0)
                 {
                     return RunImp<GridwiseGemm32, GridwiseGemmCTranspose32>(arg, stream_config);
                 }
@@ -1436,7 +1444,10 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle
             }
         }
 
-        if(!ck::is_xdl_wmma_supported<AComputeDataType, BComputeDataType, MPerXDL, NPerXDL>())
+        if(!ck::is_xdl_wmma_supported<AComputeDataType,
+                                      BComputeDataType,
+                                      Wave32MaxMNPerXDL,
+                                      Wave32MaxMNPerXDL>())
         {
             return false;
         }
@@ -1720,7 +1731,7 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle
         // check Gridwise GEMM
         if(get_warp_size() == 64)
         {
-            if constexpr(NXdlPerWave64 > 0)
+            if constexpr(MXdlPerWave64 > 0)
             {
                 if constexpr(isMultiA || isMultiB)
                 {
@@ -1759,7 +1770,7 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle
         else
         {
 
-            if constexpr(NXdlPerWave32 > 0)
+            if constexpr(MXdlPerWave32 > 0)
             {
                 if constexpr(isMultiA || isMultiB)
                 {
@@ -2047,8 +2058,13 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle
         auto str = std::stringstream();
 
         // clang-format off
-        str << "DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle"
-            << "<"
+        str << "DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle";
+
+        if(get_warp_size() != 64) {
+            str << "_WmmaPorted";
+        }
+
+        str    << "<"
             << BlockSize << ", "
             << MPerBlock << ", "
             << NPerBlock << ", "

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_abd_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_abd_xdl_cshuffle.hpp
@@ -327,8 +327,8 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle
     using DeviceOp = DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle;
     GET_MXDL_PER_WAVE_IMPL
     // Force usage of 16x16 instruction for WMMA
-    constexpr index_t Wave32MaxMNPerXDL = 16;
-    static constexpr auto MXdlPerWave64 = GetMXdlPerWave<true>();
+    static constexpr index_t Wave32MaxMNPerXDL = 16;
+    static constexpr auto MXdlPerWave64        = GetMXdlPerWave<true>();
     static constexpr auto MXdlPerWave32 =
         GetMXdlPerWave<false,
                        Wave32MaxMNPerXDL,

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_abd_xdl_cshuffle_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_abd_xdl_cshuffle_v3.hpp
@@ -400,9 +400,15 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3
                                              BComputeDataType>
 {
     using DeviceOp = DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3;
-    GET_NXDL_PER_WAVE_IMPL
-    static constexpr auto NXdlPerWave64 = GetNXdlPerWave<true>();
-    static constexpr auto NXdlPerWave32 = GetNXdlPerWave<false>();
+    GET_MXDL_PER_WAVE_IMPL
+    // Force usage of 16x16 instruction for WMMA
+    constexpr index_t Wave32MaxMNPerXDL = 16;
+    static constexpr auto MXdlPerWave64 = GetMXdlPerWave<true>();
+    static constexpr auto MXdlPerWave32 =
+        GetMXdlPerWave<false,
+                       Wave32MaxMNPerXDL,
+                       Wave32MaxMNPerXDL,
+                       NXdlPerWave*(NPerXDL / Wave32MaxMNPerXDL)>();
 
     static constexpr bool isMultiA   = is_detected<is_tuple, ADataType>::value;
     static constexpr bool isMultiB   = is_detected<is_tuple, BDataType>::value;
@@ -563,7 +569,7 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3
             : BBlockTransferSrcScalarPerVector;
 
     // Use appropriate gridwise gemm
-    template <index_t NXdlPerWave_>
+    template <index_t MXdlPerWave_, index_t MPerXDL_, index_t NPerXDL_>
     using GridwiseGemmBase = GridwiseGemmMultiD_xdl_cshuffle_v3<
         tensor_layout::gemm::RowMajor,
         tensor_layout::gemm::ColumnMajor,
@@ -585,10 +591,10 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3
         KPerBlock,
         AK1,
         BK1,
-        MPerXDL,
-        NPerXDL,
-        MXdlPerWave,
-        NXdlPerWave_,
+        MPerXDL_,
+        NPerXDL_,
+        MXdlPerWave_,
+        NXdlPerWave*(NPerXDL / NPerXDL_),
         ABlockTransferThreadClusterLengths_AK0_M_AK1,
         ABlockTransferThreadClusterArrangeOrder,
         ABlockTransferSrcAccessOrder,
@@ -606,7 +612,7 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3
         false,
         BBlockLdsExtraN,
         CShuffleMXdlPerWavePerShuffle,
-        CShuffleNXdlPerWavePerShuffle,
+        CShuffleNXdlPerWavePerShuffle*(NPerXDL / NPerXDL_),
         CDEBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock,
         CDEBlockTransferScalarPerVectors,
         BlkGemmPipeSched,
@@ -617,8 +623,8 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3
         BDataType,
         DoElementwiseBeforeCShuffle,
         DirectLoad>;
-    using GridwiseGemm64 = GridwiseGemmBase<math::max(NXdlPerWave64, 1)>;
-    using GridwiseGemm32 = GridwiseGemmBase<NXdlPerWave32>;
+    using GridwiseGemm64 = GridwiseGemmBase<math::max(MXdlPerWave64, 1), MPerXDL, NPerXDL>;
+    using GridwiseGemm32 = GridwiseGemmBase<MXdlPerWave32, Wave32MaxMNPerXDL, Wave32MaxMNPerXDL>;
 
     // #undef GridwiseGemmV3TemplateParams
 
@@ -1430,7 +1436,24 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3
             return avg_time;
         }
 
-        INVOKER_RUN_IMPL
+        float Run(const Argument& arg, const StreamConfig& stream_config = StreamConfig{})
+        {
+            if(get_warp_size() == 64)
+            {
+                if constexpr(MXdlPerWave64 > 0)
+                {
+                    return RunImp<GridwiseGemm64>(arg, stream_config);
+                }
+            }
+            else
+            {
+                if constexpr(MXdlPerWave32 > 0)
+                {
+                    return RunImp<GridwiseGemm32>(arg, stream_config);
+                }
+            }
+            return 0;
+        }
 
         float Run(const BaseArgument* p_arg,
                   const StreamConfig& stream_config = StreamConfig{}) override
@@ -1483,7 +1506,10 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3
             }
         }
 
-        if(!ck::is_xdl_wmma_supported<AComputeDataType, BComputeDataType, MPerXDL, NPerXDL>())
+        if(!ck::is_xdl_wmma_supported<AComputeDataType,
+                                      BComputeDataType,
+                                      Wave32MaxMNPerXDL,
+                                      Wave32MaxMNPerXDL>())
         {
             if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
             {
@@ -1758,7 +1784,7 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3
 
         if(get_warp_size() == 64)
         {
-            if constexpr(NXdlPerWave64 > 0)
+            if constexpr(MXdlPerWave64 > 0)
             {
                 typename GridwiseGemm64::Argument gemm_arg{nullptr,
                                                            nullptr,
@@ -1780,7 +1806,7 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3
         }
         else
         {
-            if constexpr(NXdlPerWave32 > 0)
+            if constexpr(MXdlPerWave32 > 0)
             {
                 typename GridwiseGemm32::Argument gemm_arg{nullptr,
                                                            nullptr,
@@ -2063,6 +2089,10 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3
 
         // clang-format off
         str << "DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3";
+
+        if(get_warp_size() != 64) {
+            str << "_WmmaPorted";
+        }
 
         if constexpr(DirectLoad) {
             str << "_DirectLoad";

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_abd_xdl_cshuffle_v3.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_abd_xdl_cshuffle_v3.hpp
@@ -402,8 +402,8 @@ struct DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3
     using DeviceOp = DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3;
     GET_MXDL_PER_WAVE_IMPL
     // Force usage of 16x16 instruction for WMMA
-    constexpr index_t Wave32MaxMNPerXDL = 16;
-    static constexpr auto MXdlPerWave64 = GetMXdlPerWave<true>();
+    static constexpr index_t Wave32MaxMNPerXDL = 16;
+    static constexpr auto MXdlPerWave64        = GetMXdlPerWave<true>();
     static constexpr auto MXdlPerWave32 =
         GetMXdlPerWave<false,
                        Wave32MaxMNPerXDL,

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_d_xdl_large_tensor_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_d_xdl_large_tensor_cshuffle.hpp
@@ -208,8 +208,8 @@ struct DeviceGroupedConvFwdMultipleD_Xdl_CShuffle_Large_Tensor
     using DeviceOp = DeviceGroupedConvFwdMultipleD_Xdl_CShuffle_Large_Tensor;
     GET_MXDL_PER_WAVE_IMPL
     // Force usage of 16x16 instruction for WMMA
-    constexpr index_t Wave32MaxMNPerXDL = 16;
-    static constexpr auto MXdlPerWave64 = GetMXdlPerWave<true>();
+    static constexpr index_t Wave32MaxMNPerXDL = 16;
+    static constexpr auto MXdlPerWave64        = GetMXdlPerWave<true>();
     static constexpr auto MXdlPerWave32 =
         GetMXdlPerWave<false,
                        Wave32MaxMNPerXDL,

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_d_xdl_large_tensor_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_d_xdl_large_tensor_cshuffle.hpp
@@ -206,9 +206,15 @@ struct DeviceGroupedConvFwdMultipleD_Xdl_CShuffle_Large_Tensor
                                              BComputeDataType>
 {
     using DeviceOp = DeviceGroupedConvFwdMultipleD_Xdl_CShuffle_Large_Tensor;
-    GET_NXDL_PER_WAVE_IMPL
-    static constexpr auto NXdlPerWave64 = GetNXdlPerWave<true>();
-    static constexpr auto NXdlPerWave32 = GetNXdlPerWave<false>();
+    GET_MXDL_PER_WAVE_IMPL
+    // Force usage of 16x16 instruction for WMMA
+    constexpr index_t Wave32MaxMNPerXDL = 16;
+    static constexpr auto MXdlPerWave64 = GetMXdlPerWave<true>();
+    static constexpr auto MXdlPerWave32 =
+        GetMXdlPerWave<false,
+                       Wave32MaxMNPerXDL,
+                       Wave32MaxMNPerXDL,
+                       NXdlPerWave*(NPerXDL / Wave32MaxMNPerXDL)>();
 
     static constexpr index_t NumDTensor  = DsDataType::Size();
     static constexpr index_t MaxGemmsNum = 32;
@@ -409,25 +415,26 @@ struct DeviceGroupedConvFwdMultipleD_Xdl_CShuffle_Large_Tensor
 #define CK_GRIDWISE_GEMM_FWD_MULTIPLE_D_LARGE_TENSOR_TEMPLATE_PARAMETERS                          \
     ADataType, BDataType, AComputeDataType, AccDataType, CShuffleDataType, DsDataType, EDataType, \
         AElementwiseOperation, BElementwiseOperation, CDEElementwiseOperation,                    \
-        NumGemmKPrefetchStage, BlockSize, MPerBlock, NPerBlock, KPerBlock, AK1, BK1, MPerXDL,     \
-        NPerXDL, MXdlPerWave, NXdlPerWave, ABlockTransferThreadClusterLengths_AK0_M_AK1,          \
-        ABlockTransferThreadClusterArrangeOrder, ABlockTransferSrcAccessOrder,                    \
-        ABlockTransferSrcVectorDim, ABlockTransferSrcScalarPerVector,                             \
-        ABlockTransferDstScalarPerVector_AK1, false, ABlockLdsExtraM,                             \
-        BBlockTransferThreadClusterLengths_BK0_N_BK1, BBlockTransferThreadClusterArrangeOrder,    \
-        BBlockTransferSrcAccessOrder, BBlockTransferSrcVectorDim,                                 \
-        BBlockTransferSrcScalarPerVector, BBlockTransferDstScalarPerVector_BK1, false,            \
-        BBlockLdsExtraN, CShuffleMXdlPerWavePerShuffle, CShuffleNXdlPerWavePerShuffle,            \
+        NumGemmKPrefetchStage, BlockSize, MPerBlock, NPerBlock, KPerBlock, AK1, BK1, MPerXDL_,    \
+        NPerXDL_, MXdlPerWave_, NXdlPerWave*(NPerXDL / NPerXDL_),                                 \
+        ABlockTransferThreadClusterLengths_AK0_M_AK1, ABlockTransferThreadClusterArrangeOrder,    \
+        ABlockTransferSrcAccessOrder, ABlockTransferSrcVectorDim,                                 \
+        ABlockTransferSrcScalarPerVector, ABlockTransferDstScalarPerVector_AK1, false,            \
+        ABlockLdsExtraM, BBlockTransferThreadClusterLengths_BK0_N_BK1,                            \
+        BBlockTransferThreadClusterArrangeOrder, BBlockTransferSrcAccessOrder,                    \
+        BBlockTransferSrcVectorDim, BBlockTransferSrcScalarPerVector,                             \
+        BBlockTransferDstScalarPerVector_BK1, false, BBlockLdsExtraN,                             \
+        CShuffleMXdlPerWavePerShuffle, CShuffleNXdlPerWavePerShuffle*(NPerXDL / NPerXDL_),        \
         CDEBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock,                         \
         CDEBlockTransferScalarPerVector_NPerBlock, LoopSched, PipelineVersion::v1,                \
         AComputeDataType, DoElementwiseBeforeCShuffle
     // Use appropriate gridwise gemm
-    template <index_t NXdlPerWave_>
+    template <index_t MXdlPerWave_, index_t MPerXDL_, index_t NPerXDL_>
     using GridwiseGemmBase = GridwiseGemmMultipleD_xdl_cshuffle<
         CK_GRIDWISE_GEMM_FWD_MULTIPLE_D_LARGE_TENSOR_TEMPLATE_PARAMETERS>;
 #undef CK_GRIDWISE_GEMM_FWD_MULTIPLE_D_LARGE_TENSOR_TEMPLATE_PARAMETERS
-    using GridwiseGemm64 = GridwiseGemmBase<math::max(NXdlPerWave64, 1)>;
-    using GridwiseGemm32 = GridwiseGemmBase<NXdlPerWave32>;
+    using GridwiseGemm64 = GridwiseGemmBase<math::max(MXdlPerWave64, 1), MPerXDL, NPerXDL>;
+    using GridwiseGemm32 = GridwiseGemmBase<MXdlPerWave32, Wave32MaxMNPerXDL, Wave32MaxMNPerXDL>;
 
     // desc for blockwise copy
     using AGridDesc_AK0_M_AK1 =
@@ -607,7 +614,7 @@ struct DeviceGroupedConvFwdMultipleD_Xdl_CShuffle_Large_Tensor
 
                     if(get_warp_size() == 64)
                     {
-                        if constexpr(NXdlPerWave64 > 0)
+                        if constexpr(MXdlPerWave64 > 0)
                         {
                             init_gemm_args<GridwiseGemm64>(a_grid_ptrs[i],
                                                            static_cast<const BDataType*>(p_b),
@@ -624,7 +631,7 @@ struct DeviceGroupedConvFwdMultipleD_Xdl_CShuffle_Large_Tensor
                     }
                     else
                     {
-                        if constexpr(NXdlPerWave32 > 0)
+                        if constexpr(MXdlPerWave32 > 0)
                         {
                             init_gemm_args<GridwiseGemm32>(a_grid_ptrs[i],
                                                            static_cast<const BDataType*>(p_b),
@@ -769,7 +776,24 @@ struct DeviceGroupedConvFwdMultipleD_Xdl_CShuffle_Large_Tensor
             }
         }
 
-        INVOKER_RUN_IMPL
+        float Run(const Argument& arg, const StreamConfig& stream_config = StreamConfig{})
+        {
+            if(get_warp_size() == 64)
+            {
+                if constexpr(MXdlPerWave64 > 0)
+                {
+                    return RunImp<GridwiseGemm64>(arg, stream_config);
+                }
+            }
+            else
+            {
+                if constexpr(MXdlPerWave32 > 0)
+                {
+                    return RunImp<GridwiseGemm32>(arg, stream_config);
+                }
+            }
+            return 0;
+        }
 
         float Run(const BaseArgument* p_arg,
                   const StreamConfig& stream_config = StreamConfig{}) override
@@ -822,7 +846,10 @@ struct DeviceGroupedConvFwdMultipleD_Xdl_CShuffle_Large_Tensor
                 return false;
             }
         }
-        if(!ck::is_xdl_wmma_supported<AComputeDataType, BComputeDataType, MPerXDL, NPerXDL>())
+        if(!ck::is_xdl_wmma_supported<AComputeDataType,
+                                      BComputeDataType,
+                                      Wave32MaxMNPerXDL,
+                                      Wave32MaxMNPerXDL>())
         {
             return false;
         }
@@ -1205,8 +1232,12 @@ struct DeviceGroupedConvFwdMultipleD_Xdl_CShuffle_Large_Tensor
         auto str = std::stringstream();
 
         // clang-format off
-        str << "DeviceGroupedConvFwdMultipleD_Xdl_CShuffle_Large_Tensor"
-            << "<"
+        str << "DeviceGroupedConvFwdMultipleD_Xdl_CShuffle_Large_Tensor";
+        if(get_warp_size() != 64) {
+            str << "_WmmaPorted";
+        }
+
+        str    << "<"
             << BlockSize << ", "
             << MPerBlock << ", "
             << NPerBlock << ", "

--- a/include/ck/tensor_operation/gpu/device/impl/device_grouped_gemm_softmax_gemm_permute_xdl_cshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_grouped_gemm_softmax_gemm_permute_xdl_cshuffle.hpp
@@ -206,9 +206,9 @@ struct DeviceGroupedGemmSoftmaxGemmPermute_Xdl_CShuffle
                                                  MaskingSpec>
 {
     static constexpr auto MXdlPerWave64 =
-        GetNXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, true>();
+        GetXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, true>();
     static constexpr auto MXdlPerWave32 =
-        GetNXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, false>();
+        GetXdlPerWave2<BlockSize, NPerBlock, MPerBlock, NPerXDL, MPerXDL, NXdlPerWave, false>();
 
     static_assert(NumDimG > 0 && NumDimM > 0 && NumDimN > 0 && NumDimK > 0 && NumDimO > 0,
                   "Number of dimension must be greater than 0");


### PR DESCRIPTION
## Proposed changes

This pull request refactors the way the number of XDL (matrix multiply-accumulate) instructions per wave is calculated and used in the grouped convolution forward implementations, especially to better support WMMA (Wave Matrix Multiply-Accumulate) instructions and 16x16 tiles. The changes  use of `MXdlPerWave` instead of `NXdlPerWave` to increase number of waves per M dim.

Key changes include:

**Refactoring and Standardization of XDL Per Wave Calculation:**

* Replaced the `GetNXdlPerWave` and `GET_NXDL_PER_WAVE_IMPL` macros with `GetMXdlPerWave` and `GET_MXDL_PER_WAVE_IMPL`, and updated all related usage to use `MXdlPerWave` instead of `NXdlPerWave` for both 32- and 64-thread warps. This also enforces the use of 16x16 instructions for WMMA [[1]](diffhunk://#diff-085d6261c2081326516e52747a8adb3722a99cd1664ddb38555ca19109cc7fe1L63-R63) [[2]](diffhunk://#diff-085d6261c2081326516e52747a8adb3722a99cd1664ddb38555ca19109cc7fe1L91-R91) [[3]](diffhunk://#diff-085d6261c2081326516e52747a8adb3722a99cd1664ddb38555ca19109cc7fe1R100-R115) [[4]](diffhunk://#diff-4be7a793616698784c1dd201ee79f3c9f1d7352e02cc97bfd1c9f38183de75e6L328-R336) [[5]](diffhunk://#diff-07f1241316111dd1243d577144dcd5699f3201aa9171aa85563c5323ac298167L403-R411).

* Updated template parameters and macro expansions in grouped convolution and GEMM kernel definitions to use the new `MXdlPerWave` approach, including correct propagation of tile sizes for WMMA [[1]](diffhunk://#diff-4be7a793616698784c1dd201ee79f3c9f1d7352e02cc97bfd1c9f38183de75e6L493-R524) [[2]](diffhunk://#diff-4be7a793616698784c1dd201ee79f3c9f1d7352e02cc97bfd1c9f38183de75e6L526-R533) [[3]](diffhunk://#diff-07f1241316111dd1243d577144dcd5699f3201aa9171aa85563c5323ac298167L588-R597) [[4]](diffhunk://#diff-07f1241316111dd1243d577144dcd5699f3201aa9171aa85563c5323ac298167L609-R615).

**Updates to Kernel and GridwiseGemm Instantiations:**

* Changed the instantiation of `GridwiseGemm` types to use the new `MXdlPerWave` and tile size parameters, ensuring correct behavior for both standard and WMMA ported kernels [[1]](diffhunk://#diff-4be7a793616698784c1dd201ee79f3c9f1d7352e02cc97bfd1c9f38183de75e6L539-R574) [[2]](diffhunk://#diff-07f1241316111dd1243d577144dcd5699f3201aa9171aa85563c5323ac298167L566-R572) [[3]](diffhunk://#diff-07f1241316111dd1243d577144dcd5699f3201aa9171aa85563c5323ac298167L620-R627).

* Updated runtime kernel selection logic to use `MXdlPerWave` checks instead of `NXdlPerWave` [[1]](diffhunk://#diff-4be7a793616698784c1dd201ee79f3c9f1d7352e02cc97bfd1c9f38183de75e6L916-R931) [[2]](diffhunk://#diff-4be7a793616698784c1dd201ee79f3c9f1d7352e02cc97bfd1c9f38183de75e6L1391-R1399) [[3]](diffhunk://#diff-4be7a793616698784c1dd201ee79f3c9f1d7352e02cc97bfd1c9f38183de75e6L1402-R1410) [[4]](diffhunk://#diff-07f1241316111dd1243d577144dcd5699f3201aa9171aa85563c5323ac298167L1433-R1456).

**WMMA Support and Logging:**

* Adjusted WMMA support checks to use the forced 16x16 instruction size for 32-thread warps, improving compatibility and clarity [[1]](diffhunk://#diff-4be7a793616698784c1dd201ee79f3c9f1d7352e02cc97bfd1c9f38183de75e6L1439-R1450) [[2]](diffhunk://#diff-07f1241316111dd1243d577144dcd5699f3201aa9171aa85563c5323ac298167L1486-R1512).

**Cosmetic and Logging Improvements:**

* Appended `_WmmaPorted` to the kernel name string for kernels using the WMMA ported path, aiding in debugging and profiling.

These changes collectively improve the correctness, maintainability, and clarity of the grouped convolution forward code, especially in the context of supporting WMMA and varying warp sizes.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered



[AICK-488]: https://amd-hub.atlassian.net/browse/AICK-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ