### PR TITLE
[CK_BUILDER] Remove cmath include

### DIFF
--- a/include/ck/library/utility/device_tensor_generator.hpp
+++ b/include/ck/library/utility/device_tensor_generator.hpp
@@ -7,7 +7,6 @@
 #include "ck/utility/common_header.hpp"
 #include "ck/library/utility/device_tensor_generator.hpp"
 #include "ck/utility/data_type.hpp"
-#include <cmath>
 
 // use xorshift for now since it is simple. Should be suitable enough, but feel free to switch in
 // the future
@@ -107,7 +106,7 @@ template <typename T>
 __global__ void
 fill_tensor_norm_rand_fp_values(T* p, float sigma, float mean, uint64_t buffer_element_size)
 {
-    static constexpr PI = std::acos(-1.0);
+    static constexpr float PI = 3.141592653f;
     // initial values
     ran_state_u32 s = ran_init();
     float norm[2];
@@ -116,12 +115,11 @@ fill_tensor_norm_rand_fp_values(T* p, float sigma, float mean, uint64_t buffer_e
     {
         if(j % (2 / ck::packed_size_v<T>) == 0)
         {
-            float u1 = ran_gen_round_u32(s) * (1.0f / 4294967296.0f);
-            float u2 = ran_gen_round_u32(s) * (1.0f / 4294967296.0f);
-            norm[0] =
-                sigma * std::sqrt(-2.0f * ck::math::log(u1)) * std::cos(2.0f * PI * u2) + mean;
-            norm[1] =
-                sigma * std::sqrt(-2.0f * ck::math::log(u1)) * std::sin(2.0f * PI * u2) + mean;
+            float u1    = ran_gen_round_u32(s) * (1.0f / 4294967296.0f);
+            float u2    = ran_gen_round_u32(s) * (1.0f / 4294967296.0f);
+            float scale = sigma * ck::math::sqrt(-2.0f * ck::math::log(u1));
+            norm[0]     = scale * ck::math::cos(2.0f * PI * u2) + mean;
+            norm[1]     = scale * ck::math::sin(2.0f * PI * u2) + mean;
         }
 
         if constexpr(ck::is_same_v<T, ck::f4x2_pk_t>)


### PR DESCRIPTION
This PR removes the <cmath> dependency from device_tensor_generator.hpp and fixes a typo from a previous force push. The changes replace standard library math functions with their ck::math equivalents and define PI as a local constant instead of computing it using std::acos.

Key changes:

Removed #include <cmath> header dependency
Replaced std::acos(-1.0) with hardcoded PI constant 3.141592653f
Replaced std::sqrt, std::cos, and std::sin with ck::math equivalents

Tested with linux build with MIOPEN_REQ_LIBS_ONLY=ON.

