### PR TITLE
Fixing Perfetto Image Notification

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,7 @@ def generateAndArchiveBuildTraceVisualization(String buildTraceFileName) {
         // Run container to get snapshot
         def dockerOpts = "--cap-add=SYS_ADMIN -v \"\$(pwd)/workspace:/workspace\" -e NODE_PATH=/home/pptruser/node_modules -e BUILD_TRACE_FILE=${buildTraceFileName}"
         // Create unique image name by sanitizing job name
-        def sanitizedJobName = env.JOB_NAME.replaceAll(/[\/\\:*?"<>| ]/, '_')
+        def sanitizedJobName = env.JOB_NAME.replaceAll(/[\/\\:*?"<>| ]/, '_').replaceAll('%2F', '_')
         def architectureName = (buildTraceFileName =~ /(gfx[0-9a-zA-Z]+)/)[0][1]
         def imageName = "perfetto_snapshot_${sanitizedJobName}_build_${env.BUILD_NUMBER}_${architectureName}.png"
         sh """


### PR DESCRIPTION
## Proposed changes

This is a fix for when the automation periodically fails when pushing the Perfetto image notification. The failure is triggered when a branch name contains an URL-encoded forward slash. This fix will replace the forward slash in the file name.

To test this change, I've intentionally named this branch with a '/' to verify if it is correctly handled during notification generation. I've confirmed the images are now being stored and posted.

