### PR TITLE
feat(ck): add gfx90c build support (cherry-pick rocm-libraries#9333)

### DIFF
--- a/include/ck/ck.hpp
+++ b/include/ck/ck.hpp
@@ -79,7 +79,8 @@
 // buffer resource
 #ifndef __HIP_DEVICE_COMPILE__ // for host code
 #define CK_BUFFER_RESOURCE_3RD_DWORD -1
-#elif defined(__gfx803__) || defined(__gfx900__) || defined(__gfx906__) || defined(__gfx9__)
+#elif defined(__gfx803__) || defined(__gfx900__) || defined(__gfx90c__) || defined(__gfx906__) || \
+    defined(__gfx9__)
 #define CK_BUFFER_RESOURCE_3RD_DWORD 0x00020000
 #elif defined(__gfx101__) || defined(__gfx103__)
 #define CK_BUFFER_RESOURCE_3RD_DWORD 0x31014000
@@ -94,7 +95,7 @@
 #define CK_USE_AMD_V_FMAC_F32
 #define CK_USE_AMD_V_DOT2_F32_F16
 #define CK_USE_AMD_V_DOT4_I32_I8
-#elif defined(__gfx803__) || defined(__gfx900__) || defined(__gfx101__)
+#elif defined(__gfx803__) || defined(__gfx900__) || defined(__gfx90c__) || defined(__gfx101__)
 #define CK_USE_AMD_V_MAC_F32
 #elif defined(__gfx11__) || defined(__gfx12__)
 #define CK_USE_AMD_V_FMAC_F32


### PR DESCRIPTION
## Proposed changes

Cherrypicking https://github.com/ROCm/rocm-libraries/pull/9333 into pytorch/release/2.11 branch. Intention is to bump the ROCm/pytorch release/2.11 CK submodule to pick up this change and resolve below build failures,
```
FAILED: [code=1] caffe2/aten/src/ATen/CMakeFiles/ck_gemm.dir/native/hip/bgemm_kernels/bgemm_kernel_bf16bf16bf16_64_16x16x64_16x16_1x1_8x8x1_8x8x1_1x16x1x4_4_Intrawave_v1.hip.o
/__w/rockrel/rockrel/external-builds/pytorch/pytorch/aten/src/ATen/../../../third_party/composable_kernel/include/ck/utility/amd_buffer_addressing_builtins.hpp:49:48: error: use of undeclared identifier 'CK_BUFFER_RESOURCE_3RD_DWORD'
   49 |     wave_buffer_resource.config(Number<3>{}) = CK_BUFFER_RESOURCE_3RD_DWORD;
4 errors generated when compiling for gfx90c.
```
## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally
- [ ] I have added the test to REGRESSION_TESTS list defined at the top of CMakeLists.txt in tests/CMakeLists.txt, **IF** the test takes more than 30 seconds to run.
- [ ] I have added inline documentation which enables the maintainers with understanding the motivation
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] (If this change is user-facing) I have added release notes which provide the end users with a brief summary of the improvement from this pull request
- [ ] I have run `clang-format` on all changed files
- [ ] Any dependent changes have been merged

## Discussion

If this is a relatively large or complex change, feel free to start a discussion by explaining why you chose the solution you did and what alternatives you considered

