### PR TITLE
[CK_BUILDER] Enable math defines for MSVC

### DIFF
--- a/include/ck/library/utility/device_tensor_generator.hpp
+++ b/include/ck/library/utility/device_tensor_generator.hpp
@@ -7,6 +7,7 @@
 #include "ck/utility/common_header.hpp"
 #include "ck/library/utility/device_tensor_generator.hpp"
 #include "ck/utility/data_type.hpp"
+#define _USE_MATH_DEFINES // Required for M_PI in MSVC
 #include <cmath>
 
 // use xorshift for now since it is simple. Should be suitable enough, but feel free to switch in


### PR DESCRIPTION
The symbol M_PI introduced in #3427 is breaking the build on Windows.  The _USE_MATH_DEFINES macro enables M_PI and other math constants on Windows. (I'm guessing this is more idiomatic than the old trick of using PI=acos(-1.0).)

https://learn.microsoft.com/en-us/cpp/c-runtime-library/math-constants