### PR TITLE
Re enable two fp16 x pkint4 tests

### DIFF
--- a/test/ck_tile/gemm/test_gemm_pipeline_ut_cases.inc
+++ b/test/ck_tile/gemm/test_gemm_pipeline_ut_cases.inc
@@ -19,15 +19,6 @@ TYPED_TEST(TEST_SUITE_NAME, SmallM)
     {
         for(int K : Ks)
         {
-            if constexpr(std::is_same_v<typename TestFixture::ADataType, ck_tile::fp16_t> &&
-                         std::is_same_v<typename TestFixture::BDataType, ck_tile::pk_int4_t>)
-            {
-                if(K == 2 * TestFixture::K_Tile)
-                {
-                    // This particular combination of parameters fails.
-                    continue;
-                }
-            }
             if constexpr(std::is_same_v<typename TestFixture::ALayout,
                                         ck_tile::tensor_layout::gemm::ColumnMajor>)
             {

--- a/test/ck_tile/gemm/test_gemm_pipeline_ut_cases.inc
+++ b/test/ck_tile/gemm/test_gemm_pipeline_ut_cases.inc
@@ -64,15 +64,6 @@ TYPED_TEST(TEST_SUITE_NAME, MidLargeM)
     {
         for(int K : Ks)
         {
-            if constexpr(std::is_same_v<typename TestFixture::ADataType, ck_tile::fp16_t> &&
-                         std::is_same_v<typename TestFixture::BDataType, ck_tile::pk_int4_t>)
-            {
-                if(K == 2 * TestFixture::K_Tile)
-                {
-                    // This particular combination of parameters fails.
-                    continue;
-                }
-            }
             if constexpr(std::is_same_v<typename TestFixture::ALayout,
                                         ck_tile::tensor_layout::gemm::ColumnMajor>)
             {


### PR DESCRIPTION
## Proposed changes

The SmallM and MidLargeM fp16 x pkint4 tests were failing previously for K size 2*KTile. These tests now pass locally on gfx950. Remove the checks that skip these previously failing test cases.

## Checklist

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

