### PR TITLE
feat(DeviceMoeGemm): add NoCombine template flag for aiter's per-rout…

### DIFF
--- a/include/ck/tensor_operation/gpu/device/impl/device_moe_gemm.hpp
+++ b/include/ck/tensor_operation/gpu/device/impl/device_moe_gemm.hpp
@@ -70,6 +70,7 @@ template <typename ALayout,
           bool IsInputGemm                            = true,
           bool MulRoutedWeight                        = true,
           bool PerTokenQuant                          = true,
+          bool NoCombine                              = false,
           typename IndexType                          = index_t,
           typename ComputeTypeA                       = CDataType,
           typename ComputeTypeB                       = ComputeTypeA,
@@ -144,6 +145,7 @@ struct DeviceMoeGemm : public DeviceGemmMultipleDSplitKBPreShuffle<ALayout,
                         IsInputGemm,
                         MulRoutedWeight,
                         PerTokenQuant,
+                        NoCombine,
                         IndexType,
                         ComputeTypeA,
                         ComputeTypeB,
@@ -277,8 +279,9 @@ struct DeviceMoeGemm : public DeviceGemmMultipleDSplitKBPreShuffle<ALayout,
 
             constexpr index_t minimum_occupancy = (estimated_reg_total >= 256) ? 1 : 2;
 
