### PR TITLE
[CK_TILE] Stream-K XCD remapping

### DIFF
--- a/include/ck_tile/ops/gemm/kernel/streamk_gemm/streamk_gemm_kernel.hpp
+++ b/include/ck_tile/ops/gemm/kernel/streamk_gemm/streamk_gemm_kernel.hpp
@@ -673,10 +673,12 @@ struct StreamKKernel
         __shared__ char smem_ptr_0[UniversalGemmKernel::GetSmemSize()];
 
         index_t block_idx   = ck_tile::get_block_1d_id();
+        index_t grid_size   = kargs.tile_partitioner.grid_size().x;
         index_t dp_num_loop = kargs.tile_partitioner.get_iters_per_tile();
         index_t dp_ctas     = kargs.tile_partitioner.get_dp_ctas();
         bool is_dp_ctas     = block_idx < kargs.tile_partitioner.get_dp_ctas();
 
+        block_idx = kargs.tile_partitioner.RemapXCD(block_idx, grid_size);
         // Check if at the data parallel section
         if(is_dp_ctas)
         {
@@ -706,11 +708,14 @@ struct StreamKKernel
         __shared__ char smem_ptr_0[UniversalGemmKernel::GetSmemSize()];
 
         index_t block_idx   = ck_tile::get_block_1d_id();
+        index_t grid_size   = kargs.tile_partitioner.grid_size().x;
         index_t dp_num_loop = kargs.tile_partitioner.get_iters_per_tile();
 
-        // Data-parallel section
-        for(index_t tile_idx = block_idx; tile_idx < kargs.tile_partitioner.get_dp_tiles();
-            tile_idx += kargs.tile_partitioner.get_grid())
+        block_idx =
+            kargs.tile_partitioner.RemapXCD(block_idx, grid_size)
+            // Data-parallel section
+            for(index_t tile_idx = block_idx; tile_idx < kargs.tile_partitioner.get_dp_tiles();
+                tile_idx += kargs.tile_partitioner.get_grid())
         {
             BaseGemm(kargs, tile_idx, dp_num_loop, 0, 0, kargs.K, smem_ptr_0);
             block_sync_lds();

--- a/include/ck_tile/ops/gemm/kernel/streamk_gemm/streamk_gemm_tile_partitioner.hpp
+++ b/include/ck_tile/ops/gemm/kernel/streamk_gemm/streamk_gemm_tile_partitioner.hpp
@@ -213,6 +213,19 @@ struct StreamKTilePartitionerBase
      */
     CK_TILE_HOST index_t estimate_num_wgs_per_tile() const noexcept;
 
+    /**
+     * @brief XCDs access ids in round robin format, this function remaps the 1D ids to continguous
+     * XCD segments
+     *
+     * @param block_1d_id       grid 1D id
+     * @param total_num_tiles   size of the 1D grid
+     * @param NUM_XCDS          number of XCDs
+     * @return index_t  The id after XCD remap
+     */
+    CK_TILE_HOST_DEVICE index_t RemapXCD(index_t block_1d_id,
+                                         index_t total_num_tiles,
+                                         index_t NUM_XCDS = 8) const noexcept;
+
     protected:
     index_t num_tiles_;
     index_t grid_;
@@ -281,7 +294,7 @@ struct StreamKTilePartitioner<BlockGemmShapeType, ReductionStrategyType, true>
      *
      * @return dim_3           The launching grid size for the kernel.
      */
-    CK_TILE_HOST auto grid_size() const noexcept -> dim3;
+    CK_TILE_HOST_DEVICE auto grid_size() const noexcept -> dim3;
 
     /**
      * @brief Returns the total number of DP tiles per workgroup.
@@ -328,7 +341,7 @@ struct StreamKTilePartitioner<BlockGemmShapeType, ReductionStrategyType, false>
      *
      * @return dim_3           The launching grid size for the kernel.
      */
-    CK_TILE_HOST auto grid_size() const noexcept -> dim3;
+    CK_TILE_HOST_DEVICE auto grid_size() const noexcept -> dim3;
 
     /**
      * @brief Returns the total number of DP workgroups.

--- a/include/ck_tile/ops/gemm/kernel/streamk_gemm/streamk_gemm_tile_partitioner_impl.hpp
+++ b/include/ck_tile/ops/gemm/kernel/streamk_gemm/streamk_gemm_tile_partitioner_impl.hpp
@@ -279,6 +279,55 @@ StreamKTilePartitionerBase<BlockGemmShapeType, ReductionStrategyType>::estimate_
     return std::max(num_wgs_per_tile, 1);
 }
 
+/**
+ * @brief XCDs access ids in round robin format, this function remaps the 1D ids to continguous
+ * XCD segments
+ *
+ * @param block_1d_id       grid 1D id
+ * @param total_num_tiles   size of the 1D grid
+ * @param NUM_XCDS          number of XCDs
+ * @return index_t  The id after XCD remap
+ */
+template <typename BlockGemmShapeType, StreamKReductionStrategy ReductionStrategyType>
+CK_TILE_HOST_DEVICE index_t
+StreamKTilePartitionerBase<BlockGemmShapeType, ReductionStrategyType>::RemapXCD(
+    index_t block_1d_id, index_t total_num_tiles, index_t NUM_XCDS) const noexcept
+{
+    // Number of ids per XCD in the new arrangement
+    index_t ids_per_xcd = (total_num_tiles + NUM_XCDS - 1) / NUM_XCDS;
+
+    // When total_num_tiles cannot divide NUM_XCDS, some xcds will have
+    // ids_per_xcd ids, the other will have ids_per_xcd - 1 ids.
+    // We calculate the number of xcds that have ids_per_xcd ids as tall_xcds
+    index_t tall_xcds = total_num_tiles % NUM_XCDS;
+    tall_xcds         = (tall_xcds == 0) ? NUM_XCDS : tall_xcds;
+
+    // Compute current XCD and local id within the XCD
+    index_t xcd      = block_1d_id % NUM_XCDS;
+    index_t local_id = block_1d_id / NUM_XCDS;
+
+    // Calculate new id based on the new grouping
+    if(xcd < tall_xcds)
+    {
+        block_1d_id = xcd * ids_per_xcd + local_id;
+    }
+    else
+    {
+        block_1d_id = tall_xcds * ids_per_xcd + (xcd - tall_xcds) * (ids_per_xcd - 1) + local_id;
+    }
+
+    /**
+     * original ids: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+     * XCD 0 gets: [0, 8], XCD 1 gets: [1, 9], ...
+     *
+     * post-remap ids: [0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15]
+     * XCD 0 gets: [0, 1], XCD 1 gets: [2, 3], ...
+     *
+     * after remap the ids are continguous on each XCD
+     */
+    return block_1d_id;
+}
+
 template <typename BlockGemmShapeType,
           StreamKReductionStrategy ReductionStrategyType,
           bool Persistent>
@@ -295,7 +344,7 @@ StreamKTilePartitioner<BlockGemmShapeType, ReductionStrategyType, true>::StreamK
 }
 
 template <typename BlockGemmShapeType, StreamKReductionStrategy ReductionStrategyType>
-CK_TILE_HOST auto
+CK_TILE_HOST_DEVICE auto
 StreamKTilePartitioner<BlockGemmShapeType, ReductionStrategyType, true>::grid_size() const noexcept
     -> dim3
 {
@@ -337,7 +386,7 @@ StreamKTilePartitioner<BlockGemmShapeType, ReductionStrategyType, false>::Stream
 }
 
 template <typename BlockGemmShapeType, StreamKReductionStrategy ReductionStrategyType>
-CK_TILE_HOST auto
+CK_TILE_HOST_DEVICE auto
 StreamKTilePartitioner<BlockGemmShapeType, ReductionStrategyType, false>::grid_size() const noexcept
     -> dim3
 {

--- a/test/ck_tile/gemm_streamk/test_streamk_tile_partitioner.cpp
+++ b/test/ck_tile/gemm_streamk/test_streamk_tile_partitioner.cpp
@@ -407,6 +407,52 @@ TEST(StreamKTilePartitionerBaseGetOutputTileIndex, TestAllMappings)
     }
 }
 
