### PR TITLE
Add missing check target in reduce tile engine op

### DIFF
--- a/tile_engine/ops/reduce/CMakeLists.txt
+++ b/tile_engine/ops/reduce/CMakeLists.txt
@@ -96,6 +96,7 @@ function(build_multi_reduce_for_datatype datatype variant)
 
         add_test(NAME ${test_target} COMMAND ${test_target})
         set_tests_properties(${test_target} PROPERTIES LABELS "multi_reduce")
+        add_dependencies(check ${test_target})
     endforeach()
     add_custom_target(test_reduce_${variant}_${datatype} DEPENDS ${codegen_blobs})
 


### PR DESCRIPTION
## Proposed changes

The "check" target was missing in the Tile Engine reduce operation. It cause the CI to fails as the test were not executed. 

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

N/A

