### PR TITLE
[CK_BUILDER] Fix missing template arguments in ConvBwdWeightV3 test

### DIFF
--- a/experimental/builder/test/conv/ck/test_conv_traits.cpp
+++ b/experimental/builder/test/conv/ck/test_conv_traits.cpp
@@ -812,7 +812,9 @@ TEST_F(ConvTraitsTest, ConvBwdWeightXdlCshuffleV3TraitsExtraction)
         ck::BlockGemmPipelineScheduler::Intrawave, // BlkGemmPipeSched
         ck::BlockGemmPipelineVersion::v1,          // BlkGemmPipelineVer
         ck::half_t,                                // AComputeDataType
-        ck::half_t>;                               // BComputeDataType
+        ck::half_t,                                // BComputeDataType
+        false,                                     // DirectLoad
+        1>;                                        // NumGroupsToMerge
 
     // Use ConvTraitsTmpl to extract compile-time information
     const auto traits = ck_tile::reflect::conv::instance_to_conv_traits<DeviceInstance>();


### PR DESCRIPTION
## Proposed changes

Add DirectLoad and NumGroupsToMerge template parameters to the DeviceGroupedConvBwdWeight_Xdl_CShuffleV3 test instantiation. These parameters were added to the device implementation in #3648 but the forward declaration in the reflect header does not have default values, requiring explicit specification in test code.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

