### PR TITLE
[CK_BUILDER] fix test related to changed xdl bwd cshuf v3 interface

### DIFF
--- a/experimental/builder/test/conv/ck/test_conv_traits.cpp
+++ b/experimental/builder/test/conv/ck/test_conv_traits.cpp
@@ -812,7 +812,9 @@ TEST_F(ConvTraitsTest, ConvBwdWeightXdlCshuffleV3TraitsExtraction)
         ck::BlockGemmPipelineScheduler::Intrawave, // BlkGemmPipeSched
         ck::BlockGemmPipelineVersion::v1,          // BlkGemmPipelineVer
         ck::half_t,                                // AComputeDataType
-        ck::half_t>;                               // BComputeDataType
+        ck::half_t,                                // BComputeDataType
+        false,                                     // DirectLoad
+        1>;                                        // NumGroupsToMerge
 
     // Use ConvTraitsTmpl to extract compile-time information
     const auto traits = ck_tile::reflect::conv::instance_to_conv_traits<DeviceInstance>();


### PR DESCRIPTION
## Proposed changes

This fixes a failing test on develop related to CK-Builder

In #3648, the interface for `DeviceGroupedConvBwdWeight_Xdl_CShuffleV3` was changed, and a test in CK-Builder's test_conv_traits was not updated properly. This change highlights a more fundamental problem, related to defaults for these template parameters. After thinking about it for a while I realized that a proper fix will be more effort, and given that this is now failing the develop branch, I've produced this fix for now. I'll create a follow-up for making a proper implementation.

