### PR TITLE
[ck_builder] add utility functions to convolution

### DIFF
--- a/experimental/builder/include/ck_tile/builder/conv_signature_concepts.hpp
+++ b/experimental/builder/include/ck_tile/builder/conv_signature_concepts.hpp
@@ -81,11 +81,23 @@ concept ConvOutputLayout3D =
     (L == TensorLayout::NGKDHW) || (L == TensorLayout::G_NDHW_K_strided);
 
 template <typename T>
+concept HasDataType = requires(T t) {
+    { t.data_type };
+};
+
+// Note: for signature and TensorConfigDescriptor,
+// it is not required to provide a default data type, but if one is provided, check if well defined
+template <typename T>
+concept DataTypeWellDefinedIfProvided = requires(T t) {
+    requires !HasDataType<T> || requires {
+        { t.data_type } -> std::convertible_to<DataType>;
+    };
+};
+
+template <typename T>
 concept TensorConfigDescriptor = requires(T t) {
     { t.layout } -> std::convertible_to<TensorLayout>;
-    // Only require that data type is defined. It might be set to undefined value, in which case the
-    // signature's data type is used.
-    { t.data_type } -> std::convertible_to<DataType>;
+    requires DataTypeWellDefinedIfProvided<T>;
 };
 
 template <typename T>
