### PR TITLE
[CK_TILE] Fix alignment in Stream-K workspace buffer

### DIFF
--- a/include/ck_tile/ops/gemm/kernel/streamk_gemm/streamk_gemm_tile_partitioner.hpp
+++ b/include/ck_tile/ops/gemm/kernel/streamk_gemm/streamk_gemm_tile_partitioner.hpp
@@ -42,7 +42,8 @@ struct StreamKTilePartitionerBase
     CK_TILE_HOST_DEVICE index_t get_partials_buffer_size(index_t acc_element_bytes) const noexcept;
 
     /**
-     * @brief Calculates the total space needed for the flags buffer.
+     * @brief Calculates the total space needed for the flags buffer whose total byte size is
+     * 128B-aligned.
      *
      * @return index_t The number of bytes needed for the flags buffer.
      */

--- a/include/ck_tile/ops/gemm/kernel/streamk_gemm/streamk_gemm_tile_partitioner_impl.hpp
+++ b/include/ck_tile/ops/gemm/kernel/streamk_gemm/streamk_gemm_tile_partitioner_impl.hpp
@@ -58,7 +58,10 @@ CK_TILE_HOST_DEVICE index_t
 StreamKTilePartitionerBase<BlockGemmShapeType, ReductionStrategyType>::get_flags_buffer_size()
     const noexcept
 {
-    return sizeof(index_t) * sk_ctas_;
+    constexpr index_t alignment  = 128;
+    const index_t required_bytes = sizeof(index_t) * sk_ctas_;
+    const index_t padded_bytes   = ck_tile::integer_least_multiple(required_bytes, alignment);
+    return padded_bytes;
 }
 
 template <typename BlockGemmShapeType, StreamKReductionStrategy ReductionStrategyType>

--- a/test/ck_tile/gemm_streamk/CMakeLists.txt
+++ b/test/ck_tile/gemm_streamk/CMakeLists.txt
@@ -23,10 +23,9 @@ if(GPU_TARGETS MATCHES "gfx90a|gfx942|gfx950")
     #TODO: support all arches
     #TODO: current c-shuffle only supports C layout as R
     add_gtest_executable(test_ck_tile_streamk_tile_partitioner test_streamk_tile_partitioner.cpp)
