### PR TITLE
[CK_BUILDER] Disable CK Builder for SLES15 in Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1759,7 +1759,10 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx90a") }
                     environment{
-                        setup_args = """ -DGPU_TARGETS="gfx942" -DCK_USE_ALTERNATIVE_PYTHON=/opt/Python-3.8.13/bin/python3.8 """
+                        // SLES15 is a legacy platform with limited C++20 ecosystem support (older system libraries,
+                        // standard library implementation). While the ROCm compiler supports C++20, the experimental
+                        // CK Builder requires full C++20 feature support that does not be reliably available on SLES15.
+                        setup_args = """ -DGPU_TARGETS="gfx942" -DCK_USE_ALTERNATIVE_PYTHON=/opt/Python-3.8.13/bin/python3.8 -DCK_EXPERIMENTAL_BUILDER=OFF """
                         execute_args = " "
                     }
                     steps{


### PR DESCRIPTION
SLES15 is a legacy platform with limited C++20 ecosystem support. The CK Builder (#3574) requires C++20.

While the ROCm compiler supports C++20, the older system libraries and standard library implementation on SLES15 does not reliably support all C++20 features required by the experimental CK Builder

I tried some workarounds, but decided we should disable the builder for SLES15 in our CI. I verified this will not impact our builder integration with MIOpen. I made the following changes to our Jenkinsfile:

1. Added `-DCK_EXPERIMENTAL_BUILDER=OFF` to the `setup_args` to explicitly disable the experimental builder

2. Added a detailed comment explaining why this is necessary:


