### PR TITLE
Update pytorch version in convolution dataset test generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ dispatcher/**/dispatcher_kernels.json
 test_data/*
 !test_data/*.py
 !test_data/*.sh
+!test_data/requirements.txt
 
 # Exceptions to build* patterns above
 # The experimental/builder directory should be tracked despite matching build*

--- a/test_data/generate_test_dataset.sh
+++ b/test_data/generate_test_dataset.sh
@@ -50,10 +50,8 @@ if ! python3 -c "import torch" 2>/dev/null; then
     
     # Install PyTorch in virtual environment with ROCm support
     echo "Installing PyTorch and torchvision with ROCm support in virtual environment..."
-    # Since we're in a ROCm 6.4.1 environment, we need compatible PyTorch
-    # PyTorch doesn't have 6.4 wheels yet, so we use 6.2 which should be compatible
-    echo "Installing PyTorch with ROCm 6.2 support (compatible with ROCm 6.4)..."
-    pip install torch==2.5.1 torchvision==0.20.1 --index-url https://download.pytorch.org/whl/rocm6.2 || {
+    echo "Installing PyTorch with ROCm 7.1 support..."
+    pip install -r requirements.txt || {
         echo "ERROR: Failed to install PyTorch with ROCm support."
         echo "Creating empty CSV files as fallback..."
         echo "# 2D Convolution Test Cases" > conv_test_set_2d_dataset.csv

--- a/test_data/requirements.txt
+++ b/test_data/requirements.txt
@@ -1,0 +1,3 @@
+-i https://download.pytorch.org/whl/rocm7.1
+torch==2.10.*
+torchvision==0.25.*


### PR DESCRIPTION
## Proposed changes

The version of pytorch used in convolution dataset test generation was old enough to not being able to find MI350X GPU with `torch.cuda.is_available()`. Very slightly refactored the generation script to use a `requirements.txt` to specify dependencies instead of directly in the script.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