+TEST(StreamKTilePartitionerBaseRemapXCD, SmallArray)
+{
+    using Config = StreamKTilePartitionerBaseConfigSKOnly;
+
+    ck_tile::StreamKTilePartitioner_v2<Config::GemmShape,
+                                       ck_tile::StreamKReductionStrategy::Atomic,
+                                       true>
+        tile_partitioner{Config::M, Config::N, Config::K, Config::GRID};
+
+    const std::vector<ck_tile::index_t> initial_values = {
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    const std::vector<ck_tile::index_t> expected_values = {
+        0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15};
+
+    test_remap_xcd<Config::GemmShape>(initial_values, expected_values, tile_partitioner);
+}
+
+TEST(StreamKTilePartitionerBaseRemapXCD, MidArray)
+{
+    using Config = StreamKTilePartitionerBaseConfigSKOnly;
+
+    ck_tile::StreamKTilePartitioner_v2<Config::GemmShape,
+                                       ck_tile::StreamKReductionStrategy::Atomic,
+                                       true>
+        tile_partitioner{Config::M, Config::N, Config::K, Config::GRID};
+
+    const std::vector<ck_tile::index_t> initial_values = {
+        0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,  14,  15,
+        16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,
+        32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47,
+        48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63,
+        64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,
+        80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  90,  91,  92,  93,  94,  95,
+        96,  97,  98,  99,  100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111,
+        112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126};
+    const std::vector<ck_tile::index_t> expected_values = {
+        0,  16, 32,  48,  64, 80, 96,  112, 1,  17, 33,  49,  65, 81, 97,  113, 2,  18, 34,  50,
+        66, 82, 98,  114, 3,  19, 35,  51,  67, 83, 99,  115, 4,  20, 36,  52,  68, 84, 100, 116,
+        5,  21, 37,  53,  69, 85, 101, 117, 6,  22, 38,  54,  70, 86, 102, 118, 7,  23, 39,  55,
+        71, 87, 103, 119, 8,  24, 40,  56,  72, 88, 104, 120, 9,  25, 41,  57,  73, 89, 105, 121,
+        10, 26, 42,  58,  74, 90, 106, 122, 11, 27, 43,  59,  75, 91, 107, 123, 12, 28, 44,  60,
+        76, 92, 108, 124, 13, 29, 45,  61,  77, 93, 109, 125, 14, 30, 46,  62,  78, 94, 110, 126,
+        15, 31, 47,  63,  79, 95, 111};
+    test_remap_xcd<Config::GemmShape>(initial_values, expected_values, tile_partitioner);
+}
+
 TEST(StreamKTilePartitionerBaseGetTileLocalCtaIndex, SKOnlyLargeK)
 {
     /*

--- a/test/ck_tile/gemm_streamk/test_streamk_tile_partitioner_common.hpp
+++ b/test/ck_tile/gemm_streamk/test_streamk_tile_partitioner_common.hpp
@@ -421,6 +421,23 @@ void test_get_tile_local_cta_idx(ck_tile::index_t tile_iter_start,
     EXPECT_EQ(tile_local_cta_idx, expected_tile_local_cta_idx);
 }
 
+template <typename GemmShape>
+void test_remap_xcd(
+    const std::vector<ck_tile::index_t>& initial_values,
+    const std::vector<ck_tile::index_t>& expected_values,
+    ck_tile::StreamKTilePartitioner_v2<GemmShape, ck_tile::StreamKReductionStrategy::Atomic, true>&
+        tile_partitioner)
+{
+    // ck_tile::index_t grid_size   = tile_partitioner.grid_size().x;
+    std::vector<ck_tile::index_t> remapped_values(initial_values.size());
+    for(std::size_t i = 0; i < initial_values.size(); ++i)
+    {
+        remapped_values[i] = tile_partitioner.RemapXCD(initial_values[i], initial_values.size());
+    }
+
+    EXPECT_EQ(remapped_values, expected_values);
+}
+
 // Configs for TilePartitioner Child structs
 struct StreamKTilePartitionerV2PersistentExpected
 {


### PR DESCRIPTION
## Proposed changes

This PR adds support for XCD remapping as detailed in this [document](https://amdcloud.sharepoint.com/:w:/r/sites/ComposableKernels/Shared%20Documents/Stream-K/Design%20Docs/XCD%20Mapping.docx?d=w2df1b0737dc54614970d99a2e26022d1&csf=1&web=1&e=mLVN4A). On gfx942, workgroups are typically scheduled round-robin across XCDs, which can lead to poor locality. We will use a remapping to assign workgroups to contiguous tiles in the XCDs improving the locality and the cache hit rate. This is done through a function that computes this contiguous mapping from this [PR](https://github.com/ROCm/composable_kernel/pull/3161), which we have added to the StreamKTilePartitioner. This will require minimal changes to the Stream-K algorithm, only requiring a remap at the time the workgroups are partitioned. Through this approach we can improve the data locality by improving cache hits therefore closing performance gaps that are seen with the default scheduling. There have been unit tests added to verify the function in isolation. This is an optimization that is not specialized to just Stream-K GEMM and can be applied across GEMM. 

Note: This only applies to the gfx942 as they introduce the XCDs.

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [x] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged
