### PR TITLE
[CK TILE] remove dependency on std chrono

### DIFF
--- a/include/ck_tile/host.hpp
+++ b/include/ck_tile/host.hpp
@@ -11,6 +11,7 @@
 #include "ck_tile/host/device_prop.hpp"
 #include "ck_tile/host/fill.hpp"
 #include "ck_tile/host/flush_icache.hpp"
+#include "ck_tile/host/high_res_cpu_clock.hpp"
 #include "ck_tile/host/hip_check_error.hpp"
 #include "ck_tile/host/host_tensor.hpp"
 #include "ck_tile/host/joinable_thread.hpp"

--- a/include/ck_tile/host/high_res_cpu_clock.hpp
+++ b/include/ck_tile/host/high_res_cpu_clock.hpp
@@ -8,27 +8,33 @@
 namespace ck_tile {
 
 // Time structure to hold nanoseconds since epoch or arbitrary start point
-typedef struct
+struct timepoint_t
 {
     int64_t nanoseconds;
-} timepoint_t;
+};
 
 // Platform-specific includes and implementation
 #if defined(_WIN32) || defined(_WIN64)
 // Windows
 #include <windows.h>
 
-static inline timepoint_t high_res_now(void)
+static inline timepoint_t high_res_now()
 {
-    LARGE_INTEGER frequency;
+    // Cache the performance counter frequency; it is constant for the system lifetime.
+    static LARGE_INTEGER frequency = []() {
+        LARGE_INTEGER f;
+        QueryPerformanceFrequency(&f);
+        return f;
+    }();
+
     LARGE_INTEGER counter;
     timepoint_t tp;
-
-    QueryPerformanceFrequency(&frequency);
     QueryPerformanceCounter(&counter);
 
-    // Convert to nanoseconds
-    tp.nanoseconds = static_cast<int64_t>((counter.QuadPart * 1000000000LL) / frequency.QuadPart);
+    // Convert to nanoseconds using floating-point to avoid 64-bit integer overflow
+    tp.nanoseconds =
+        static_cast<int64_t>((static_cast<long double>(counter.QuadPart) * 1000000000.0L) /
+                             static_cast<long double>(frequency.QuadPart));
 
     return tp;
 }
@@ -37,7 +43,7 @@ static inline timepoint_t high_res_now(void)
 // Linux/Unix/POSIX
 #include <time.h>
 
-static inline timepoint_t high_res_now(void)
+static inline timepoint_t high_res_now()
 {
     struct timespec ts;
     timepoint_t tp;
@@ -55,7 +61,7 @@ static inline timepoint_t high_res_now(void)
 // Fallback for other platforms
 #include <time.h>
 
-static inline timepoint_t high_res_now(void)
+static inline timepoint_t high_res_now()
 {
     timepoint_t tp;
     time_t t       = time(NULL);

--- a/include/ck_tile/host/high_res_cpu_clock.hpp
+++ b/include/ck_tile/host/high_res_cpu_clock.hpp
@@ -1,0 +1,89 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <stdint.h>
+
+namespace ck_tile {
+
+// Time structure to hold nanoseconds since epoch or arbitrary start point
+typedef struct
+{
+    int64_t nanoseconds;
+} timepoint_t;
+
+// Platform-specific includes and implementation
+#if defined(_WIN32) || defined(_WIN64)
+// Windows
+#include <windows.h>
+
+static inline timepoint_t high_res_now(void)
+{
+    LARGE_INTEGER frequency;
+    LARGE_INTEGER counter;
+    timepoint_t tp;
+
+    QueryPerformanceFrequency(&frequency);
+    QueryPerformanceCounter(&counter);
+
+    // Convert to nanoseconds
+    tp.nanoseconds = static_cast<int64_t>((counter.QuadPart * 1000000000LL) / frequency.QuadPart);
+
+    return tp;
+}
+
+#elif defined(__linux__) || defined(__unix__) || defined(_POSIX_VERSION)
+// Linux/Unix/POSIX
+#include <time.h>
+
+static inline timepoint_t high_res_now(void)
+{
+    struct timespec ts;
+    timepoint_t tp;
+
+    // Use CLOCK_MONOTONIC for consistent timing unaffected by system time changes
+    // Use CLOCK_REALTIME if you need wall-clock time
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+
+    tp.nanoseconds = static_cast<int64_t>(ts.tv_sec * 1000000000LL + ts.tv_nsec);
+
+    return tp;
+}
+
+#else
+// Fallback for other platforms
+#include <time.h>
+
+static inline timepoint_t high_res_now(void)
+{
+    timepoint_t tp;
+    time_t t       = time(NULL);
+    tp.nanoseconds = static_cast<int64_t>(t * 1000000000LL);
+    return tp;
+}
+
+#endif
+
+// Duration calculation functions
+static inline int64_t duration_ns(timepoint_t start, timepoint_t end)
+{
+    return end.nanoseconds - start.nanoseconds;
+}
+
+static inline int64_t duration_us(timepoint_t start, timepoint_t end)
+{
+    return (end.nanoseconds - start.nanoseconds) / 1000LL;
+}
+
+static inline int64_t duration_ms(timepoint_t start, timepoint_t end)
+{
+    return (end.nanoseconds - start.nanoseconds) / 1000000LL;
+}
+
+static inline double duration_sec(timepoint_t start, timepoint_t end)
+{
+    return static_cast<double>(end.nanoseconds - start.nanoseconds) / 1000000000.0;
+}
+
+} // namespace ck_tile

--- a/include/ck_tile/host/timer.hpp
+++ b/include/ck_tile/host/timer.hpp
@@ -5,9 +5,9 @@
 
 #include "ck_tile/core/config.hpp"
 #include "ck_tile/host/hip_check_error.hpp"
+#include "ck_tile/host/high_res_cpu_clock.hpp"
 #include <hip/hip_runtime.h>
 #include <cstddef>
-#include <chrono>
 
 namespace ck_tile {
 
@@ -54,26 +54,24 @@ struct cpu_timer
     CK_TILE_HOST void start(const hipStream_t& s)
     {
         HIP_CHECK_ERROR(hipStreamSynchronize(s));
-        start_tick = std::chrono::high_resolution_clock::now();
+        start_tick = high_res_now();
     }
     // torch.utils.benchmark.Timer(), there is a sync inside each timer callback
     CK_TILE_HOST void stop(const hipStream_t& s)
     {
         HIP_CHECK_ERROR(hipStreamSynchronize(s));
-        stop_tick = std::chrono::high_resolution_clock::now();
+        stop_tick = high_res_now();
     }
     // return in ms
     CK_TILE_HOST float duration() const
     {
-        double sec =
-            std::chrono::duration_cast<std::chrono::duration<double>>(stop_tick - start_tick)
-                .count();
-        return static_cast<float>(sec * 1e3);
+        auto us = duration_us(start_tick, stop_tick);
+        return static_cast<float>(us) / 1e3;
     }
 
     private:
-    std::chrono::time_point<std::chrono::high_resolution_clock> start_tick;
-    std::chrono::time_point<std::chrono::high_resolution_clock> stop_tick;
+    timepoint_t start_tick;
+    timepoint_t stop_tick;
 };
 
 } // namespace ck_tile


### PR DESCRIPTION
## Proposed changes

I did some more digging and found that chrono is overkill for what we need.  Including <chrono> is notoriously slow because it is a heavyweight header. It doesn't just define a few functions; it brings in a massive web of templates, type traits, and extensive timezone and calendar support.



What we need is just a simple timer. 



I replace it chrono with some C function. ( for windows and linux)

Tracking issue: #3575

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

