### PR TITLE
 Fix static_assert in streamk_gemm_kernel.hpp

### DIFF
--- a/include/ck_tile/ops/gemm/kernel/streamk_gemm/streamk_gemm_kernel.hpp
+++ b/include/ck_tile/ops/gemm/kernel/streamk_gemm/streamk_gemm_kernel.hpp
@@ -515,7 +515,7 @@ struct StreamKKernel
             }
             else
             {
-                static_assert(
+                static_assert(false,
                     "An implementation does not exist for the chosen reduction strategy.");
             }
 


### PR DESCRIPTION
The single-argument static_assert uses the string literal as the condition, which implicitly converts to true (non-null pointer), so the assertion never fires. Add false as the condition so it correctly triggers a compile error when an unsupported reduction strategy is instantiated.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

