### PR TITLE
fix(ck_tile): report the D-tensor layout rejection instead of failing silently

### DIFF
--- a/include/ck_tile/ops/gemm/kernel/universal_gemm_kernel.hpp
+++ b/include/ck_tile/ops/gemm/kernel/universal_gemm_kernel.hpp
@@ -580,6 +580,18 @@ struct UniversalGemmKernel
             using DiLayout = remove_cvref_t<std::tuple_element_t<index.value, DsLayout>>;
             if(std::is_same_v<DiLayout, CLayout> == false)
             {
+                // Every other rejection in this function reports itself under
+                // CK_TILE_LOGGING; this one used to fail silently, so a kernel
+                // simply never ran and the reason had to be found by reading
+                // the source. A broadcast scale D (an M-vector with a column
+                // layout, paired with a row-major C) hits exactly this path.
+                if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
+                {
+                    CK_TILE_ERROR("D tensor layout must match the C layout: D",
+                                  index.value,
+                                  " differs, so this kernel cannot run. Give D the C layout, "
+                                  "or use a kernel/epilogue that supports a transposed D.");
+                }
                 DTensorIsValid = false;
             }
             if constexpr(std::is_same_v<DiLayout, tensor_layout::gemm::RowMajor>)


### PR DESCRIPTION
Addresses the first ask in #3766.

`UniversalGemmKernel::IsSupportedArgument` rejects any D tensor whose layout differs from `CLayout`:

```cpp
if(std::is_same_v<DiLayout, CLayout> == false)
{
    DTensorIsValid = false;   // no message
}
```

It is the **only** rejection in that function that says nothing — every other one emits `CK_TILE_ERROR` under `CK_TILE_LOGGING`. The kernel simply never runs, and the reason has to be found by reading the source. We lost an afternoon to it.

The case that hits this is not exotic: a **broadcast scale D** — an M-vector with a column layout, paired with a row-major C — i.e. per-token scales expressed as a D tensor.

This PR only makes the rejection speak, matching the surrounding convention and naming the offending D index. The deeper asks in #3766 (support column-layout D in the CShuffle epilogue's distribution, or document RowColQuant as the intended route) are unchanged and left open.

Compile-checked with `hipcc -fsyntax-only --offload-arch=gfx950`, with the unpatched header as a baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)