@@ -164,11 +176,11 @@ concept HasElementwiseOpWithAuxiliaryOperands = requires(T t) {
 template <typename T>
 concept ConvSignatureDescriptor = requires(T t) {
     { t.spatial_dim } -> std::convertible_to<unsigned int>;
-    { t.data_type } -> std::convertible_to<DataType>;
     { t.input } -> ConvTensorDescriptor;
     { t.weight } -> ConvTensorDescriptor;
     { t.output } -> ConvTensorDescriptor;
     requires ConvolutionDirectionWellDefinedIfProvided<T>;
+    requires DataTypeWellDefinedIfProvided<T>;
 };
 
 // Concept to validate a convolution signature's values.

--- a/experimental/builder/include/ck_tile/builder/conv_signature_utils.hpp
+++ b/experimental/builder/include/ck_tile/builder/conv_signature_utils.hpp
@@ -16,18 +16,22 @@ namespace ck_tile::builder {
  **********************************************/
 
 template <auto Sig>
-concept ProvidesElementwiseOperation = requires { Sig.elementwiseOperation; };
+concept ProvidesElementwiseOperation = requires { Sig.elementwise_operation; };
+
+template <auto ConvTensor>
+concept ConvTensorHasOp = requires { ConvTensor.operation; };
 
 template <auto Sig>
 concept ProvidesConvolutionDirection = requires { Sig.direction; };
 
-// returns elementwise operation for signature. Will default to PASS_THROUGH if not provided by signature
+// returns elementwise operation for signature. Will default to PASS_THROUGH if not provided by
+// signature
 template <auto Sig>
 constexpr auto getInputElementwiseOperation()
 {
-    if constexpr(ck_tile::builder::ProvidesElementwiseOperation<Sig.input>)
+    if constexpr(ConvTensorHasOp<Sig.input>)
     {
-        return Sig.input.elementwise_operation;
+        return Sig.input.operation.elementwise_operation;
     }
     else if constexpr(ProvidesElementwiseOperation<Sig>)
     {
@@ -42,9 +46,9 @@ constexpr auto getInputElementwiseOperation()
 template <auto Sig>
 constexpr auto getWeightElementwiseOperation()
 {
-    if constexpr(ProvidesElementwiseOperation<Sig.weight>)
+    if constexpr(ConvTensorHasOp<Sig.weight>)
     {
-        return Sig.weight.elementwise_operation;
+        return Sig.weight.operation.elementwise_operation;
     }
     else if constexpr(ProvidesElementwiseOperation<Sig>)
     {
@@ -59,9 +63,9 @@ constexpr auto getWeightElementwiseOperation()
 template <auto Sig>
 constexpr auto getOutputElementwiseOperation()
 {
-    if constexpr(ProvidesElementwiseOperation<Sig.weight>)
+    if constexpr(ConvTensorHasOp<Sig.output>)
     {
-        return Sig.weight.elementwise_operation;
+        return Sig.output.operation.elementwise_operation;
     }
     else if constexpr(ProvidesElementwiseOperation<Sig>)
     {
@@ -87,27 +91,26 @@ constexpr auto getConvDirection()
     }
 }
 
-
 // return data type of input tensor
-template<auto Sig>
+template <auto Sig>
     requires ck_tile::builder::ValidConvSignature<Sig>
 consteval auto getInputDataType()
 {
-    return  GetTensorDataAndComputeTypes<Sig.input.config, Sig.data_type>().get(0);
+    return GetTensorDataAndComputeTypes<Sig.input.config, Sig.data_type>().get(0);
 }
 
-template<auto Sig>
+template <auto Sig>
     requires ck_tile::builder::ValidConvSignature<Sig>
 consteval auto getWeightDataType()
 {
-    return  GetTensorDataAndComputeTypes<Sig.weight.config, Sig.data_type>().get(0);
+    return GetTensorDataAndComputeTypes<Sig.weight.config, Sig.data_type>().get(0);
 }
 
-template<auto Sig>
+template <auto Sig>
     requires ck_tile::builder::ValidConvSignature<Sig>
 consteval auto getOutputDataType()
 {
-    return  GetTensorDataAndComputeTypes<Sig.output.config, Sig.data_type>().get(0);
+    return GetTensorDataAndComputeTypes<Sig.output.config, Sig.data_type>().get(0);
 }
 
 // returns data type if and only if all tensors have the same type.
@@ -117,7 +120,7 @@ template <auto Sig>
 consteval auto getDataTypeIfCommon()
 {
 
-    auto inputDataType = getInputDataType<Sig>();
+    auto inputDataType  = getInputDataType<Sig>();
     auto weightDataType = getWeightDataType<Sig>();
     auto outputDataType = getOutputDataType<Sig>();
 
@@ -129,6 +132,5 @@ consteval auto getDataTypeIfCommon()
     {
         return DataType::UNDEFINED_DATA_TYPE;
     }
-
 }
 } // namespace ck_tile::builder

--- a/experimental/builder/include/ck_tile/builder/conv_signature_utils.hpp
+++ b/experimental/builder/include/ck_tile/builder/conv_signature_utils.hpp
@@ -18,15 +18,20 @@ namespace ck_tile::builder {
 template <auto Sig>
 concept ProvidesElementwiseOperation = requires { Sig.elementwise_operation; };
 
+template <auto Sig>
+concept ProvidesDataType = requires { Sig.data_type; };
+
 template <auto ConvTensor>
 concept ConvTensorHasOp = requires { ConvTensor.operation; };
 
 template <auto Sig>
 concept ProvidesConvolutionDirection = requires { Sig.direction; };
 
-// returns elementwise operation for signature. Will default to PASS_THROUGH if not provided by
-// signature
+// returns elementwise operation for input tensor
+// will defalut to signature's generic type if provided
+// otherwise, default to PASS_THROUGH
 template <auto Sig>
+    requires ValidConvSignature<Sig>
 constexpr auto getInputElementwiseOperation()
 {
     if constexpr(ConvTensorHasOp<Sig.input>)
@@ -43,7 +48,11 @@ constexpr auto getInputElementwiseOperation()
     }
 }
 
+// returns elementwise operation for weight tensor
+// will defalut to signature's generic type if provided
+// otherwise, default to PASS_THROUGH
 template <auto Sig>
+    requires ValidConvSignature<Sig>
 constexpr auto getWeightElementwiseOperation()
 {
     if constexpr(ConvTensorHasOp<Sig.weight>)
@@ -60,7 +69,11 @@ constexpr auto getWeightElementwiseOperation()
     }
 }
 
+// returns elementwise operation for output tensor
+// will defalut to signature's generic type if provided
+// otherwise, default to PASS_THROUGH
 template <auto Sig>
+    requires ValidConvSignature<Sig>
 constexpr auto getOutputElementwiseOperation()
 {
     if constexpr(ConvTensorHasOp<Sig.output>)
@@ -79,6 +92,7 @@ constexpr auto getOutputElementwiseOperation()
 
 // returns convolution direction for signature. Will default to FORWARD if not provided by signature
 template <auto Sig>
+    requires ValidConvSignature<Sig>
 constexpr auto getConvDirection()
 {
     if constexpr(ProvidesConvolutionDirection<Sig>)
@@ -91,32 +105,74 @@ constexpr auto getConvDirection()
     }
 }
 
+// generic helper that returns data_type if provided and UNDEFINED otherwise
+// can be used on both signature and TensorConfigDescriptor objects
+template <auto TensorConfigOrSig>
+constexpr auto getDataType()
+{
+    if constexpr(ProvidesDataType<TensorConfigOrSig>)
+    {
+        return TensorConfigOrSig.data_type;
+    }
+    else
+    {
+        return DataType::UNDEFINED_DATA_TYPE;
+    }
+}
+
 // return data type of input tensor
 template <auto Sig>
-    requires ck_tile::builder::ValidConvSignature<Sig>
+    requires ValidConvSignature<Sig>
 consteval auto getInputDataType()
 {
-    return GetTensorDataAndComputeTypes<Sig.input.config, Sig.data_type>().get(0);
+    constexpr auto tensorDataType    = getDataType<Sig.input.config>();
+    constexpr auto universalDataType = getDataType<Sig>();
+    if constexpr(tensorDataType != DataType::UNDEFINED_DATA_TYPE)
+    {
+        return tensorDataType;
+    }
+    else
+    {
+        return universalDataType;
+    }
 }
 
 template <auto Sig>
-    requires ck_tile::builder::ValidConvSignature<Sig>
+    requires ValidConvSignature<Sig>
 consteval auto getWeightDataType()
 {
-    return GetTensorDataAndComputeTypes<Sig.weight.config, Sig.data_type>().get(0);
+    constexpr auto tensorDataType    = getDataType<Sig.weight.config>();
+    constexpr auto universalDataType = getDataType<Sig>();
+    if constexpr(tensorDataType != DataType::UNDEFINED_DATA_TYPE)
+    {
+        return tensorDataType;
+    }
+    else
+    {
+        return universalDataType;
+    }
 }
 
 template <auto Sig>
-    requires ck_tile::builder::ValidConvSignature<Sig>
+    requires ValidConvSignature<Sig>
 consteval auto getOutputDataType()
 {
-    return GetTensorDataAndComputeTypes<Sig.output.config, Sig.data_type>().get(0);
+    constexpr auto tensorDataType    = getDataType<Sig.output.config>();
+    constexpr auto universalDataType = getDataType<Sig>();
+    if constexpr(tensorDataType != DataType::UNDEFINED_DATA_TYPE)
+    {
+        return tensorDataType;
+    }
+    else
+    {
+        return universalDataType;
+    }
 }
 
 // returns data type if and only if all tensors have the same type.
 // Otherwise, return DataType::UNDEFINED_DATA_TYPE
 template <auto Sig>
-    requires ck_tile::builder::ValidConvSignature<Sig>
+    requires ValidConvSignature<Sig>
 consteval auto getDataTypeIfCommon()
 {
 
@@ -124,7 +180,7 @@ consteval auto getDataTypeIfCommon()
     auto weightDataType = getWeightDataType<Sig>();
     auto outputDataType = getOutputDataType<Sig>();
 
-    if(inputDataType == weightDataType == outputDataType)
+    if(inputDataType == weightDataType && inputDataType == outputDataType)
     {
         return inputDataType;
     }

--- a/experimental/builder/include/ck_tile/builder/conv_signature_utils.hpp
+++ b/experimental/builder/include/ck_tile/builder/conv_signature_utils.hpp
@@ -1,0 +1,134 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <concepts>
+#include <type_traits>
+
+#include "ck_tile/builder/conv_signature_concepts.hpp"
+#include "ck_tile/builder/factory/helpers/ck/conv_tensor_type.hpp"
+#include "ck_tile/builder/types.hpp"
+
+namespace ck_tile::builder {
+/**********************************************
+ * constexpr helper functions for optional parameters
+ **********************************************/
+
+template <auto Sig>
+concept ProvidesElementwiseOperation = requires { Sig.elementwiseOperation; };
+
+template <auto Sig>
+concept ProvidesConvolutionDirection = requires { Sig.direction; };
+
+// returns elementwise operation for signature. Will default to PASS_THROUGH if not provided by signature
+template <auto Sig>
+constexpr auto getInputElementwiseOperation()
+{
+    if constexpr(ck_tile::builder::ProvidesElementwiseOperation<Sig.input>)
+    {
+        return Sig.input.elementwise_operation;
+    }
+    else if constexpr(ProvidesElementwiseOperation<Sig>)
+    {
+        return Sig.elementwise_operation;
+    }
+    else
+    {
+        return ElementwiseOperation::PASS_THROUGH;
+    }
+}
+
+template <auto Sig>
+constexpr auto getWeightElementwiseOperation()
+{
+    if constexpr(ProvidesElementwiseOperation<Sig.weight>)
+    {
+        return Sig.weight.elementwise_operation;
+    }
+    else if constexpr(ProvidesElementwiseOperation<Sig>)
+    {
+        return Sig.elementwise_operation;
+    }
+    else
+    {
+        return ElementwiseOperation::PASS_THROUGH;
+    }
+}
+
+template <auto Sig>
+constexpr auto getOutputElementwiseOperation()
+{
+    if constexpr(ProvidesElementwiseOperation<Sig.weight>)
+    {
+        return Sig.weight.elementwise_operation;
+    }
+    else if constexpr(ProvidesElementwiseOperation<Sig>)
+    {
+        return Sig.elementwise_operation;
+    }
+    else
+    {
+        return ElementwiseOperation::PASS_THROUGH;
+    }
+}
+
+// returns convolution direction for signature. Will default to FORWARD if not provided by signature
+template <auto Sig>
+constexpr auto getConvDirection()
+{
+    if constexpr(ProvidesConvolutionDirection<Sig>)
+    {
+        return Sig.direction;
+    }
+    else
+    {
+        return ConvDirection::FORWARD;
+    }
+}
+
+
+// return data type of input tensor
+template<auto Sig>
+    requires ck_tile::builder::ValidConvSignature<Sig>
+consteval auto getInputDataType()
+{
+    return  GetTensorDataAndComputeTypes<Sig.input.config, Sig.data_type>().get(0);
+}
+
+template<auto Sig>
+    requires ck_tile::builder::ValidConvSignature<Sig>
+consteval auto getWeightDataType()
+{
+    return  GetTensorDataAndComputeTypes<Sig.weight.config, Sig.data_type>().get(0);
+}
+
+template<auto Sig>
+    requires ck_tile::builder::ValidConvSignature<Sig>
+consteval auto getOutputDataType()
+{
+    return  GetTensorDataAndComputeTypes<Sig.output.config, Sig.data_type>().get(0);
+}
+
+// returns data type if and only if all tensors have the same type.
+// Otherwise, return DataType::UNDEFINED_DATA_TYPE
+template <auto Sig>
+    requires ck_tile::builder::ValidConvSignature<Sig>
+consteval auto getDataTypeIfCommon()
+{
+
+    auto inputDataType = getInputDataType<Sig>();
+    auto weightDataType = getWeightDataType<Sig>();
+    auto outputDataType = getOutputDataType<Sig>();
+
+    if(inputDataType == weightDataType == outputDataType)
+    {
+        return inputDataType;
+    }
+    else
+    {
+        return DataType::UNDEFINED_DATA_TYPE;
+    }
+
+}
+} // namespace ck_tile::builder

--- a/experimental/builder/test/test_conv_description.cpp
+++ b/experimental/builder/test/test_conv_description.cpp
@@ -171,7 +171,7 @@ struct ConvSignatureUtilsTest1
                       .config = {GNHWC, FP16},
     };
     ConvTensorWithOp weight = {.config = {GKYXC, FP16}};
-    ConvTensorWithOp output = {.config = {GNHWK, BF16}, .operation = {SCALE}};
+    ConvTensorWithOp output = {.config = {GNHWK, UNDEFINED_DATA_TYPE}, .operation = {SCALE}};
 };
 
 static_assert(ckb::ConvSignatureDescriptor<ConvSignatureUtilsTest1>);
@@ -196,6 +196,26 @@ struct ConvSignatureUtilsTest2
 };
 
 static_assert(ckb::ConvSignatureDescriptor<ConvSignatureUtilsTest2>);
+
+TEST(ConvUtilsTest, getDataType1)
+{
+    using enum ckb::DataType;
+    static constexpr const ConvSignatureUtilsTest1 SIGNATURE;
+    EXPECT_THAT(ckb::getInputDataType<SIGNATURE>(), FP16);
+    EXPECT_THAT(ckb::getWeightDataType<SIGNATURE>(), FP16);
+    EXPECT_THAT(ckb::getOutputDataType<SIGNATURE>(), FP16);
+    EXPECT_THAT(ckb::getDataTypeIfCommon<SIGNATURE>(), FP16);
+}
+
+TEST(ConvUtilsTest, getDataType2)
+{
+    using enum ckb::DataType;
+    static constexpr const ConvSignatureUtilsTest2 SIGNATURE;
+    EXPECT_THAT(ckb::getInputDataType<SIGNATURE>(), FP16);
+    EXPECT_THAT(ckb::getWeightDataType<SIGNATURE>(), FP16);
+    EXPECT_THAT(ckb::getOutputDataType<SIGNATURE>(), BF16);
+    EXPECT_THAT(ckb::getDataTypeIfCommon<SIGNATURE>(), UNDEFINED_DATA_TYPE);
+}
 
 TEST(ConvUtilsTest, getElementwiseOperation1)
 {

--- a/experimental/builder/test/test_conv_description.cpp
+++ b/experimental/builder/test/test_conv_description.cpp
@@ -10,6 +10,7 @@
 #include "testing_utils.hpp"
 #include "impl/conv_signature_types.hpp"
 #include "impl/conv_algorithm_types.hpp"
+#include "ck_tile/builder/conv_signature_utils.hpp"
 
 namespace {
 
@@ -154,6 +155,65 @@ struct DefaultAlgorithm
                                     .scheduler        = ckb::PipelineScheduler::INTRAWAVE};
 };
 static_assert(ckb::ConvAlgorithmDescriptor<DefaultAlgorithm>);
+
+struct ConvSignatureUtilsTest1
+{
+    using enum ckb::DataType;
+    using enum ckb::TensorLayout;
+    using enum ckb::ConvDirection;
+    using enum ckb::ElementwiseOperation;
+
+    int spatial_dim                      = 2;
+    ckb::DataType data_type              = FP16;
+    ckb::DataType accumulation_data_type = FP32;
+    ckb::ConvDirection direction         = FORWARD;
+    ConvTensorWithOp input               = {
+                      .config = {GNHWC, FP16},
+    };
+    ConvTensorWithOp weight = {.config = {GKYXC, FP16}};
+    ConvTensorWithOp output = {.config = {GNHWK, BF16}, .operation = {SCALE}};
+};
+
+static_assert(ckb::ConvSignatureDescriptor<ConvSignatureUtilsTest1>);
+
+struct ConvSignatureUtilsTest2
+{
+    using enum ckb::DataType;
+    using enum ckb::TensorLayout;
+    using enum ckb::ConvDirection;
+    using enum ckb::ElementwiseOperation;
+
+    int spatial_dim                                 = 2;
+    ckb::DataType data_type                         = FP16;
+    ckb::ElementwiseOperation elementwise_operation = CONV_INVSCALE;
+    ckb::DataType accumulation_data_type            = FP32;
+    ckb::ConvDirection direction                    = FORWARD;
+    ConvTensorSimple input                          = {
+                                 .config = {GNHWC, FP16},
+    };
+    ConvTensorWithOp weight = {.config = {GKYXC, FP16}, .operation = {POWER}};
+    ConvTensorWithOp output = {.config = {GNHWK, BF16}, .operation = {GELU}};
+};
+
+static_assert(ckb::ConvSignatureDescriptor<ConvSignatureUtilsTest2>);
+
+TEST(ConvUtilsTest, getElementwiseOperation1)
+{
+    using enum ckb::ElementwiseOperation;
+    static constexpr const ConvSignatureUtilsTest1 SIGNATURE;
+    EXPECT_THAT(ckb::getInputElementwiseOperation<SIGNATURE>(), PASS_THROUGH);
+    EXPECT_THAT(ckb::getWeightElementwiseOperation<SIGNATURE>(), PASS_THROUGH);
+    EXPECT_THAT(ckb::getOutputElementwiseOperation<SIGNATURE>(), SCALE);
+}
+
+TEST(ConvUtilsTest, getElementwiseOperation2)
+{
+    using enum ckb::ElementwiseOperation;
+    static constexpr const ConvSignatureUtilsTest2 SIGNATURE;
+    EXPECT_THAT(ckb::getInputElementwiseOperation<SIGNATURE>(), CONV_INVSCALE);
+    EXPECT_THAT(ckb::getWeightElementwiseOperation<SIGNATURE>(), POWER);
+    EXPECT_THAT(ckb::getOutputElementwiseOperation<SIGNATURE>(), GELU);
+}
 
 TEST(ConvDescriptionTest, DefaultInstanceHasBriefDescription)
 {

--- a/experimental/builder/test/test_conv_description.cpp
+++ b/experimental/builder/test/test_conv_description.cpp
@@ -36,6 +36,18 @@ struct TensorConfig
     ckb::DataType compute_type{ckb::DataType::UNDEFINED_DATA_TYPE};
 };
 
+struct TensorConfigNoDataType
+{
+    ckb::TensorLayout layout;
+    ckb::DataType compute_type{ckb::DataType::UNDEFINED_DATA_TYPE};
+};
+
+struct ConvTensorNoDataType
+{
+    TensorConfigNoDataType config;
+    TensorOp operation{};
+};
+
 struct ConvTensorSimple
 {
     TensorConfig config;
@@ -191,8 +203,8 @@ struct ConvSignatureUtilsTest2
     ConvTensorSimple input                          = {
                                  .config = {GNHWC, FP16},
     };
-    ConvTensorWithOp weight = {.config = {GKYXC, FP16}, .operation = {POWER}};
-    ConvTensorWithOp output = {.config = {GNHWK, BF16}, .operation = {GELU}};
+    ConvTensorNoDataType weight = {.config = {GKYXC}, .operation = {POWER}};
+    ConvTensorWithOp output     = {.config = {GNHWK, BF16}, .operation = {GELU}};
 };
 
 static_assert(ckb::ConvSignatureDescriptor<ConvSignatureUtilsTest2>);


### PR DESCRIPTION
This PR adds builder-level utilities for convolution configuration and aligns tensor type schema with factory helpers to ensure consistency across CK components.
* Introduces helper functions in CK Builder for convolution parameters (layouts, strides, dilations, padding, groups) to reduce boilerplate and improve readability
* Updates `conv_tensor_type.hpp` and related factory helpers to match the builder schema for tensor metadata
* Applies minor refactors in `examples/tests` to adopt new builder utilities