-            constexpr auto MemoryDataOp =
-                IsInputGemm ? InMemoryDataOperationEnum::Set : InMemoryDataOperationEnum::AtomicAdd;
+            constexpr auto MemoryDataOp = (IsInputGemm || NoCombine)
+                                              ? InMemoryDataOperationEnum::Set
+                                              : InMemoryDataOperationEnum::AtomicAdd;
             if(has_main_k_block_loop)
             {
                 // Tail number always full

--- a/include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_common.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_common.hpp
@@ -1633,6 +1633,7 @@ struct GridwiseGemm_xdl_cshuffle_base
     template <InMemoryDataOperationEnum CGlobalMemoryDataOperation,
               bool TransposeC,
               bool IsInputGemm,
+              bool NoCombine,
               typename IndexType,
               typename BlockwiseGemmPipe,
               typename CGridDesc_MBlock_MPerBlock_NBlock_NPerBlock,
@@ -1795,7 +1796,7 @@ struct GridwiseGemm_xdl_cshuffle_base
             static_for<0, EMRepeats, 1>{}([&](auto m0) {
                 const index_t fused_token = p_sorted_token_ids[c_token_pos + m0];
                 index_t token_offset      = fused_token & 0xffffff;
-                if constexpr(IsInputGemm)
+                if constexpr(IsInputGemm || NoCombine)
                 {
                     token_offset = token_offset * problemTopK + (fused_token >> 24);
                 }

--- a/include/ck/tensor_operation/gpu/grid/gridwise_moe_gemm.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_moe_gemm.hpp
@@ -159,6 +159,7 @@ template <typename ALayout,
           bool IsInputGemm                            = true,
           bool MulRoutedWeight                        = true,
           bool PerTokenQuant                          = false,
+          bool NoCombine                              = false,
           typename IndexType                          = index_t,
           typename ComputeTypeA                       = CDataType,
           typename ComputeTypeB                       = ComputeTypeA,
@@ -1114,7 +1115,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
         const auto b_grid_desc_bpreshuffled =
             MakeBGridDescriptor_Preshuffled(BN0Shuffled, BK0Shuffled);
         const auto c_grid_desc_m_n = MakeCGridDescriptor_M_N<CLayout>(
-            IsInputGemm ? problem.NumTokens * problem.TopK : problem.NumTokens,
+            (IsInputGemm || NoCombine) ? problem.NumTokens * problem.TopK : problem.NumTokens,
             problem.MPadded,
             problem.N,
             problem.NPadded,
@@ -1379,7 +1380,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                                 *c_style_pointer_cast<const vector_type<int32_t, M4>*>(
                                     p_sorted_token_ids + m_pos);
                         }
-                        if constexpr(MulRoutedWeight)
+                        if constexpr(MulRoutedWeight && !NoCombine)
                         {
                             topk_weights = *c_style_pointer_cast<const vector_type<float, M4>*>(
                                 p_ds_grid[I2] + m_pos);
@@ -1417,7 +1418,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                                                   PerTokenQuant];
                                     float gate = scale_a * scale_b * c_thread_buf[cidx];
                                     float up   = scale_a * scale_up * c_thread_buf_up[cidx];
-                                    if constexpr(MulRoutedWeight)
+                                    if constexpr(MulRoutedWeight && !NoCombine)
                                     {
                                         gate = gate * topk_weights.template AsType<float>()[m4];
                                         up   = up * topk_weights.template AsType<float>()[m4];
@@ -1437,7 +1438,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                                                   PerTokenQuant];
                                     float gate = scale_a * scale_b * c_thread_buf[cidx];
                                     float up   = scale_a * scale_up * c_thread_buf_up[cidx];
-                                    if constexpr(MulRoutedWeight)
+                                    if constexpr(MulRoutedWeight && !NoCombine)
                                     {
                                         gate = gate * topk_weights.template AsType<float>()[m4];
                                         up   = up * topk_weights.template AsType<float>()[m4];
@@ -1454,7 +1455,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                             else
                             {
                                 c_thread_buf_fp32(cidx) = scale_a * scale_b * c_thread_buf[cidx];
-                                if constexpr(MulRoutedWeight)
+                                if constexpr(MulRoutedWeight && !NoCombine)
                                 {
                                     c_thread_buf_fp32(cidx) =
                                         c_thread_buf_fp32(cidx) *
@@ -1474,7 +1475,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                     static_for<0, M2, 1>{}([&](auto m2) {      // m_inst_num_groups_per_blk
                         const index_t m_pos = block_m_id * MPerBlock + m0 * M1 * M2 * M3 * M4 +
                                               m1 * M2 * M3 * M4 + m2 * M3 * M4 + m3 * M4;
-                        if constexpr(MulRoutedWeight)
+                        if constexpr(MulRoutedWeight && !NoCombine)
                         {
                             topk_weights = *c_style_pointer_cast<const vector_type<float, M4>*>(
                                 p_ds_grid[I2] + m_pos);
@@ -1491,7 +1492,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                                 {
                                     float gate = c_thread_buf[cidx];
                                     float up   = c_thread_buf_up[cidx];
-                                    if constexpr(MulRoutedWeight)
+                                    if constexpr(MulRoutedWeight && !NoCombine)
                                     {
                                         gate = gate * topk_weights.template AsType<float>()[m4];
                                         up   = up * topk_weights.template AsType<float>()[m4];
@@ -1503,7 +1504,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                                 {
                                     float gate = c_thread_buf[cidx];
                                     float up   = c_thread_buf_up[cidx];
-                                    if constexpr(MulRoutedWeight)
+                                    if constexpr(MulRoutedWeight && !NoCombine)
                                     {
                                         gate = gate * topk_weights.template AsType<float>()[m4];
                                         up   = up * topk_weights.template AsType<float>()[m4];
@@ -1515,7 +1516,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                             else
                             {
                                 c_thread_buf_fp32(cidx) = c_thread_buf[cidx];
-                                if constexpr(MulRoutedWeight)
+                                if constexpr(MulRoutedWeight && !NoCombine)
                                 {
                                     c_thread_buf_fp32(cidx) =
                                         topk_weights.template AsType<float>()[m4] *
@@ -1534,7 +1535,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
         const auto ds_grid_desc_mblock_mperblock_nblock_nperblock =
             MakeDsGridDescriptor_MBlock_MPerBlock_NBlock_NPerBlock(
                 ds_grid_desc_m_n, problem.MBlock, problem.NBlock);
-        Base::template RunMoeEpilogue<CGlobalMemoryDataOperation, false, IsInputGemm, IndexType>(
+        Base::template RunMoeEpilogue<CGlobalMemoryDataOperation, false, IsInputGemm, NoCombine, IndexType>(
             blockwise_gemm_pipeline,
             c_grid_desc_mblock_mperblock_nblock_nperblock,
             ds_grid_desc_mblock_mperblock_nblock_nperblock,
@@ -1580,7 +1581,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
         const auto b_grid_desc_bpreshuffled =
             MakeBGridDescriptor_Preshuffled(BN0Shuffled, BK0Shuffled);
         const auto c_grid_desc_m_n = MakeCGridDescriptor_M_N<CLayout>(
-            IsInputGemm ? problem.NumTokens * problem.TopK : problem.NumTokens,
+            (IsInputGemm || NoCombine) ? problem.NumTokens * problem.TopK : problem.NumTokens,
             problem.MPadded,
             problem.N,
             problem.NPadded,
@@ -1852,7 +1853,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                                 *c_style_pointer_cast<const vector_type<int32_t, M4>*>(
                                     p_sorted_token_ids + m_pos);
                         }
-                        if constexpr(MulRoutedWeight)
+                        if constexpr(MulRoutedWeight && !NoCombine)
                         {
                             topk_weights = *c_style_pointer_cast<const vector_type<float, M4>*>(
                                 p_ds_grid[I2] + m_pos);
@@ -1890,7 +1891,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                                                   PerTokenQuant];
                                     float gate = scale_a * scale_b * c_thread_buf[cidx];
                                     float up   = scale_a * scale_up * c_thread_buf_up[cidx];
-                                    if constexpr(MulRoutedWeight)
+                                    if constexpr(MulRoutedWeight && !NoCombine)
                                     {
                                         gate = gate * topk_weights.template AsType<float>()[m4];
                                         up   = up * topk_weights.template AsType<float>()[m4];
@@ -1910,7 +1911,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                                                   PerTokenQuant];
                                     float gate = scale_a * scale_b * c_thread_buf[cidx];
                                     float up   = scale_a * scale_up * c_thread_buf_up[cidx];
-                                    if constexpr(MulRoutedWeight)
+                                    if constexpr(MulRoutedWeight && !NoCombine)
                                     {
                                         gate = gate * topk_weights.template AsType<float>()[m4];
                                         up   = up * topk_weights.template AsType<float>()[m4];
@@ -1927,7 +1928,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                             else
                             {
                                 c_thread_buf_fp32(cidx) = scale_a * scale_b * c_thread_buf[cidx];
-                                if constexpr(MulRoutedWeight)
+                                if constexpr(MulRoutedWeight && !NoCombine)
                                 {
                                     c_thread_buf_fp32(cidx) =
                                         c_thread_buf_fp32(cidx) *
@@ -1947,7 +1948,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                     static_for<0, M2, 1>{}([&](auto m2) {      // m_inst_num_groups_per_blk
                         const index_t m_pos = block_m_id * MPerBlock + m0 * M1 * M2 * M3 * M4 +
                                               m1 * M2 * M3 * M4 + m2 * M3 * M4 + m3 * M4;
-                        if constexpr(MulRoutedWeight)
+                        if constexpr(MulRoutedWeight && !NoCombine)
                         {
                             topk_weights = *c_style_pointer_cast<const vector_type<float, M4>*>(
                                 p_ds_grid[I2] + m_pos);
@@ -1964,7 +1965,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                                 {
                                     float gate = c_thread_buf[cidx];
                                     float up   = c_thread_buf_up[cidx];
-                                    if constexpr(MulRoutedWeight)
+                                    if constexpr(MulRoutedWeight && !NoCombine)
                                     {
                                         gate = gate * topk_weights.template AsType<float>()[m4];
                                         up   = up * topk_weights.template AsType<float>()[m4];
@@ -1976,7 +1977,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                                 {
                                     float gate = c_thread_buf[cidx];
                                     float up   = c_thread_buf_up[cidx];
-                                    if constexpr(MulRoutedWeight)
+                                    if constexpr(MulRoutedWeight && !NoCombine)
                                     {
                                         gate = gate * topk_weights.template AsType<float>()[m4];
                                         up   = up * topk_weights.template AsType<float>()[m4];
@@ -1988,7 +1989,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
                             else
                             {
                                 c_thread_buf_fp32(cidx) = c_thread_buf[cidx];
-                                if constexpr(MulRoutedWeight)
+                                if constexpr(MulRoutedWeight && !NoCombine)
                                 {
                                     c_thread_buf_fp32(cidx) =
                                         topk_weights.template AsType<float>()[m4] *
@@ -2008,7 +2009,7 @@ struct GridwiseMoeGemm : public GridwiseGemm_xdl_cshuffle_base<
         const auto ds_grid_desc_mblock_mperblock_nblock_nperblock =
             MakeDsGridDescriptor_MBlock_MPerBlock_NBlock_NPerBlock(
                 ds_grid_desc_m_n, problem.MBlock, problem.NBlock);
-        Base::template RunMoeEpilogue<CGlobalMemoryDataOperation, false, IsInputGemm, IndexType>(
+        Base::template RunMoeEpilogue<CGlobalMemoryDataOperation, false, IsInputGemm, NoCombine, IndexType>(
             blockwise_gemm_pipeline,
             c_grid_desc_mblock_mperblock_nblock_nperblock,
             ds_grid_desc_mblock_mperblock_nblock_nperblock,

--- a/include/ck/tensor_operation/gpu/grid/gridwise_moe_gemm_blockscale.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_moe_gemm_blockscale.hpp
@@ -1648,7 +1648,7 @@ struct GridwiseMoeGemmBlockScale
         const auto ds_grid_desc_mblock_mperblock_nblock_nperblock =
             MakeDsGridDescriptor_MBlock_MPerBlock_NBlock_NPerBlock(
                 ds_grid_desc_m_n, problem.MBlock, problem.NBlock);
-        Base::template RunMoeEpilogue<CGlobalMemoryDataOperation, true, IsInputGemm, IndexType>(
+        Base::template RunMoeEpilogue<CGlobalMemoryDataOperation, true, IsInputGemm, false, IndexType>(
             blockwise_gemm_pipeline,
             c_grid_desc_mblock_mperblock_nblock_nperblock,
             ds_grid_desc_mblock_mperblock_nblock_nperblock,
@@ -2195,7 +2195,7 @@ struct GridwiseMoeGemmBlockScale
         const auto ds_grid_desc_mblock_mperblock_nblock_nperblock =
             MakeDsGridDescriptor_MBlock_MPerBlock_NBlock_NPerBlock(
                 ds_grid_desc_m_n, problem.MBlock, problem.NBlock);
-        Base::template RunMoeEpilogue<CGlobalMemoryDataOperation, true, IsInputGemm, IndexType>(
+        Base::template RunMoeEpilogue<CGlobalMemoryDataOperation, true, IsInputGemm, false, IndexType>(
             blockwise_gemm_pipeline,
             c_grid_desc_mblock_mperblock_nblock_nperblock,
             ds_grid_desc_mblock_mperblock_nblock_nperblock,

--- a/include/ck/tensor_operation/gpu/grid/gridwise_moe_mx_gemm.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_moe_mx_gemm.hpp
@@ -1681,7 +1681,7 @@ struct GridwiseMoeGemmMX
                 MakeDsGridDescriptor_MBlock_MPerBlock_NBlock_NPerBlock(
                     ds_grid_desc_m_n, problem.MBlock, problem.NBlock);
             Base::
-                template RunMoeEpilogue<CGlobalMemoryDataOperation, false, IsInputGemm, IndexType>(
+                template RunMoeEpilogue<CGlobalMemoryDataOperation, false, IsInputGemm, false, IndexType>(
                     blockwise_gemm_pipeline,
                     c_grid_desc_mblock_mperblock_nblock_nperblock,
                     ds_grid_desc_mblock_mperblock_nblock_nperblock,

--- a/include/ck/tensor_operation/gpu/grid/gridwise_moe_mx_gemm_bns.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_moe_mx_gemm_bns.hpp
@@ -1599,7 +1599,7 @@ struct GridwiseMoeGemmMXBNS
                 MakeDsGridDescriptor_MBlock_MPerBlock_NBlock_NPerBlock(
                     ds_grid_desc_m_n, problem.MBlock, problem.NBlock);
             Base::
-                template RunMoeEpilogue<CGlobalMemoryDataOperation, false, IsInputGemm, IndexType>(
+                template RunMoeEpilogue<CGlobalMemoryDataOperation, false, IsInputGemm, false, IndexType>(
                     blockwise_gemm_pipeline,
                     c_grid_desc_mblock_mperblock_nblock_nperblock,
                     ds_grid_desc_mblock_mperblock_nblock_nperblock,

--- a/include/ck/tensor_operation/gpu/grid/gridwise_moe_mx_gemm_bpreshuffle.hpp
+++ b/include/ck/tensor_operation/gpu/grid/gridwise_moe_mx_gemm_bpreshuffle.hpp
@@ -1684,7 +1684,7 @@ struct GridwiseMoeGemmMX_BPreshuffle
                 MakeDsGridDescriptor_MBlock_MPerBlock_NBlock_NPerBlock(
                     ds_grid_desc_m_n, problem.MBlock, problem.NBlock);
             Base::
-                template RunMoeEpilogue<CGlobalMemoryDataOperation, false, IsInputGemm, IndexType>(
+                template RunMoeEpilogue<CGlobalMemoryDataOperation, false, IsInputGemm, false, IndexType>(
                     blockwise_gemm_pipeline,
                     c_grid_desc_mblock_mperblock_nblock_nperblock,
                     ds_grid_desc_mblock_mperblock_nblock_nperblock,
@@ -2181,7 +2181,7 @@ struct GridwiseMoeGemmMX_BPreshuffle
                 MakeDsGridDescriptor_MBlock_MPerBlock_NBlock_NPerBlock(
                     ds_grid_desc_m_n, problem.MBlock, problem.NBlock);
             Base::
-                template RunMoeEpilogue<CGlobalMemoryDataOperation, false, IsInputGemm, IndexType>(
+                template RunMoeEpilogue<CGlobalMemoryDataOperation, false, IsInputGemm, false, IndexType>(
                     blockwise_gemm_pipeline,
                     c_grid_desc_mblock_mperblock_nblock_nperblock,
                     ds_grid_desc_mblock_mperblock_nblock_nperblock,


### PR DESCRIPTION
…e output path

Adds a trailing 'bool NoCombine = false' template parameter inserted at the same slot in three layered templates:

- DeviceMoeGemm (include/ck/tensor_operation/gpu/device/impl/device_moe_gemm.hpp)
- GridwiseMoeGemm (include/ck/tensor_operation/gpu/grid/gridwise_moe_gemm.hpp)
- RunMoeEpilogue (include/ck/tensor_operation/gpu/grid/gridwise_gemm_xdl_cshuffle_common.hpp)

Behavior changes when NoCombine=true:

1. Memory data op switches from AtomicAdd to Set, so stage2 overwrites instead of accumulating across routes for the same token.
2. C grid descriptor row count is NumTokens*TopK instead of NumTokens, so the descriptor bounds-mask does not drop per-route writes past the combined-output row count.
3. Epilogue scatter offset uses (token_id*TopK + topk_id) instead of token_id, directing each (token, route) pair to its own row in the [NumTokens, TopK, model_dim] output buffer.

The four sibling gridwise variants (blockscale, mx_gemm, mx_gemm_bns, mx_gemm_bpreshuffle) pass NoCombine=false explicitly to keep compiling against the wider RunMoeEpilogue template arity.

All existing CK callers compile unchanged (NoCombine defaults to false at the outermost DeviceMoeGemm site). Documented and validated end-to-end by the amd-aiter project's no_combine v1 implementation.

## Proposed changes

Please describe the motivation behind the pull request, whether it enables a new feature or fixes a bug. If there are associated pull requests or issues, please link them to the pull request.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

