### PR TITLE
[CK_BUILDER] Remove non-standard M_PI

### DIFF
--- a/include/ck/library/utility/device_tensor_generator.hpp
+++ b/include/ck/library/utility/device_tensor_generator.hpp
@@ -7,7 +7,6 @@
 #include "ck/utility/common_header.hpp"
 #include "ck/library/utility/device_tensor_generator.hpp"
 #include "ck/utility/data_type.hpp"
-#define _USE_MATH_DEFINES // Required for M_PI in MSVC
 #include <cmath>
 
 // use xorshift for now since it is simple. Should be suitable enough, but feel free to switch in
@@ -108,6 +107,7 @@ template <typename T>
 __global__ void
 fill_tensor_norm_rand_fp_values(T* p, float sigma, float mean, uint64_t buffer_element_size)
 {
+    static constexpr PI = std::acos(-1.0);
     // initial values
     ran_state_u32 s = ran_init();
     float norm[2];
@@ -119,9 +119,9 @@ fill_tensor_norm_rand_fp_values(T* p, float sigma, float mean, uint64_t buffer_e
             float u1 = ran_gen_round_u32(s) * (1.0f / 4294967296.0f);
             float u2 = ran_gen_round_u32(s) * (1.0f / 4294967296.0f);
             norm[0] =
-                sigma * std::sqrt(-2.0f * ck::math::log(u1)) * std::cos(2.0f * M_PI * u2) + mean;
+                sigma * std::sqrt(-2.0f * ck::math::log(u1)) * std::cos(2.0f * PI * u2) + mean;
             norm[1] =
-                sigma * std::sqrt(-2.0f * ck::math::log(u1)) * std::sin(2.0f * M_PI * u2) + mean;
+                sigma * std::sqrt(-2.0f * ck::math::log(u1)) * std::sin(2.0f * PI * u2) + mean;
         }
 
         if constexpr(ck::is_same_v<T, ck::f4x2_pk_t>)


### PR DESCRIPTION
Just use PI=acos(-1.0) as a local static constexpr. This has been causing build issues on windows.

