### PR TITLE
Fix redundant cast in model sensitive rmsnorm

### DIFF
--- a/include/ck_tile/ops/rmsnorm2d/pipeline/rmsnorm2d_fwd_pipeline_model_sensitive_pass.hpp
+++ b/include/ck_tile/ops/rmsnorm2d/pipeline/rmsnorm2d_fwd_pipeline_model_sensitive_pass.hpp
@@ -184,7 +184,7 @@ struct Rmsnorm2dFwdPipelineModelSensitiveT5Pass
                 const auto tmp      = acc[idx] * inv_rms_[i_idx];
                 const auto tmp_bf16 = float_to_bf16<bf16_rounding_mode::standard>(tmp);
                 const auto rmsn_    = type_convert<ComputeDataType>(tmp_bf16) * gamma_;
-                rmsn(idx)        = rmsn_;
+                rmsn(idx)           = rmsn_;
             }
             else
             {

--- a/include/ck_tile/ops/rmsnorm2d/pipeline/rmsnorm2d_fwd_pipeline_model_sensitive_pass.hpp
+++ b/include/ck_tile/ops/rmsnorm2d/pipeline/rmsnorm2d_fwd_pipeline_model_sensitive_pass.hpp
@@ -181,11 +181,9 @@ struct Rmsnorm2dFwdPipelineModelSensitiveT5Pass
 
             if constexpr(std::is_same_v<XDataType, ck_tile::bf16_t>)
             {
-                const auto tmp0 =
-                    float_to_bf16<bf16_rounding_mode::standard>(acc[idx] * inv_rms_[i_idx]);
-                const auto tmp1 = float_to_bf16<bf16_rounding_mode::standard>(
-                    type_convert<ComputeDataType>(tmp0) * gamma_);
-                const auto rmsn_ = type_convert<ComputeDataType>(tmp1);
+                const auto tmp      = acc[idx] * inv_rms_[i_idx];
+                const auto tmp_bf16 = float_to_bf16<bf16_rounding_mode::standard>(tmp);
+                const auto rmsn_    = type_convert<ComputeDataType>(tmp_bf16) * gamma_;
                 rmsn(idx)        = rmsn_;
             }
             else


### PR DESCRIPTION
## Proposed changes

[Source](https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3/modeling_qwen3.py#L58)
Remove redundant casting in model sensitive rmsnorm to align HuggingFace implementation.


## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [x] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [x] I have run `clang-format` on all changed files
- [x] Any dependent changes have been merged