### PR TITLE
Fix codegen writing config.h into source tree

### DIFF
--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CK_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
-configure_file(${CK_ROOT}/include/ck/config.h.in ${CK_ROOT}/include/ck/config.h)
+configure_file(${CK_ROOT}/include/ck/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/ck/config.h)
 
 find_package(ROCM)
 include(ROCMInstallTargets)


### PR DESCRIPTION
## Summary

`codegen/CMakeLists.txt` uses `configure_file()` to generate `config.h` directly into the source tree (`include/ck/config.h`) instead of the build directory. This causes `-Wmacro-redefined` warnings because:

1. The generated source-tree `config.h` unconditionally `#define`s macros like `CK_ENABLE_INT8`, `CK_ENABLE_FP8`, etc.
2. The same macros are also passed via `-D` flags on the command line by CMake
3. The source-tree `include/` is searched before the build-dir `include/`, so this guardless file wins over the properly generated one

The main `CMakeLists.txt` (line 530) already generates `config.h` correctly into `${CMAKE_CURRENT_BINARY_DIR}`. This PR fixes `codegen/CMakeLists.txt` to do the same.

### Example warnings

```
In file included from .../ck/include/ck/ck.hpp:6:
.../ck/include/ck/config.h:5:9: warning: 'CK_ENABLE_INT8' macro redefined [-Wmacro-redefined]
    5 | #define CK_ENABLE_INT8 "ON"
      |         ^
<command line>:8:9: note: previous definition is here
    8 | #define CK_ENABLE_INT8 1
      |         ^

.../ck/include/ck/config.h:6:9: warning: 'CK_ENABLE_FP8' macro redefined [-Wmacro-redefined]
    6 | #define CK_ENABLE_FP8 "ON"
      |         ^
<command line>:7:9: note: previous definition is here
    7 | #define CK_ENABLE_FP8 1
      |         ^

.../ck/include/ck/config.h:8:9: warning: 'CK_ENABLE_FP16' macro redefined [-Wmacro-redefined]
    8 | #define CK_ENABLE_FP16 "ON"
      |         ^
<command line>:4:9: note: previous definition is here
    4 | #define CK_ENABLE_FP16 1
      |         ^
```

These warnings repeat for every translation unit that includes `ck.hpp`.

### Fix

Change `codegen/CMakeLists.txt` to write the generated `config.h` to `${CMAKE_CURRENT_BINARY_DIR}` instead of the source tree, matching the main `CMakeLists.txt`.