### PR TITLE
feat(ck_tile): RowColQuant does support PreshuffleB — drop it from the gate

### DIFF
--- a/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
+++ b/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
@@ -494,11 +494,18 @@ int run_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
             K, BQuantGroupSize::kK); // Group quantization: BQK = K / GroupSize
         BQN = ck_tile::integer_divide_ceil(N, BQuantGroupSize::kN);
     }
-    else if constexpr(QuantMode == ck_tile::QuantType::RowColQuant ||
-                      QuantMode == ck_tile::QuantType::TensorQuant)
+    else if constexpr(QuantMode == ck_tile::QuantType::RowColQuant)
     {
-        AQK = 1; // Row quantization: tensor shape [M, 1] or [1]
-        BQK = 1; // Column quantization: tensor shape [1, N] or [1]
+        AQK = 1; // Row quantization: AQ tensor shape [M, 1]
+        BQK = 1; // Column quantization: BQ tensor shape [1, N] -- one scale per
+        BQN = N; // output column, so the extent is N, not 1. stride_BQ below is
+                 // already computed for (1, N); allocating (1, 1) here left the
+                 // kernel reading N scales out of a single-element buffer.
+    }
+    else if constexpr(QuantMode == ck_tile::QuantType::TensorQuant)
+    {
+        AQK = 1; // Tensor quantization: AQ tensor shape [1]
+        BQK = 1; // Tensor quantization: BQ tensor shape [1]
         BQN = 1;
     }
     else

--- a/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
+++ b/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
@@ -999,12 +999,11 @@ int run_gemm_example_prec_type(const ck_tile::ArgParser& arg_parser)
     using Col = ck_tile::tensor_layout::gemm::ColumnMajor;
 
     if((QuantMode == ck_tile::QuantType::AQuantGrouped ||
-        QuantMode == ck_tile::QuantType::RowColQuant ||
         std::is_same_v<typename TypeConfig::BDataType, ck_tile::pk_fp4_t>) &&
        GemmConfig::PreshuffleB)
     {
         throw std::runtime_error(
-            "Preshuffling weight matrix is not supported for AQuant, RowColQuant or bf16_fp4_gemm");
+            "Preshuffling weight matrix is not supported for AQuant or bf16_fp4_gemm");
     }
 
     if constexpr(std::is_same_v<typename TypeConfig::ADataType, ck_tile::pk_int4_t> ||


### PR DESCRIPTION
Stacked on #3769 (the BQ-extent fix) — that one should land first, since without it the rowcol path fails verification on its own and this combination cannot be judged.

## What

`run_gemm_quant_example.inc` rejects `PreshuffleB` for `AQuantGrouped`, `RowColQuant` and `bf16_fp4` in a single condition. **RowColQuant does not belong there.** The kernel treats quant mode and B layout as orthogonal axes — the pipeline is invoked plainly and the scales are applied through the epilogue's scale windows — so a preshuffled B is just a different B layout to it.

## Evidence (gfx950, MI350X)

In this example, on top of #3769:

| run | result |
|---|---|
| `rowcol -preshuffleb=1`, 512³ | **correct** (×2 runs) |
| `rowcol -preshuffleb=1`, 1024×2688×6144 | **correct** |
| `rowcol -preshuffleb=0`, 512³ (control) | correct |

Independently, driving the same combination through AITER's `a8w8` tuner: `errRatio 0.0000` across 7 GEMM shapes with per-token A scales and per-channel B scales, **beating the flatmm path by 8–11%** at three of them:

| shape (M,N,K) | rowcol + preshuffle | flatmm | Δ |
|---|---:|---:|---:|
| 256, 2688, 6144 | 24.69 µs | 27.44 | **+11.2%** |
| 1920, 6144, 12288 | 178.81 | 193.21 | **+8.1%** |
| 2048, 6144, 12288 | 184.70 | 204.36 | **+10.6%** |

That combination — preshuffled weights with per-token × per-channel scales — is the common shape for FP8 LLM inference with online activation quantization, so having it reachable matters beyond this example.

`AQuantGrouped` and `bf16_fp4` are left gated; not investigated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)