### PR TITLE
fix(ck_tile): RowColQuant example allocates a 1x1 BQ tensor but reads N scales

### DIFF
--- a/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
+++ b/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
@@ -494,11 +494,18 @@ int run_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
             K, BQuantGroupSize::kK); // Group quantization: BQK = K / GroupSize
         BQN = ck_tile::integer_divide_ceil(N, BQuantGroupSize::kN);
     }
-    else if constexpr(QuantMode == ck_tile::QuantType::RowColQuant ||
-                      QuantMode == ck_tile::QuantType::TensorQuant)
+    else if constexpr(QuantMode == ck_tile::QuantType::RowColQuant)
     {
-        AQK = 1; // Row quantization: tensor shape [M, 1] or [1]
-        BQK = 1; // Column quantization: tensor shape [1, N] or [1]
+        AQK = 1; // Row quantization: AQ tensor shape [M, 1]
+        BQK = 1; // Column quantization: BQ tensor shape [1, N] -- one scale per
+        BQN = N; // output column, so the extent is N, not 1. stride_BQ below is
+                 // already computed for (1, N); allocating (1, 1) here left the
+                 // kernel reading N scales out of a single-element buffer.
+    }
+    else if constexpr(QuantMode == ck_tile::QuantType::TensorQuant)
+    {
+        AQK = 1; // Tensor quantization: AQ tensor shape [1]
+        BQK = 1; // Tensor quantization: BQ tensor shape [1]
         BQN = 1;
     }
     else


### PR DESCRIPTION
## Problem

`38_block_scale_gemm` fails its **own** verification for `-quant_mode=rowcol` on gfx950, and does so *non-deterministically*, while `abquant` and `tensor` pass in the same harness:

```
tile_example_gemm_quant -prec=fp8 -quant_mode=rowcol -m=512 -n=512 -k=512 -v=1
  run 1: max err: inf, 21504 errors, 8.203125% wrong values -> fail
  run 2: max err: inf, 20480 errors, 7.812500% wrong values -> fail
```

## Cause

`RowColQuant` shares its `AQK`/`BQK`/`BQN` branch with `TensorQuant` and inherits `BQN = 1`, so the BQ tensor is allocated as `(BQK=1, BQN=1)` — a single element. But `stride_BQ` is computed a few lines later for a `(1, N)` tensor, and the kernel reads one scale per output column. The kernel reads N values out of a one-element buffer, which is exactly why the failure carries `inf`/NaN and changes between identical runs.

`BQN = 1` is correct for `TensorQuant` — which is what hid this in the shared branch.

## Fix

Split the branch; give `RowColQuant` `BQN = N`.

| quant_mode | before | after |
|---|---|---|
| rowcol, 512³ | fail (8.2%, then 7.8%, max err inf) | **correct** (×2 runs) |
| rowcol, default dims | fail | **correct** |
| abquant, 512³ | correct | correct |
| tensor, 512³ | correct | correct |

Found while investigating whether `RowColQuant` + `PreshuffleB` is really unsupported (the `throw` at `run_gemm_quant_example.inc:~995`). That question is separate and left alone here — it cannot be answered honestly while the rowcol path fails verification on its own, and this may well be why the combination was gated in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)