-    # TODO: Renable once transient bug for reduction is resolved.
-    # add_gtest_executable(test_ck_tile_streamk_reduction
-    #                     ${CMAKE_CURRENT_SOURCE_DIR}/smoke_tests/test_gemm_streamk_fp16_reduction.cpp
-    #                     test_gemm_streamk_util.cpp)
+    add_gtest_executable(test_ck_tile_streamk_reduction
+                        ${CMAKE_CURRENT_SOURCE_DIR}/smoke_tests/test_gemm_streamk_fp16_reduction.cpp
+                        test_gemm_streamk_util.cpp)
     add_gtest_executable(test_ck_tile_streamk_smoke 
                         ${CMAKE_CURRENT_SOURCE_DIR}/smoke_tests/test_gemm_streamk_fp16_persistent.cpp
                         ${CMAKE_CURRENT_SOURCE_DIR}/smoke_tests/test_gemm_streamk_bf16_persistent.cpp

--- a/test/ck_tile/gemm_streamk/test_gemm_streamk_util.hpp
+++ b/test/ck_tile/gemm_streamk/test_gemm_streamk_util.hpp
@@ -262,20 +262,40 @@ class TestCkTileStreamK : public ::testing::Test
 
         c_m_n_dev_buf.FromDevice(c_m_n_dev_result.data());
 
-        ck_tile::HostTensor<CDataType> c_m_n_host_ref(
+        // Calculate reference GEMM on the GPU
+        ck_tile::HostTensor<CDataType> c_m_n_dev_ref(
             f_host_tensor_descriptor(M, N, stride_C, CLayout{}));
-        c_m_n_host_ref.SetZero();
+        ck_tile::DeviceMem ref_c_m_n_dev_buf(c_m_n_dev_ref.get_element_space_size_in_bytes());
+        ref_c_m_n_dev_buf.SetZero();
 
-        ck_tile::reference_gemm<ADataType, BDataType, AccDataType, CDataType>(
-            a_m_k, b_k_n, c_m_n_host_ref);
+        ADataType* a_m_k_dev_ref_ptr = static_cast<ADataType*>(a_m_k_dev_buf.GetDeviceBuffer());
+        BDataType* b_k_n_dev_ref_ptr = static_cast<BDataType*>(b_k_n_dev_buf.GetDeviceBuffer());
+        CDataType* c_m_n_dev_ref_ptr = static_cast<CDataType*>(ref_c_m_n_dev_buf.GetDeviceBuffer());
+        ck_tile::reference_gemm_gpu<ADataType,
+                                    BDataType,
+                                    AccDataType,
+                                    CDataType,
+                                    ALayout,
+                                    BLayout,
+                                    CLayout>(a_m_k_dev_ref_ptr,
+                                             b_k_n_dev_ref_ptr,
+                                             c_m_n_dev_ref_ptr,
+                                             M,
+                                             N,
+                                             K,
+                                             stride_A,
+                                             stride_B,
+                                             stride_C);
+        ref_c_m_n_dev_buf.FromDevice(c_m_n_dev_ref.data());
 
         const float max_accumulated_value =
-            *std::max_element(c_m_n_host_ref.mData.begin(), c_m_n_host_ref.mData.end());
+            *std::max_element(c_m_n_dev_ref.mData.begin(), c_m_n_dev_ref.mData.end());
+
         const auto rtol_atol = calculate_rtol_atol<ADataType, BDataType, AccDataType, CDataType>(
             K, num_accumulations_per_tile, max_accumulated_value);
 
         bool pass = ck_tile::check_err(c_m_n_dev_result,
-                                       c_m_n_host_ref,
+                                       c_m_n_dev_ref,
                                        "Error: Incorrect results!",
                                        rtol_atol.at(ck_tile::number<0>{}),
                                        rtol_atol.at(ck_tile::number<1>{}));

--- a/test/ck_tile/gemm_streamk/test_streamk_tile_partitioner.cpp
+++ b/test/ck_tile/gemm_streamk/test_streamk_tile_partitioner.cpp
@@ -51,6 +51,39 @@ TEST(StreamKTilePartitionerBaseConstructor, EdgeCase)
     validate_streamk_base_constructor<Config::GemmShape>(expected_values, tile_partitioner);
 }
 
+TEST(StreamKTilePartitionerBaseGetFlagsBufferSize, FlagsLessThan128Bytes)
+{
+    using Config = StreamKTilePartitionerBaseConfigDP2TileSK;
+
+    ck_tile::StreamKTilePartitionerBase<Config::GemmShape,
+                                        ck_tile::StreamKReductionStrategy::Reduction>
+        tile_partitioner{Config::M, Config::N, Config::K, Config::GRID};
+
+    EXPECT_EQ(tile_partitioner.get_flags_buffer_size(), 128);
+}
+
+TEST(StreamKTilePartitionerBaseGetFlagsBufferSize, FlagsEqual128Bytes)
+{
+    using Config = StreamKTilePartitionerBaseConfigFlagsSizeEqual128Bytes;
+
+    ck_tile::StreamKTilePartitionerBase<Config::GemmShape,
+                                        ck_tile::StreamKReductionStrategy::Reduction>
+        tile_partitioner{Config::M, Config::N, Config::K, Config::GRID};
+
+    EXPECT_EQ(tile_partitioner.get_flags_buffer_size(), 128);
+}
+
+TEST(StreamKTilePartitionerBaseGetFlagsBufferSize, FlagsGreaterThan128Bytes)
+{
+    using Config = StreamKTilePartitionerBaseConfigFlagsSizeGreaterThan128Bytes;
+
+    ck_tile::StreamKTilePartitionerBase<Config::GemmShape,
+                                        ck_tile::StreamKReductionStrategy::Reduction>
+        tile_partitioner{Config::M, Config::N, Config::K, Config::GRID};
+
+    EXPECT_EQ(tile_partitioner.get_flags_buffer_size(), 256);
+}
+
 TEST(StreamKTilePartitionerBaseGetWorkSpaceSize, AtomicStrategy)
 {
     using Config = StreamKTilePartitionerBaseConfigDP2TileSK;
@@ -71,7 +104,9 @@ TEST(StreamKTilePartitionerBaseGetWorkSpaceSize, ReductionStrategy)
 
     ck_tile::index_t expected_partials_size =
         sizeof(float) * Config::M_TILE * Config::N_TILE * Config::GRID;
-    ck_tile::index_t expected_flags_size = sizeof(ck_tile::index_t) * Config::GRID;
+    // Since GRID is 3, the final padded flags array must be 128B to ensure the total byte size of
+    // the flags array is 128B-aligned.
+    ck_tile::index_t expected_flags_size = 128;
 
     EXPECT_EQ(tile_partitioner.get_workspace_size(sizeof(float)),
               expected_partials_size + expected_flags_size);

--- a/test/ck_tile/gemm_streamk/test_streamk_tile_partitioner_common.hpp
+++ b/test/ck_tile/gemm_streamk/test_streamk_tile_partitioner_common.hpp
@@ -198,14 +198,55 @@ struct StreamKTilePartitionerBaseConfig
 
 struct StreamKTilePartitionerBaseConfigDP2TileSK : public StreamKTilePartitionerBaseConfig
 {
-    static constexpr ck_tile::index_t M    = 28;
-    static constexpr ck_tile::index_t N    = 4;
-    static constexpr ck_tile::index_t K    = 16;
+    static constexpr ck_tile::index_t M = 28;
+    static constexpr ck_tile::index_t N = 4;
+    static constexpr ck_tile::index_t K = 16;
+    // The minimum number of bytes needed for the flags array is GRID * 4B = 3 * 4B = 12B. To ensure
+    // the total byte size of the array is 128B-aligned, the flags array must be 128B.
     static constexpr ck_tile::index_t GRID = 3;
 
     static constexpr ck_tile::index_t M_TILE = 4;
     static constexpr ck_tile::index_t N_TILE = 4;
     static constexpr ck_tile::index_t K_TILE = 8;
+
+    using GemmShape = ck_tile::TileGemmShape<ck_tile::sequence<M_TILE, N_TILE, K_TILE>,
+                                             ck_tile::sequence<UNUSED, UNUSED, UNUSED>,
+                                             ck_tile::sequence<UNUSED, UNUSED, UNUSED>>;
+};
+
+struct StreamKTilePartitionerBaseConfigFlagsSizeEqual128Bytes
+    : public StreamKTilePartitionerBaseConfig
+{
+    static constexpr ck_tile::index_t M = 28;
+    static constexpr ck_tile::index_t N = 4;
+    static constexpr ck_tile::index_t K = 32;
+    // The minimum number of bytes needed for the flags array is GRID * 4B = 32 * 4B = 128B. So, the
+    // number of bytes for the flags array should be 128B.
+    static constexpr ck_tile::index_t GRID = 32;
+
+    static constexpr ck_tile::index_t M_TILE = 4;
+    static constexpr ck_tile::index_t N_TILE = 4;
+    static constexpr ck_tile::index_t K_TILE = 1;
+
+    using GemmShape = ck_tile::TileGemmShape<ck_tile::sequence<M_TILE, N_TILE, K_TILE>,
+                                             ck_tile::sequence<UNUSED, UNUSED, UNUSED>,
+                                             ck_tile::sequence<UNUSED, UNUSED, UNUSED>>;
+};
+
+struct StreamKTilePartitionerBaseConfigFlagsSizeGreaterThan128Bytes
+    : public StreamKTilePartitionerBaseConfig
+{
+    static constexpr ck_tile::index_t M = 28;
+    static constexpr ck_tile::index_t N = 4;
+    static constexpr ck_tile::index_t K = 33;
+    // The minimum number of bytes needed for the flags array is GRID * 4B = 33 * 4B = 132B. So, the
+    // number of bytes for the flags array should be 2 * 128B = 256B to ensure the total byte size
+    // of the array is 128B-aligned.
+    static constexpr ck_tile::index_t GRID = 33;
+
+    static constexpr ck_tile::index_t M_TILE = 4;
+    static constexpr ck_tile::index_t N_TILE = 4;
+    static constexpr ck_tile::index_t K_TILE = 1;
 
     using GemmShape = ck_tile::TileGemmShape<ck_tile::sequence<M_TILE, N_TILE, K_TILE>,
                                              ck_tile::sequence<UNUSED, UNUSED, UNUSED>,


### PR DESCRIPTION
## Proposed changes

Recently, a Stream-K reduction unit test failed; these tests were temporarily disabled in #3559 since the failure was difficult to reproduce (i.e., the test only failed ~once every 8,000-10,000 runs on one machine).  After debugging, the issue was narrowed down to an alignment issue in Stream-K's workspace buffer that resulted in stale data being read by a workgroup. See the Discussion section for more details. 

Hence, this PR makes the following changes:
- Pads the flags portion of the workspace buffer to be 128B-aligned
- Adds unit tests to test this updated functionality in Stream-K's tile partitioner's `get_flags_buffer_size` class method.
- Re-enabled the `test_ck_tile_streamk_reduction` unit tests.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

The Stream-K workspace buffer is a single buffer where the first partition stores flags for the workgroups and the second partition holds each workgroups partials (i.e., partial results for a macro tile in the output tensor) as shown in the following diagram:
<img width="1071" height="125" alt="image" src="https://github.com/user-attachments/assets/14b0f677-39b1-454a-9020-3784e8d2ff4b" />

But, in this scenario, there is no guarantee that flags will span an entire cache line. So, we could end up with something like this:
<img width="1137" height="267" alt="image" src="https://github.com/user-attachments/assets/04c0b596-7fe5-4486-8b43-49c3d2740b5e" />

In the Stream-K normal and tree reductions, we use cache modifiers to skip cache in certain cases (see #3371 for details). Workgroups skip cache when reading and writing to flags and when writing to partials. But, the cache is not skipped when _reading from_ partials. Using the example above, when a workgroup reads from flags, the entire cache line, which may contain unfinalized partials data, gets stored in cache. Since workgroups don't skip cache to read from partials, they may end up reading incorrect partials data from cache, leading to incorrect results.

While debugging, I ran various experiments to confirm the alignment issue was the cause. The strongest evidence was as follows:
- The number of incorrect values in the output tensor equaled the number of partials elements that fit on the same cache line as flags (i.e., the portion labelled beta in the diagram).
- Padding the flags buffer by 1 resulted in 1 less incorrect entry in the output tensor

While one solution is to create separate buffers for partials and flags (rather than a single workspace buffer), this option would involve an interface change. Instead, we opted to pad the flags portion of the workspace buffer to be 128B-aligned since this does not involve any interface changes. Hence, the resulting workspace buffer looks something like this:
<img width="1251" height="272" alt="image" src="https://github.com/user-attachments/assets/fe9d2c0d-067c-4808-83dd-9a21e06040fe" />

